### PR TITLE
Exempt Dependabot PRs from title check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
             exit 0
           fi
 
+          # Exempt Dependabot PRs
+          if echo "$TITLE" | grep -qE "^chore\(deps(-dev)?\): [Bb]ump "; then
+            echo "✅ Dependabot PR exempt"
+            exit 0
+          fi
+
           PATTERN="^(feat|fix|perf|docs|refactor|ci|chore)(\(.+\))?!?:"
           if echo "$TITLE" | grep -qE "$PATTERN"; then
             echo "::error::PR title should NOT use conventional commit format."


### PR DESCRIPTION
## Summary
- Adds exemption for Dependabot PRs in the PR title check
- Dependabot generates titles like `chore(deps): Bump ...` which match conventional commit format
- This is expected behavior for automated dependency updates, similar to release-please

Fixes #78 CI failure.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, rebase PR #78 and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)