### PR TITLE
Use PAT for release-please to trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   build-release:
     needs: release-please


### PR DESCRIPTION
## Summary
- Use RELEASE_PLEASE_TOKEN (PAT) instead of GITHUB_TOKEN for release-please
- PRs created by GITHUB_TOKEN do not trigger other workflows (GitHub security measure)
- This allows CI to run on release-please PRs

## Test plan
- [ ] Merge this PR
- [ ] Verify release-please PR #70 gets CI checks triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)