### PR TITLE
Add linting, CodeQL, and tooling improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,39 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "go"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"
 
   # npm (Svelte frontend)
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "frontend"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,29 @@ jobs:
         with:
           config: .testcoverage.yml
 
+      - name: Per-package coverage report
+        run: |
+          echo "## Per-Package Coverage Report"
+          echo ""
+          echo "| Package | Coverage | Status |"
+          echo "|---------|----------|--------|"
+          for pkg in api command config domain gedcom query repository repository/memory; do
+            COV=$(go tool cover -func=coverage.out | grep "github.com/cacack/my-family/internal/$pkg" | tail -1 | awk '{print $3}')
+            if [ -z "$COV" ]; then
+              echo "| internal/$pkg | N/A | - |"
+              continue
+            fi
+            PCT=$(echo "$COV" | sed 's/%//')
+            if (( $(echo "$PCT >= 85.0" | bc -l) )); then
+              echo "| internal/$pkg | $COV | :white_check_mark: |"
+            else
+              echo "| internal/$pkg | $COV | :warning: |"
+            fi
+          done
+          echo ""
+          TOTAL=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}')
+          echo "**Total: $TOTAL**"
+
       - name: Build
         run: go build ./...
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Sundays at 00:00 UTC
+    - cron: '0 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+
+      - name: Create placeholder for embedded files
+        if: matrix.language == 'go'
+        run: |
+          mkdir -p internal/web/dist
+          echo "placeholder" > internal/web/dist/.gitkeep
+
+      - name: Set up Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install frontend dependencies
+        if: matrix.language == 'javascript-typescript'
+        run: cd web && npm ci
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,79 @@
+# golangci-lint v2 config
+# Run: golangci-lint run ./...
+version: "2"
+
+run:
+  modules-download-mode: readonly
+  tests: true
+
+linters:
+  enable:
+    - gocritic      # Opinionated style checks
+    - gocyclo       # Cyclomatic complexity
+    - gosec         # Security issues
+    - misspell      # Spelling mistakes
+    - revive        # Replacement for golint
+    - unconvert     # Unnecessary type conversions
+    - unparam       # Unused function parameters
+
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    gocyclo:
+      min-complexity: 15
+    revive:
+      severity: warning
+      rules:
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+            - sayRepetitiveInsteadOfStutters
+          severity: warning
+          disabled: false
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Relax rules for test files
+      - linters:
+          - errcheck
+          - gocyclo
+          - gosec
+        path: _test\.go
+      # Ignore nil pointer checks in tests
+      - path: _test\.go
+        text: SA5011
+      # Relax for cmd (main packages)
+      - linters:
+          - gocyclo
+        path: cmd/
+      # Event interface methods must use value receivers for interface compatibility
+      - linters:
+          - gocritic
+        path: internal/domain/events\.go
+        text: hugeParam
+
+    paths:
+      - third_party$
+      - builtin$
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$


### PR DESCRIPTION
## Summary

- Add `.golangci.yml` with comprehensive linter config (gocritic, gocyclo, gosec, misspell, revive, unparam)
- Add CodeQL workflow for Go and JavaScript/TypeScript security analysis
- Add per-package coverage table to CI output for visibility
- Enhance dependabot config with labels (`dependencies`, `go`, `ci`, `frontend`) and commit prefixes
- Add `make help` target with self-documenting targets
- Pin tool versions in Makefile (golangci-lint v2.7.2)
- Improve tool discovery in lint and check-coverage targets

Aligns tooling with gedcom-go repo patterns for consistent developer experience across both repos.

## Test plan

- [x] `make help` displays all targets
- [x] `make check-coverage` passes
- [x] Pre-push hook passes
- [ ] CI runs CodeQL successfully
- [ ] Linter config works in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)