### PR TITLE
Fix Codecov badge showing unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- Adds `CODECOV_TOKEN` secret reference to the codecov-action step

## Problem
The Codecov badge was showing "unknown" because coverage uploads were failing with:
```
error -- Upload failed: {"message":"Token required because branch is protected"}
```

Codecov v5 requires a token for repositories with branch protection enabled.

## Action Required
After merging, add the `CODECOV_TOKEN` secret:
1. Get token from https://app.codecov.io/gh/cacack/my-family/settings
2. Add as secret at https://github.com/cacack/my-family/settings/secrets/actions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)