### PR TITLE
Rollback capability for entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ coverage.out
 
 # Generated code (regenerate with go generate)
 internal/api/openapi_gen.go
+
+# Claude Code prompts (ephemeral, not committed)
+prompts/

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -25,6 +25,8 @@ tags:
     description: GEDCOM import/export
   - name: history
     description: Change history and audit trail
+  - name: rollback
+    description: Rollback and restore point management
 
 paths:
   /persons:
@@ -482,6 +484,274 @@ paths:
                 $ref: '#/components/schemas/ChangeHistoryResponse'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  # Rollback endpoints
+
+  /persons/{id}/restore-points:
+    parameters:
+      - $ref: '#/components/parameters/personId'
+
+    get:
+      operationId: getPersonRestorePoints
+      summary: Get restore points for a person
+      description: Returns a list of versions to which the person can be rolled back
+      tags: [rollback]
+      parameters:
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+      responses:
+        '200':
+          description: List of restore points
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestorePointsResponse'
+              example:
+                items:
+                  - version: 3
+                    timestamp: "2024-01-15T14:30:00Z"
+                    action: updated
+                    summary: "updated given_name, surname"
+                  - version: 2
+                    timestamp: "2024-01-15T10:00:00Z"
+                    action: updated
+                    summary: "updated birth_date"
+                  - version: 1
+                    timestamp: "2024-01-14T09:00:00Z"
+                    action: created
+                    summary: "created John Smith"
+                total: 3
+                has_more: false
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /persons/{id}/rollback:
+    parameters:
+      - $ref: '#/components/parameters/personId'
+
+    post:
+      operationId: rollbackPerson
+      summary: Rollback a person to a previous version
+      description: Restores the person's data to match the state at the specified version
+      tags: [rollback]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollbackRequest'
+            example:
+              target_version: 2
+      responses:
+        '200':
+          description: Rollback successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollbackResponse'
+              example:
+                entity_id: "123e4567-e89b-12d3-a456-426614174000"
+                entity_type: "Person"
+                new_version: 4
+                changes:
+                  given_name: "John"
+                  surname: "Doe"
+                message: "Person rolled back successfully"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cannot rollback deleted entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /families/{id}/restore-points:
+    parameters:
+      - $ref: '#/components/parameters/familyId'
+
+    get:
+      operationId: getFamilyRestorePoints
+      summary: Get restore points for a family
+      description: Returns a list of versions to which the family can be rolled back
+      tags: [rollback]
+      parameters:
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+      responses:
+        '200':
+          description: List of restore points
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestorePointsResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /families/{id}/rollback:
+    parameters:
+      - $ref: '#/components/parameters/familyId'
+
+    post:
+      operationId: rollbackFamily
+      summary: Rollback a family to a previous version
+      description: Restores the family's data to match the state at the specified version
+      tags: [rollback]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollbackRequest'
+      responses:
+        '200':
+          description: Rollback successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollbackResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cannot rollback deleted entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sources/{id}/restore-points:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: getSourceRestorePoints
+      summary: Get restore points for a source
+      description: Returns a list of versions to which the source can be rolled back
+      tags: [rollback]
+      parameters:
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+      responses:
+        '200':
+          description: List of restore points
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestorePointsResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /sources/{id}/rollback:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      operationId: rollbackSource
+      summary: Rollback a source to a previous version
+      description: Restores the source's data to match the state at the specified version
+      tags: [rollback]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollbackRequest'
+      responses:
+        '200':
+          description: Rollback successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollbackResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cannot rollback deleted entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /citations/{id}/restore-points:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: getCitationRestorePoints
+      summary: Get restore points for a citation
+      description: Returns a list of versions to which the citation can be rolled back
+      tags: [rollback]
+      parameters:
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+      responses:
+        '200':
+          description: List of restore points
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestorePointsResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /citations/{id}/rollback:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      operationId: rollbackCitation
+      summary: Rollback a citation to a previous version
+      description: Restores the citation's data to match the state at the specified version
+      tags: [rollback]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollbackRequest'
+      responses:
+        '200':
+          description: Rollback successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollbackResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cannot rollback deleted entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:
@@ -1007,3 +1277,78 @@ components:
           type: integer
         has_more:
           type: boolean
+
+    RestorePoint:
+      type: object
+      required: [version, timestamp, action, summary]
+      properties:
+        version:
+          type: integer
+          format: int64
+          description: The version number of this restore point
+          example: 2
+        timestamp:
+          type: string
+          format: date-time
+          description: When this version was created
+          example: "2024-01-15T10:30:00Z"
+        action:
+          type: string
+          enum: [created, updated, deleted, linked, unlinked]
+          description: The action that created this version
+          example: "updated"
+        summary:
+          type: string
+          description: Human-readable summary of the changes
+          example: "updated given_name, birth_date"
+
+    RestorePointsResponse:
+      type: object
+      required: [items, total, has_more]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/RestorePoint'
+        total:
+          type: integer
+          description: Total number of restore points available
+        has_more:
+          type: boolean
+          description: Whether there are more restore points beyond the current page
+
+    RollbackRequest:
+      type: object
+      required: [target_version]
+      properties:
+        target_version:
+          type: integer
+          format: int64
+          minimum: 1
+          description: The version number to rollback to
+          example: 2
+
+    RollbackResponse:
+      type: object
+      required: [entity_id, entity_type, new_version, changes, message]
+      properties:
+        entity_id:
+          type: string
+          format: uuid
+          description: ID of the entity that was rolled back
+        entity_type:
+          type: string
+          enum: [Person, Family, Source, Citation]
+          description: Type of entity that was rolled back
+        new_version:
+          type: integer
+          format: int64
+          description: The new version number after the rollback
+        changes:
+          type: object
+          additionalProperties: true
+          description: Map of field names to their restored values
+        message:
+          type: string
+          description: Success message
+          example: "Person rolled back successfully"

--- a/internal/api/rollback_handlers.go
+++ b/internal/api/rollback_handlers.go
@@ -1,0 +1,311 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/cacack/my-family/internal/command"
+	"github.com/cacack/my-family/internal/query"
+)
+
+// Rollback request/response types
+
+// RestorePointResponse represents a single restore point in the API response.
+type RestorePointResponse struct {
+	Version   int64  `json:"version"`
+	Timestamp string `json:"timestamp"`
+	Action    string `json:"action"`
+	Summary   string `json:"summary"`
+}
+
+// RestorePointsResponse represents the paginated restore points response.
+type RestorePointsResponse struct {
+	Items   []RestorePointResponse `json:"items"`
+	Total   int                    `json:"total"`
+	HasMore bool                   `json:"has_more"`
+}
+
+// RollbackRequest represents a rollback request.
+type RollbackRequest struct {
+	TargetVersion int64 `json:"target_version"`
+}
+
+// RollbackResponse represents the result of a rollback operation.
+type RollbackResponse struct {
+	EntityID   string         `json:"entity_id"`
+	EntityType string         `json:"entity_type"`
+	NewVersion int64          `json:"new_version"`
+	Changes    map[string]any `json:"changes"`
+	Message    string         `json:"message"`
+}
+
+// Person rollback handlers
+
+// getPersonRestorePoints handles GET /persons/{id}/restore-points
+func (s *Server) getPersonRestorePoints(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid person ID")
+	}
+
+	// Verify person exists
+	_, err = s.personService.GetPerson(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	return s.getRestorePoints(c, "Person", id)
+}
+
+// rollbackPerson handles POST /persons/{id}/rollback
+func (s *Server) rollbackPerson(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid person ID")
+	}
+
+	// Verify person exists
+	_, err = s.personService.GetPerson(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	var req RollbackRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.TargetVersion < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "target_version must be a positive integer")
+	}
+
+	result, err := s.commandHandler.RollbackPerson(c.Request().Context(), id, req.TargetVersion)
+	if err != nil {
+		return s.handleRollbackError(err)
+	}
+
+	return c.JSON(http.StatusOK, convertRollbackResultToResponse(result, "Person rolled back successfully"))
+}
+
+// Family rollback handlers
+
+// getFamilyRestorePoints handles GET /families/{id}/restore-points
+func (s *Server) getFamilyRestorePoints(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid family ID")
+	}
+
+	// Verify family exists
+	_, err = s.familyService.GetFamily(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	return s.getRestorePoints(c, "Family", id)
+}
+
+// rollbackFamily handles POST /families/{id}/rollback
+func (s *Server) rollbackFamily(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid family ID")
+	}
+
+	// Verify family exists
+	_, err = s.familyService.GetFamily(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	var req RollbackRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.TargetVersion < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "target_version must be a positive integer")
+	}
+
+	result, err := s.commandHandler.RollbackFamily(c.Request().Context(), id, req.TargetVersion)
+	if err != nil {
+		return s.handleRollbackError(err)
+	}
+
+	return c.JSON(http.StatusOK, convertRollbackResultToResponse(result, "Family rolled back successfully"))
+}
+
+// Source rollback handlers
+
+// getSourceRestorePoints handles GET /sources/{id}/restore-points
+func (s *Server) getSourceRestorePoints(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid source ID")
+	}
+
+	// Verify source exists
+	_, err = s.sourceService.GetSource(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	return s.getRestorePoints(c, "Source", id)
+}
+
+// rollbackSource handles POST /sources/{id}/rollback
+func (s *Server) rollbackSource(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid source ID")
+	}
+
+	// Verify source exists
+	_, err = s.sourceService.GetSource(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	var req RollbackRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.TargetVersion < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "target_version must be a positive integer")
+	}
+
+	result, err := s.commandHandler.RollbackSource(c.Request().Context(), id, req.TargetVersion)
+	if err != nil {
+		return s.handleRollbackError(err)
+	}
+
+	return c.JSON(http.StatusOK, convertRollbackResultToResponse(result, "Source rolled back successfully"))
+}
+
+// Citation rollback handlers
+
+// getCitationRestorePoints handles GET /citations/{id}/restore-points
+func (s *Server) getCitationRestorePoints(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid citation ID")
+	}
+
+	// Verify citation exists
+	_, err = s.sourceService.GetCitation(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	return s.getRestorePoints(c, "Citation", id)
+}
+
+// rollbackCitation handles POST /citations/{id}/rollback
+func (s *Server) rollbackCitation(c echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid citation ID")
+	}
+
+	// Verify citation exists
+	_, err = s.sourceService.GetCitation(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	var req RollbackRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.TargetVersion < 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "target_version must be a positive integer")
+	}
+
+	result, err := s.commandHandler.RollbackCitation(c.Request().Context(), id, req.TargetVersion)
+	if err != nil {
+		return s.handleRollbackError(err)
+	}
+
+	return c.JSON(http.StatusOK, convertRollbackResultToResponse(result, "Citation rolled back successfully"))
+}
+
+// Helper functions
+
+// getRestorePoints is a generic helper for fetching restore points.
+func (s *Server) getRestorePoints(c echo.Context, entityType string, entityID uuid.UUID) error {
+	// Parse pagination parameters
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	offset, _ := strconv.Atoi(c.QueryParam("offset"))
+
+	// Apply defaults
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	result, err := s.rollbackService.GetRestorePoints(c.Request().Context(), entityType, entityID, limit, offset)
+	if err != nil {
+		if errors.Is(err, query.ErrNoEvents) {
+			return echo.NewHTTPError(http.StatusNotFound, "No history found for this entity")
+		}
+		return err
+	}
+
+	response := RestorePointsResponse{
+		Items:   make([]RestorePointResponse, len(result.RestorePoints)),
+		Total:   result.TotalCount,
+		HasMore: result.HasMore,
+	}
+
+	for i, rp := range result.RestorePoints {
+		response.Items[i] = RestorePointResponse{
+			Version:   rp.Version,
+			Timestamp: rp.Timestamp.Format(time.RFC3339),
+			Action:    rp.Action,
+			Summary:   rp.Summary,
+		}
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// handleRollbackError converts rollback errors to appropriate HTTP responses.
+func (s *Server) handleRollbackError(err error) error {
+	switch {
+	case errors.Is(err, command.ErrRollbackInvalidVersion):
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid target version: must be positive and less than current version")
+	case errors.Is(err, command.ErrRollbackDeletedEntity):
+		return echo.NewHTTPError(http.StatusConflict, "Cannot rollback a deleted entity")
+	case errors.Is(err, command.ErrRollbackNoChanges):
+		return echo.NewHTTPError(http.StatusBadRequest, "Target version matches current version, no rollback needed")
+	case errors.Is(err, query.ErrNoEvents):
+		return echo.NewHTTPError(http.StatusNotFound, "No history found for this entity")
+	case errors.Is(err, query.ErrInvalidVersion):
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid version specified")
+	default:
+		return err
+	}
+}
+
+// convertRollbackResultToResponse converts a command.RollbackResult to an API response.
+func convertRollbackResultToResponse(result *command.RollbackResult, message string) RollbackResponse {
+	return RollbackResponse{
+		EntityID:   result.EntityID.String(),
+		EntityType: result.EntityType,
+		NewVersion: result.NewVersion,
+		Changes:    result.Changes,
+		Message:    message,
+	}
+}

--- a/internal/api/rollback_handlers_test.go
+++ b/internal/api/rollback_handlers_test.go
@@ -1,0 +1,982 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Person rollback tests
+
+func TestGetPersonRestorePoints_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Update the person to create more restore points
+	updateBody := `{"given_name":"Jane","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Get restore points
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Verify response structure
+	if resp["items"] == nil {
+		t.Error("Expected items field in response")
+	}
+	if resp["total"] == nil {
+		t.Error("Expected total field in response")
+	}
+	if resp["has_more"] == nil {
+		t.Error("Expected has_more field in response")
+	}
+
+	// Should have at least 2 restore points
+	items := resp["items"].([]any)
+	if len(items) < 2 {
+		t.Errorf("Expected at least 2 restore points, got %d", len(items))
+	}
+
+	// Verify first restore point structure
+	firstPoint := items[0].(map[string]any)
+	if firstPoint["version"] == nil {
+		t.Error("Expected version in restore point")
+	}
+	if firstPoint["timestamp"] == nil {
+		t.Error("Expected timestamp in restore point")
+	}
+	if firstPoint["action"] == nil {
+		t.Error("Expected action in restore point")
+	}
+	if firstPoint["summary"] == nil {
+		t.Error("Expected summary in restore point")
+	}
+}
+
+func TestGetPersonRestorePoints_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/not-a-uuid/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetPersonRestorePoints_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/00000000-0000-0000-0000-000000000001/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestGetPersonRestorePoints_Pagination(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person and update multiple times
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Update multiple times
+	for i := 1; i <= 5; i++ {
+		updateBody := `{"notes":"Update ` + string(rune('A'+i-1)) + `","version":` + string(rune('0'+i)) + `}`
+		updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
+		updateReq.Header.Set("Content-Type", "application/json")
+		updateRec := httptest.NewRecorder()
+		server.Echo().ServeHTTP(updateRec, updateReq)
+	}
+
+	// Get first page with limit=2
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/restore-points?limit=2&offset=0", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	items := resp["items"].([]any)
+	if len(items) != 2 {
+		t.Errorf("items count = %d, want 2", len(items))
+	}
+	if resp["has_more"].(bool) != true {
+		t.Error("has_more should be true")
+	}
+}
+
+func TestRollbackPerson_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Update the person
+	updateBody := `{"given_name":"Jane","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Rollback to version 1
+	rollbackBody := `{"target_version":1}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rollbackRec.Code, http.StatusOK, rollbackRec.Body.String())
+	}
+
+	var rollbackResp map[string]any
+	if err := json.Unmarshal(rollbackRec.Body.Bytes(), &rollbackResp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Verify response structure
+	if rollbackResp["entity_id"] != personID {
+		t.Errorf("entity_id = %v, want %v", rollbackResp["entity_id"], personID)
+	}
+	if rollbackResp["entity_type"] != "Person" {
+		t.Errorf("entity_type = %v, want Person", rollbackResp["entity_type"])
+	}
+	if rollbackResp["new_version"].(float64) != 3 {
+		t.Errorf("new_version = %v, want 3", rollbackResp["new_version"])
+	}
+	if rollbackResp["message"] == nil {
+		t.Error("Expected message in response")
+	}
+
+	// Verify the person was restored
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID, nil)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+
+	var getResp map[string]any
+	json.Unmarshal(getRec.Body.Bytes(), &getResp)
+	if getResp["given_name"] != "John" {
+		t.Errorf("given_name = %v, want John", getResp["given_name"])
+	}
+}
+
+func TestRollbackPerson_InvalidBody(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Update the person
+	updateBody := `{"given_name":"Jane","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Try to rollback with invalid JSON
+	rollbackBody := `{invalid json`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackPerson_InvalidVersion(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Update the person
+	updateBody := `{"given_name":"Jane","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Try to rollback to version 0 (invalid)
+	rollbackBody := `{"target_version":0}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+
+	// Try to rollback to version higher than current
+	rollbackBody = `{"target_version":100}`
+	rollbackReq = httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec = httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackPerson_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/not-a-uuid/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackPerson_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/00000000-0000-0000-0000-000000000001/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackPerson_NoChanges(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person
+	body := `{"given_name":"John","surname":"Doe"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	personID := createResp["id"].(string)
+
+	// Try to rollback to current version (version 1)
+	rollbackBody := `{"target_version":1}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+// Family rollback tests
+
+func TestGetFamilyRestorePoints_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person to use as partner
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a family
+	body := `{"partner1_id":"` + personID + `","relationship_type":"marriage","marriage_place":"New York"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/families", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	familyID := createResp["id"].(string)
+
+	// Get restore points
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/families/"+familyID+"/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestGetFamilyRestorePoints_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/families/not-a-uuid/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetFamilyRestorePoints_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/families/00000000-0000-0000-0000-000000000001/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackFamily_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person to use as partner
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a family
+	body := `{"partner1_id":"` + personID + `","relationship_type":"marriage","marriage_place":"New York"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/families", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	familyID := createResp["id"].(string)
+
+	// Update the family
+	updateBody := `{"marriage_place":"Boston","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/families/"+familyID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Rollback to version 1
+	rollbackBody := `{"target_version":1}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/families/"+familyID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rollbackRec.Code, http.StatusOK, rollbackRec.Body.String())
+	}
+}
+
+func TestRollbackFamily_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/families/not-a-uuid/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackFamily_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/families/00000000-0000-0000-0000-000000000001/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackFamily_InvalidBody(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a family
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	body := `{"partner1_id":"` + personID + `","relationship_type":"marriage"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/families", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	familyID := createResp["id"].(string)
+
+	// Update to have version 2
+	updateBody := `{"marriage_place":"Boston","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/families/"+familyID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Try to rollback with invalid JSON
+	rollbackBody := `{invalid`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/families/"+familyID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackFamily_InvalidVersion(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a person to use as partner
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a family with at least one partner
+	body := `{"partner1_id":"` + personID + `","relationship_type":"marriage"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/families", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	familyID := createResp["id"].(string)
+
+	// Try to rollback to version 0
+	rollbackBody := `{"target_version":0}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/families/"+familyID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+// Source rollback tests
+
+func TestGetSourceRestorePoints_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source
+	body := `{"title":"1900 Census","author":"US Census Bureau"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	sourceID := createResp["id"].(string)
+
+	// Get restore points
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/"+sourceID+"/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestGetSourceRestorePoints_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/not-a-uuid/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetSourceRestorePoints_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sources/00000000-0000-0000-0000-000000000001/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackSource_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source
+	body := `{"title":"1900 Census","author":"US Census Bureau"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	sourceID := createResp["id"].(string)
+
+	// Update the source
+	updateBody := `{"title":"1900 Federal Census","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/sources/"+sourceID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Rollback to version 1
+	rollbackBody := `{"target_version":1}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources/"+sourceID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rollbackRec.Code, http.StatusOK, rollbackRec.Body.String())
+	}
+}
+
+func TestRollbackSource_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/not-a-uuid/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackSource_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sources/00000000-0000-0000-0000-000000000001/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackSource_InvalidBody(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source
+	body := `{"title":"Test Source"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	sourceID := createResp["id"].(string)
+
+	// Update to have version 2
+	updateBody := `{"title":"Updated Source","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/sources/"+sourceID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Try to rollback with invalid JSON
+	rollbackBody := `{invalid`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources/"+sourceID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackSource_InvalidVersion(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source
+	body := `{"title":"Test Source"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	sourceID := createResp["id"].(string)
+
+	// Try to rollback to version 0
+	rollbackBody := `{"target_version":0}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources/"+sourceID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+// Citation rollback tests
+
+func TestGetCitationRestorePoints_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source first
+	sourceBody := `{"title":"Test Source"}`
+	sourceReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(sourceBody))
+	sourceReq.Header.Set("Content-Type", "application/json")
+	sourceRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(sourceRec, sourceReq)
+
+	var sourceResp map[string]any
+	json.Unmarshal(sourceRec.Body.Bytes(), &sourceResp)
+	sourceID := sourceResp["id"].(string)
+
+	// Create a person for the citation
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a citation
+	body := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `","page":"10"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	citationID := createResp["id"].(string)
+
+	// Get restore points
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/citations/"+citationID+"/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestGetCitationRestorePoints_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/citations/not-a-uuid/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetCitationRestorePoints_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/citations/00000000-0000-0000-0000-000000000001/restore-points", nil)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackCitation_Success(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source first
+	sourceBody := `{"title":"Test Source"}`
+	sourceReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(sourceBody))
+	sourceReq.Header.Set("Content-Type", "application/json")
+	sourceRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(sourceRec, sourceReq)
+
+	var sourceResp map[string]any
+	json.Unmarshal(sourceRec.Body.Bytes(), &sourceResp)
+	sourceID := sourceResp["id"].(string)
+
+	// Create a person for the citation
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a citation
+	body := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `","page":"10"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	citationID := createResp["id"].(string)
+
+	// Update the citation
+	updateBody := `{"page":"20","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/citations/"+citationID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Rollback to version 1
+	rollbackBody := `{"target_version":1}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations/"+citationID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rollbackRec.Code, http.StatusOK, rollbackRec.Body.String())
+	}
+}
+
+func TestRollbackCitation_InvalidID(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/citations/not-a-uuid/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackCitation_NotFound(t *testing.T) {
+	server := setupTestServer()
+
+	rollbackBody := `{"target_version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/citations/00000000-0000-0000-0000-000000000001/rollback", strings.NewReader(rollbackBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRollbackCitation_InvalidBody(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source first
+	sourceBody := `{"title":"Test Source"}`
+	sourceReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(sourceBody))
+	sourceReq.Header.Set("Content-Type", "application/json")
+	sourceRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(sourceRec, sourceReq)
+
+	var sourceResp map[string]any
+	json.Unmarshal(sourceRec.Body.Bytes(), &sourceResp)
+	sourceID := sourceResp["id"].(string)
+
+	// Create a person for the citation
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a citation
+	body := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	citationID := createResp["id"].(string)
+
+	// Update to have version 2
+	updateBody := `{"page":"20","version":1}`
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/citations/"+citationID, strings.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(updateRec, updateReq)
+
+	// Try to rollback with invalid JSON
+	rollbackBody := `{invalid`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations/"+citationID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRollbackCitation_InvalidVersion(t *testing.T) {
+	server := setupTestServer()
+
+	// Create a source first
+	sourceBody := `{"title":"Test Source"}`
+	sourceReq := httptest.NewRequest(http.MethodPost, "/api/v1/sources", strings.NewReader(sourceBody))
+	sourceReq.Header.Set("Content-Type", "application/json")
+	sourceRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(sourceRec, sourceReq)
+
+	var sourceResp map[string]any
+	json.Unmarshal(sourceRec.Body.Bytes(), &sourceResp)
+	sourceID := sourceResp["id"].(string)
+
+	// Create a person for the citation
+	personBody := `{"given_name":"John","surname":"Doe"}`
+	personReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(personBody))
+	personReq.Header.Set("Content-Type", "application/json")
+	personRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(personRec, personReq)
+
+	var personResp map[string]any
+	json.Unmarshal(personRec.Body.Bytes(), &personResp)
+	personID := personResp["id"].(string)
+
+	// Create a citation
+	body := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+
+	var createResp map[string]any
+	json.Unmarshal(createRec.Body.Bytes(), &createResp)
+	citationID := createResp["id"].(string)
+
+	// Try to rollback to version 0
+	rollbackBody := `{"target_version":0}`
+	rollbackReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations/"+citationID+"/rollback", strings.NewReader(rollbackBody))
+	rollbackReq.Header.Set("Content-Type", "application/json")
+	rollbackRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rollbackRec, rollbackReq)
+
+	if rollbackRec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rollbackRec.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	pedigreeService *query.PedigreeService
 	sourceService   *query.SourceService
 	historyService  *query.HistoryService
+	rollbackService *query.RollbackService
 	frontendFS      fs.FS
 }
 
@@ -69,6 +70,7 @@ func NewServer(
 	pedigreeSvc := query.NewPedigreeService(readStore)
 	sourceSvc := query.NewSourceService(readStore)
 	historySvc := query.NewHistoryService(eventStore, readStore)
+	rollbackSvc := query.NewRollbackService(eventStore, readStore)
 
 	server := &Server{
 		echo:            e,
@@ -80,6 +82,7 @@ func NewServer(
 		pedigreeService: pedigreeSvc,
 		sourceService:   sourceSvc,
 		historyService:  historySvc,
+		rollbackService: rollbackSvc,
 		frontendFS:      frontendFS,
 	}
 
@@ -148,6 +151,16 @@ func (s *Server) registerRoutes() {
 	api.GET("/persons/:id/history", s.getPersonHistory)
 	api.GET("/families/:id/history", s.getFamilyHistory)
 	api.GET("/sources/:id/history", s.getSourceHistory)
+
+	// Rollback
+	api.GET("/persons/:id/restore-points", s.getPersonRestorePoints)
+	api.POST("/persons/:id/rollback", s.rollbackPerson)
+	api.GET("/families/:id/restore-points", s.getFamilyRestorePoints)
+	api.POST("/families/:id/rollback", s.rollbackFamily)
+	api.GET("/sources/:id/restore-points", s.getSourceRestorePoints)
+	api.POST("/sources/:id/rollback", s.rollbackSource)
+	api.GET("/citations/:id/restore-points", s.getCitationRestorePoints)
+	api.POST("/citations/:id/rollback", s.rollbackCitation)
 
 	// Serve frontend if available
 	if s.frontendFS != nil {

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -3,24 +3,56 @@ package command
 
 import (
 	"context"
+	"errors"
+
+	"github.com/google/uuid"
 
 	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/query"
 	"github.com/cacack/my-family/internal/repository"
 )
 
+// Rollback-related errors.
+var (
+	ErrRollbackInvalidVersion = errors.New("invalid rollback version: must be positive and less than current version")
+	ErrRollbackDeletedEntity  = errors.New("cannot rollback a deleted entity")
+	ErrRollbackNoChanges      = errors.New("rollback to current version is a no-op")
+)
+
+// RollbackResult contains the result of a rollback operation.
+type RollbackResult struct {
+	EntityID   uuid.UUID      `json:"entity_id"`
+	EntityType string         `json:"entity_type"`
+	NewVersion int64          `json:"new_version"`
+	Changes    map[string]any `json:"changes"`
+}
+
 // Handler processes commands and returns resulting domain events.
 type Handler struct {
-	eventStore repository.EventStore
-	readStore  repository.ReadModelStore
-	projector  *repository.Projector
+	eventStore      repository.EventStore
+	readStore       repository.ReadModelStore
+	projector       *repository.Projector
+	rollbackService *query.RollbackService
 }
 
 // NewHandler creates a new command handler.
 func NewHandler(eventStore repository.EventStore, readStore repository.ReadModelStore) *Handler {
 	return &Handler{
-		eventStore: eventStore,
-		readStore:  readStore,
-		projector:  repository.NewProjector(readStore),
+		eventStore:      eventStore,
+		readStore:       readStore,
+		projector:       repository.NewProjector(readStore),
+		rollbackService: query.NewRollbackService(eventStore, readStore),
+	}
+}
+
+// NewHandlerWithRollbackService creates a new command handler with a custom rollback service.
+// This is primarily useful for testing.
+func NewHandlerWithRollbackService(eventStore repository.EventStore, readStore repository.ReadModelStore, rollbackService *query.RollbackService) *Handler {
+	return &Handler{
+		eventStore:      eventStore,
+		readStore:       readStore,
+		projector:       repository.NewProjector(readStore),
+		rollbackService: rollbackService,
 	}
 }
 
@@ -51,4 +83,131 @@ func (h *Handler) execute(ctx context.Context, streamID string, streamType strin
 	}
 
 	return newVersion, nil
+}
+
+// RollbackPerson rolls back a person to a specific version.
+// It computes the changes needed and generates a compensating PersonUpdated event.
+func (h *Handler) RollbackPerson(ctx context.Context, personID uuid.UUID, targetVersion int64) (*RollbackResult, error) {
+	return h.rollbackEntity(ctx, "Person", personID, targetVersion, func(id uuid.UUID) (bool, error) {
+		person, err := h.readStore.GetPerson(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		return person == nil, nil
+	})
+}
+
+// RollbackFamily rolls back a family to a specific version.
+// It computes the changes needed and generates a compensating FamilyUpdated event.
+func (h *Handler) RollbackFamily(ctx context.Context, familyID uuid.UUID, targetVersion int64) (*RollbackResult, error) {
+	return h.rollbackEntity(ctx, "Family", familyID, targetVersion, func(id uuid.UUID) (bool, error) {
+		family, err := h.readStore.GetFamily(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		return family == nil, nil
+	})
+}
+
+// RollbackSource rolls back a source to a specific version.
+// It computes the changes needed and generates a compensating SourceUpdated event.
+func (h *Handler) RollbackSource(ctx context.Context, sourceID uuid.UUID, targetVersion int64) (*RollbackResult, error) {
+	return h.rollbackEntity(ctx, "Source", sourceID, targetVersion, func(id uuid.UUID) (bool, error) {
+		source, err := h.readStore.GetSource(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		return source == nil, nil
+	})
+}
+
+// RollbackCitation rolls back a citation to a specific version.
+// It computes the changes needed and generates a compensating CitationUpdated event.
+func (h *Handler) RollbackCitation(ctx context.Context, citationID uuid.UUID, targetVersion int64) (*RollbackResult, error) {
+	return h.rollbackEntity(ctx, "Citation", citationID, targetVersion, func(id uuid.UUID) (bool, error) {
+		citation, err := h.readStore.GetCitation(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		return citation == nil, nil
+	})
+}
+
+// rollbackEntity is a generic helper that handles the rollback logic for any entity type.
+// The isDeleted function checks if the entity is currently deleted in the read model.
+func (h *Handler) rollbackEntity(ctx context.Context, entityType string, entityID uuid.UUID, targetVersion int64, isDeleted func(uuid.UUID) (bool, error)) (*RollbackResult, error) {
+	// Validate target version is positive
+	if targetVersion < 1 {
+		return nil, ErrRollbackInvalidVersion
+	}
+
+	// Get current version from event store
+	currentVersion, err := h.eventStore.GetStreamVersion(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, repository.ErrStreamNotFound) {
+			return nil, query.ErrNoEvents
+		}
+		return nil, err
+	}
+
+	// Validate target version is less than current version
+	if targetVersion >= currentVersion {
+		if targetVersion == currentVersion {
+			return nil, ErrRollbackNoChanges
+		}
+		return nil, ErrRollbackInvalidVersion
+	}
+
+	// Check if entity is currently deleted (follow-up feature to handle recreation)
+	deleted, err := isDeleted(entityID)
+	if err != nil {
+		return nil, err
+	}
+	if deleted {
+		return nil, ErrRollbackDeletedEntity
+	}
+
+	// Compute rollback changes using RollbackService
+	changes, err := h.rollbackService.ComputeRollbackChanges(ctx, entityType, entityID, targetVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no changes needed, this is a no-op
+	if len(changes.Changes) == 0 {
+		return &RollbackResult{
+			EntityID:   entityID,
+			EntityType: entityType,
+			NewVersion: currentVersion,
+			Changes:    changes.Changes,
+		}, nil
+	}
+
+	// Create compensating event based on entity type
+	var event domain.Event
+	switch entityType {
+	case "Person":
+		event = domain.NewPersonUpdated(entityID, changes.Changes)
+	case "Family":
+		event = domain.NewFamilyUpdated(entityID, changes.Changes)
+	case "Source":
+		event = domain.NewSourceUpdated(entityID, changes.Changes)
+	case "Citation":
+		event = domain.NewCitationUpdated(entityID, changes.Changes)
+	default:
+		return nil, errors.New("unsupported entity type for rollback: " + entityType)
+	}
+
+	// Append event with optimistic locking
+	newVersion, err := h.execute(ctx, entityID.String(), entityType, []domain.Event{event}, currentVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RollbackResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		NewVersion: newVersion,
+		Changes:    changes.Changes,
+	}, nil
 }

--- a/internal/command/handler_test.go
+++ b/internal/command/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cacack/my-family/internal/command"
 	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/query"
 	"github.com/cacack/my-family/internal/repository"
 	"github.com/cacack/my-family/internal/repository/memory"
 )
@@ -245,5 +246,1111 @@ func TestHandler_Execute_ProjectionError(t *testing.T) {
 	}
 	if result.Version != 1 {
 		t.Errorf("Version = %d, want 1", result.Version)
+	}
+}
+
+// Rollback tests
+
+func TestRollbackPerson_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Update the person
+	newName := "Jane"
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:        createResult.ID,
+		GivenName: &newName,
+		Version:   createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// Rollback to version 1
+	rollbackResult, err := handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackPerson failed: %v", err)
+	}
+
+	// Verify rollback result
+	if rollbackResult.EntityID != createResult.ID {
+		t.Errorf("EntityID = %v, want %v", rollbackResult.EntityID, createResult.ID)
+	}
+	if rollbackResult.EntityType != "Person" {
+		t.Errorf("EntityType = %s, want Person", rollbackResult.EntityType)
+	}
+	if rollbackResult.NewVersion != 3 {
+		t.Errorf("NewVersion = %d, want 3", rollbackResult.NewVersion)
+	}
+	if rollbackResult.Changes["given_name"] != "John" {
+		t.Errorf("given_name change = %v, want John", rollbackResult.Changes["given_name"])
+	}
+
+	// Verify the person was restored
+	person, err := readStore.GetPerson(ctx, createResult.ID)
+	if err != nil {
+		t.Fatalf("GetPerson failed: %v", err)
+	}
+	if person.GivenName != "John" {
+		t.Errorf("GivenName = %s, want John", person.GivenName)
+	}
+}
+
+func TestRollbackPerson_InvalidVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Try to rollback to version 0 (invalid)
+	_, err = handler.RollbackPerson(ctx, createResult.ID, 0)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+
+	// Try to rollback to version higher than current
+	_, err = handler.RollbackPerson(ctx, createResult.ID, 10)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackPerson_ToCurrentVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Try to rollback to current version (no-op)
+	_, err = handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackNoChanges {
+		t.Errorf("Expected ErrRollbackNoChanges, got %v", err)
+	}
+}
+
+func TestRollbackPerson_ConcurrencyConflict(t *testing.T) {
+	mockStore := newMockEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(mockStore, readStore)
+	ctx := context.Background()
+
+	// Create and update a person normally
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	newName := "Jane"
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:        createResult.ID,
+		GivenName: &newName,
+		Version:   createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// Set mock to return concurrency error on next append
+	mockStore.appendError = repository.ErrConcurrencyConflict
+
+	// Try to rollback - should fail with concurrency error
+	_, err = handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != repository.ErrConcurrencyConflict {
+		t.Errorf("Expected ErrConcurrencyConflict, got %v", err)
+	}
+}
+
+func TestRollbackPerson_DeletedEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Update the person to have version 2
+	newName := "Jane"
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:        createResult.ID,
+		GivenName: &newName,
+		Version:   createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// Delete the person
+	err = handler.DeletePerson(ctx, command.DeletePersonInput{
+		ID:      createResult.ID,
+		Version: 2,
+		Reason:  "test deletion",
+	})
+	if err != nil {
+		t.Fatalf("DeletePerson failed: %v", err)
+	}
+
+	// Try to rollback a deleted entity
+	_, err = handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackDeletedEntity {
+		t.Errorf("Expected ErrRollbackDeletedEntity, got %v", err)
+	}
+}
+
+func TestRollbackPerson_NotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Try to rollback a non-existent person
+	nonExistentID := uuid.New()
+	_, err := handler.RollbackPerson(ctx, nonExistentID, 1)
+	// The memory event store returns version 0 for non-existent streams,
+	// which makes target version >= current version, causing ErrRollbackNoChanges
+	if err != command.ErrRollbackNoChanges && err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackNoChanges or ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackFamily_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+		MarriagePlace:    "New York",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Update the family
+	newPlace := "Boston"
+	_, err = handler.UpdateFamily(ctx, command.UpdateFamilyInput{
+		ID:            createResult.ID,
+		MarriagePlace: &newPlace,
+		Version:       createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFamily failed: %v", err)
+	}
+
+	// Rollback to version 1
+	rollbackResult, err := handler.RollbackFamily(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackFamily failed: %v", err)
+	}
+
+	// Verify rollback result
+	if rollbackResult.EntityType != "Family" {
+		t.Errorf("EntityType = %s, want Family", rollbackResult.EntityType)
+	}
+	if rollbackResult.NewVersion != 3 {
+		t.Errorf("NewVersion = %d, want 3", rollbackResult.NewVersion)
+	}
+}
+
+func TestRollbackFamily_InvalidVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family with at least one partner
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Try to rollback to version 0 (invalid)
+	_, err = handler.RollbackFamily(ctx, createResult.ID, 0)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackSource_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "1900 Census",
+		SourceType: "census",
+		Author:     "US Census Bureau",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Update the source
+	newTitle := "1900 Federal Census"
+	_, err = handler.UpdateSource(ctx, command.UpdateSourceInput{
+		ID:      createResult.ID,
+		Title:   &newTitle,
+		Version: createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+
+	// Rollback to version 1
+	rollbackResult, err := handler.RollbackSource(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackSource failed: %v", err)
+	}
+
+	// Verify rollback result
+	if rollbackResult.EntityType != "Source" {
+		t.Errorf("EntityType = %s, want Source", rollbackResult.EntityType)
+	}
+	if rollbackResult.NewVersion != 3 {
+		t.Errorf("NewVersion = %d, want 3", rollbackResult.NewVersion)
+	}
+	if rollbackResult.Changes["title"] != "1900 Census" {
+		t.Errorf("title change = %v, want 1900 Census", rollbackResult.Changes["title"])
+	}
+}
+
+func TestRollbackSource_InvalidVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Try to rollback to version 0 (invalid)
+	_, err = handler.RollbackSource(ctx, createResult.ID, 0)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackCitation_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "1900 Census",
+		SourceType: "census",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+		Page:        "Page 10",
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Update the citation
+	newPage := "Page 20"
+	_, err = handler.UpdateCitation(ctx, command.UpdateCitationInput{
+		ID:      createResult.ID,
+		Page:    &newPage,
+		Version: createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCitation failed: %v", err)
+	}
+
+	// Rollback to version 1
+	rollbackResult, err := handler.RollbackCitation(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackCitation failed: %v", err)
+	}
+
+	// Verify rollback result
+	if rollbackResult.EntityType != "Citation" {
+		t.Errorf("EntityType = %s, want Citation", rollbackResult.EntityType)
+	}
+	if rollbackResult.NewVersion != 3 {
+		t.Errorf("NewVersion = %d, want 3", rollbackResult.NewVersion)
+	}
+	if rollbackResult.Changes["page"] != "Page 10" {
+		t.Errorf("page change = %v, want Page 10", rollbackResult.Changes["page"])
+	}
+}
+
+func TestRollbackCitation_InvalidVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Try to rollback to version 0 (invalid)
+	_, err = handler.RollbackCitation(ctx, createResult.ID, 0)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackPerson_NoChangesNeeded(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Update the person with a field that will be removed
+	newNotes := "Some notes"
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:      createResult.ID,
+		Notes:   &newNotes,
+		Version: createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// Update again to remove the notes
+	emptyNotes := ""
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:      createResult.ID,
+		Notes:   &emptyNotes,
+		Version: 2,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// The state at version 3 should be mostly the same as version 1
+	// (given_name and surname unchanged, notes removed)
+	// Rollback to version 1 should only need to restore empty state for notes
+	rollbackResult, err := handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackPerson failed: %v", err)
+	}
+
+	// There should be changes (notes was added then removed, so at v1 there was no notes field)
+	// At v3 notes is empty string, at v1 notes didn't exist
+	if rollbackResult.NewVersion != 4 {
+		t.Errorf("NewVersion = %d, want 4", rollbackResult.NewVersion)
+	}
+}
+
+func TestNewHandlerWithRollbackService(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	rollbackService := query.NewRollbackService(eventStore, readStore)
+
+	handler := command.NewHandlerWithRollbackService(eventStore, readStore, rollbackService)
+
+	if handler == nil {
+		t.Fatal("NewHandlerWithRollbackService returned nil")
+	}
+}
+
+func TestRollbackFamily_DeletedEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+		MarriagePlace:    "New York",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Update the family to have version 2
+	newPlace := "Boston"
+	_, err = handler.UpdateFamily(ctx, command.UpdateFamilyInput{
+		ID:            createResult.ID,
+		MarriagePlace: &newPlace,
+		Version:       createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFamily failed: %v", err)
+	}
+
+	// Delete the family
+	err = handler.DeleteFamily(ctx, command.DeleteFamilyInput{
+		ID:      createResult.ID,
+		Version: 2,
+	})
+	if err != nil {
+		t.Fatalf("DeleteFamily failed: %v", err)
+	}
+
+	// Try to rollback a deleted entity
+	_, err = handler.RollbackFamily(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackDeletedEntity {
+		t.Errorf("Expected ErrRollbackDeletedEntity, got %v", err)
+	}
+}
+
+func TestRollbackSource_DeletedEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "1900 Census",
+		SourceType: "census",
+		Author:     "US Census Bureau",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Update the source to have version 2
+	newTitle := "1900 Federal Census"
+	_, err = handler.UpdateSource(ctx, command.UpdateSourceInput{
+		ID:      createResult.ID,
+		Title:   &newTitle,
+		Version: createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+
+	// Delete the source
+	err = handler.DeleteSource(ctx, createResult.ID, 2, "test deletion")
+	if err != nil {
+		t.Fatalf("DeleteSource failed: %v", err)
+	}
+
+	// Try to rollback a deleted entity
+	_, err = handler.RollbackSource(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackDeletedEntity {
+		t.Errorf("Expected ErrRollbackDeletedEntity, got %v", err)
+	}
+}
+
+func TestRollbackCitation_DeletedEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "1900 Census",
+		SourceType: "census",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+		Page:        "Page 10",
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Update the citation to have version 2
+	newPage := "Page 20"
+	_, err = handler.UpdateCitation(ctx, command.UpdateCitationInput{
+		ID:      createResult.ID,
+		Page:    &newPage,
+		Version: createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCitation failed: %v", err)
+	}
+
+	// Delete the citation
+	err = handler.DeleteCitation(ctx, createResult.ID, 2, "test deletion")
+	if err != nil {
+		t.Fatalf("DeleteCitation failed: %v", err)
+	}
+
+	// Try to rollback a deleted entity
+	_, err = handler.RollbackCitation(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackDeletedEntity {
+		t.Errorf("Expected ErrRollbackDeletedEntity, got %v", err)
+	}
+}
+
+func TestRollbackFamily_ToCurrentVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Try to rollback to current version (no-op)
+	_, err = handler.RollbackFamily(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackNoChanges {
+		t.Errorf("Expected ErrRollbackNoChanges, got %v", err)
+	}
+}
+
+func TestRollbackSource_ToCurrentVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Try to rollback to current version (no-op)
+	_, err = handler.RollbackSource(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackNoChanges {
+		t.Errorf("Expected ErrRollbackNoChanges, got %v", err)
+	}
+}
+
+func TestRollbackCitation_ToCurrentVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Try to rollback to current version (no-op)
+	_, err = handler.RollbackCitation(ctx, createResult.ID, 1)
+	if err != command.ErrRollbackNoChanges {
+		t.Errorf("Expected ErrRollbackNoChanges, got %v", err)
+	}
+}
+
+func TestRollbackPerson_NegativeVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Try to rollback to negative version
+	_, err = handler.RollbackPerson(ctx, createResult.ID, -5)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackFamily_NegativeVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Try to rollback to negative version
+	_, err = handler.RollbackFamily(ctx, createResult.ID, -5)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackSource_NegativeVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Try to rollback to negative version
+	_, err = handler.RollbackSource(ctx, createResult.ID, -5)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackCitation_NegativeVersion(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Try to rollback to negative version
+	_, err = handler.RollbackCitation(ctx, createResult.ID, -5)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackFamily_VersionBeyondCurrent(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person to use as partner
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a family
+	createResult, err := handler.CreateFamily(ctx, command.CreateFamilyInput{
+		Partner1ID:       &personResult.ID,
+		RelationshipType: "marriage",
+	})
+	if err != nil {
+		t.Fatalf("CreateFamily failed: %v", err)
+	}
+
+	// Update the family to have version 2
+	newPlace := "Boston"
+	_, err = handler.UpdateFamily(ctx, command.UpdateFamilyInput{
+		ID:            createResult.ID,
+		MarriagePlace: &newPlace,
+		Version:       1,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFamily failed: %v", err)
+	}
+
+	// Try to rollback to version beyond current
+	_, err = handler.RollbackFamily(ctx, createResult.ID, 100)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackSource_VersionBeyondCurrent(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source
+	createResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Update the source to have version 2
+	newTitle := "Updated Source"
+	_, err = handler.UpdateSource(ctx, command.UpdateSourceInput{
+		ID:      createResult.ID,
+		Title:   &newTitle,
+		Version: 1,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+
+	// Try to rollback to version beyond current
+	_, err = handler.RollbackSource(ctx, createResult.ID, 100)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackCitation_VersionBeyondCurrent(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a source first
+	sourceResult, err := handler.CreateSource(ctx, command.CreateSourceInput{
+		Title:      "Test Source",
+		SourceType: "book",
+	})
+	if err != nil {
+		t.Fatalf("CreateSource failed: %v", err)
+	}
+
+	// Create a person for the citation
+	personResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Create a citation
+	createResult, err := handler.CreateCitation(ctx, command.CreateCitationInput{
+		SourceID:    sourceResult.ID,
+		FactType:    "person_birth",
+		FactOwnerID: personResult.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateCitation failed: %v", err)
+	}
+
+	// Update the citation to have version 2
+	newPage := "Page 20"
+	_, err = handler.UpdateCitation(ctx, command.UpdateCitationInput{
+		ID:      createResult.ID,
+		Page:    &newPage,
+		Version: 1,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCitation failed: %v", err)
+	}
+
+	// Try to rollback to version beyond current
+	_, err = handler.RollbackCitation(ctx, createResult.ID, 100)
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion, got %v", err)
+	}
+}
+
+func TestRollbackPerson_NonExistentEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Try to rollback a non-existent person - memory store returns version 0
+	// so targetVersion >= currentVersion triggers ErrRollbackInvalidVersion
+	nonExistentID := uuid.New()
+	_, err := handler.RollbackPerson(ctx, nonExistentID, 1)
+
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion for non-existent entity, got %v", err)
+	}
+}
+
+func TestRollbackFamily_NonExistentEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	nonExistentID := uuid.New()
+	_, err := handler.RollbackFamily(ctx, nonExistentID, 1)
+
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion for non-existent entity, got %v", err)
+	}
+}
+
+func TestRollbackSource_NonExistentEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	nonExistentID := uuid.New()
+	_, err := handler.RollbackSource(ctx, nonExistentID, 1)
+
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion for non-existent entity, got %v", err)
+	}
+}
+
+func TestRollbackCitation_NonExistentEntity(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	nonExistentID := uuid.New()
+	_, err := handler.RollbackCitation(ctx, nonExistentID, 1)
+
+	if err != command.ErrRollbackInvalidVersion {
+		t.Errorf("Expected ErrRollbackInvalidVersion for non-existent entity, got %v", err)
+	}
+}
+
+// TestRollbackPerson_NoChangesRequiredFromState tests the case where rollback state matches current state
+func TestRollbackPerson_NoChangesRequiredFromState(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	createResult, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+	})
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Update person with the same values (effectively no change)
+	sameName := "John"
+	_, err = handler.UpdatePerson(ctx, command.UpdatePersonInput{
+		ID:        createResult.ID,
+		GivenName: &sameName,
+		Version:   createResult.Version,
+	})
+	if err != nil {
+		t.Fatalf("UpdatePerson failed: %v", err)
+	}
+
+	// Now we have version 2 but values are same as version 1
+	// Rollback should succeed with empty changes
+	result, err := handler.RollbackPerson(ctx, createResult.ID, 1)
+	if err != nil {
+		t.Fatalf("RollbackPerson failed: %v", err)
+	}
+
+	// Should return result indicating no changes needed (version stays at 2)
+	if result.NewVersion != 2 {
+		t.Errorf("Expected NewVersion=2 (no change), got %d", result.NewVersion)
 	}
 }

--- a/internal/query/rollback_queries.go
+++ b/internal/query/rollback_queries.go
@@ -1,0 +1,634 @@
+// Package query provides CQRS query services for the genealogy application.
+package query
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// ErrInvalidVersion is returned when the target version is invalid.
+var ErrInvalidVersion = errors.New("invalid version: must be positive and not exceed current version")
+
+// ErrEntityDeleted is returned when trying to rollback a deleted entity.
+var ErrEntityDeleted = errors.New("entity has been deleted")
+
+// ErrNoEvents is returned when no events exist for an entity.
+var ErrNoEvents = errors.New("no events found for entity")
+
+// RollbackService provides query operations for rollback functionality.
+type RollbackService struct {
+	eventStore repository.EventStore
+	readStore  repository.ReadModelStore
+}
+
+// NewRollbackService creates a new rollback query service.
+func NewRollbackService(eventStore repository.EventStore, readStore repository.ReadModelStore) *RollbackService {
+	return &RollbackService{
+		eventStore: eventStore,
+		readStore:  readStore,
+	}
+}
+
+// RestorePoint represents a point in time to which an entity can be restored.
+type RestorePoint struct {
+	Version      int64     `json:"version"`
+	Timestamp    time.Time `json:"timestamp"`
+	Action       string    `json:"action"` // "created", "updated", "deleted", "linked", "unlinked"
+	Summary      string    `json:"summary"`
+	IsCurrent    bool      `json:"is_current"`
+	IsRestorable bool      `json:"is_restorable"` // false for deleted or current version
+}
+
+// RestorePointsResult contains paginated restore points.
+type RestorePointsResult struct {
+	RestorePoints []RestorePoint `json:"restore_points"`
+	TotalCount    int            `json:"total_count"`
+	HasMore       bool           `json:"has_more"`
+	Limit         int            `json:"limit"`
+	Offset        int            `json:"offset"`
+}
+
+// EntityState represents the reconstructed state of an entity at a specific version.
+type EntityState struct {
+	EntityType string         `json:"entity_type"`
+	EntityID   uuid.UUID      `json:"entity_id"`
+	Version    int64          `json:"version"`
+	IsDeleted  bool           `json:"is_deleted"`
+	State      map[string]any `json:"state"`
+}
+
+// RollbackChanges represents the changes needed to rollback an entity.
+type RollbackChanges struct {
+	EntityType     string         `json:"entity_type"`
+	EntityID       uuid.UUID      `json:"entity_id"`
+	CurrentVersion int64          `json:"current_version"`
+	TargetVersion  int64          `json:"target_version"`
+	Changes        map[string]any `json:"changes"`       // field -> value to restore
+	IsRecreation   bool           `json:"is_recreation"` // true if rolling back from deleted state
+}
+
+// GetRestorePoints returns a paginated list of restore points for an entity.
+func (s *RollbackService) GetRestorePoints(ctx context.Context, entityType string, entityID uuid.UUID, limit, offset int) (*RestorePointsResult, error) {
+	// Validate inputs
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Read all events for this entity
+	events, err := s.eventStore.ReadStream(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, repository.ErrStreamNotFound) {
+			return nil, ErrNoEvents
+		}
+		return nil, fmt.Errorf("reading event stream: %w", err)
+	}
+
+	if len(events) == 0 {
+		return nil, ErrNoEvents
+	}
+
+	// Sort events by version (ascending)
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Version < events[j].Version
+	})
+
+	totalCount := len(events)
+	currentVersion := events[len(events)-1].Version
+	isDeleted := s.isDeletedEvent(events[len(events)-1].EventType)
+
+	// Build restore points (newest first for display)
+	allPoints := make([]RestorePoint, 0, len(events))
+	for i := len(events) - 1; i >= 0; i-- {
+		evt := events[i]
+		action := s.eventTypeToAction(evt.EventType)
+		summary := s.buildChangeSummary(evt)
+
+		point := RestorePoint{
+			Version:      evt.Version,
+			Timestamp:    evt.Timestamp,
+			Action:       action,
+			Summary:      summary,
+			IsCurrent:    evt.Version == currentVersion,
+			IsRestorable: evt.Version != currentVersion && !isDeleted,
+		}
+		allPoints = append(allPoints, point)
+	}
+
+	// Apply pagination
+	start := offset
+	if start >= len(allPoints) {
+		return &RestorePointsResult{
+			RestorePoints: []RestorePoint{},
+			TotalCount:    totalCount,
+			HasMore:       false,
+			Limit:         limit,
+			Offset:        offset,
+		}, nil
+	}
+
+	end := start + limit
+	if end > len(allPoints) {
+		end = len(allPoints)
+	}
+
+	return &RestorePointsResult{
+		RestorePoints: allPoints[start:end],
+		TotalCount:    totalCount,
+		HasMore:       end < len(allPoints),
+		Limit:         limit,
+		Offset:        offset,
+	}, nil
+}
+
+// GetStateAtVersion reconstructs the entity state at a specific version.
+func (s *RollbackService) GetStateAtVersion(ctx context.Context, entityType string, entityID uuid.UUID, version int64) (*EntityState, error) {
+	if version < 1 {
+		return nil, ErrInvalidVersion
+	}
+
+	// Read all events for this entity
+	events, err := s.eventStore.ReadStream(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, repository.ErrStreamNotFound) {
+			return nil, ErrNoEvents
+		}
+		return nil, fmt.Errorf("reading event stream: %w", err)
+	}
+
+	if len(events) == 0 {
+		return nil, ErrNoEvents
+	}
+
+	// Sort events by version (ascending)
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Version < events[j].Version
+	})
+
+	// Validate version
+	maxVersion := events[len(events)-1].Version
+	if version > maxVersion {
+		return nil, ErrInvalidVersion
+	}
+
+	// Replay events up to target version
+	state := make(map[string]any)
+	var isDeleted bool
+
+	for _, evt := range events {
+		if evt.Version > version {
+			break
+		}
+
+		isDeleted, err = s.applyEventToState(evt, state)
+		if err != nil {
+			return nil, fmt.Errorf("applying event: %w", err)
+		}
+	}
+
+	return &EntityState{
+		EntityType: entityType,
+		EntityID:   entityID,
+		Version:    version,
+		IsDeleted:  isDeleted,
+		State:      state,
+	}, nil
+}
+
+// ComputeRollbackChanges computes the changes needed to rollback from current to target version.
+func (s *RollbackService) ComputeRollbackChanges(ctx context.Context, entityType string, entityID uuid.UUID, targetVersion int64) (*RollbackChanges, error) {
+	if targetVersion < 1 {
+		return nil, ErrInvalidVersion
+	}
+
+	// Read all events for this entity
+	events, err := s.eventStore.ReadStream(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, repository.ErrStreamNotFound) {
+			return nil, ErrNoEvents
+		}
+		return nil, fmt.Errorf("reading event stream: %w", err)
+	}
+
+	if len(events) == 0 {
+		return nil, ErrNoEvents
+	}
+
+	// Sort events by version (ascending)
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Version < events[j].Version
+	})
+
+	// Validate target version
+	currentVersion := events[len(events)-1].Version
+	if targetVersion > currentVersion {
+		return nil, ErrInvalidVersion
+	}
+	if targetVersion == currentVersion {
+		// Nothing to rollback
+		return &RollbackChanges{
+			EntityType:     entityType,
+			EntityID:       entityID,
+			CurrentVersion: currentVersion,
+			TargetVersion:  targetVersion,
+			Changes:        make(map[string]any),
+		}, nil
+	}
+
+	// Check if current state is deleted
+	isCurrentlyDeleted := s.isDeletedEvent(events[len(events)-1].EventType)
+
+	// Get target state
+	targetState, err := s.GetStateAtVersion(ctx, entityType, entityID, targetVersion)
+	if err != nil {
+		return nil, fmt.Errorf("getting target state: %w", err)
+	}
+
+	// Get current state
+	currentState, err := s.GetStateAtVersion(ctx, entityType, entityID, currentVersion)
+	if err != nil {
+		return nil, fmt.Errorf("getting current state: %w", err)
+	}
+
+	// Compute diff: what values from target state differ from current state
+	changes := s.computeStateDiff(currentState.State, targetState.State)
+
+	return &RollbackChanges{
+		EntityType:     entityType,
+		EntityID:       entityID,
+		CurrentVersion: currentVersion,
+		TargetVersion:  targetVersion,
+		Changes:        changes,
+		IsRecreation:   isCurrentlyDeleted && !targetState.IsDeleted,
+	}, nil
+}
+
+// applyEventToState applies a single event to the state map and returns whether the entity is deleted.
+func (s *RollbackService) applyEventToState(evt repository.StoredEvent, state map[string]any) (bool, error) {
+	domainEvent, err := evt.DecodeEvent()
+	if err != nil {
+		return false, err
+	}
+
+	switch e := domainEvent.(type) {
+	// Person events
+	case domain.PersonCreated:
+		state["id"] = e.PersonID.String()
+		state["given_name"] = e.GivenName
+		state["surname"] = e.Surname
+		if e.Gender != "" {
+			state["gender"] = string(e.Gender)
+		}
+		if e.BirthDate != nil {
+			state["birth_date"] = e.BirthDate.String()
+		}
+		if e.BirthPlace != "" {
+			state["birth_place"] = e.BirthPlace
+		}
+		if e.DeathDate != nil {
+			state["death_date"] = e.DeathDate.String()
+		}
+		if e.DeathPlace != "" {
+			state["death_place"] = e.DeathPlace
+		}
+		if e.Notes != "" {
+			state["notes"] = e.Notes
+		}
+		return false, nil
+
+	case domain.PersonUpdated:
+		for field, value := range e.Changes {
+			if value == nil {
+				delete(state, field)
+			} else {
+				state[field] = normalizeValue(value)
+			}
+		}
+		return false, nil
+
+	case domain.PersonDeleted:
+		// Mark as deleted but preserve state for potential restore
+		return true, nil
+
+	// Family events
+	case domain.FamilyCreated:
+		state["id"] = e.FamilyID.String()
+		if e.Partner1ID != nil {
+			state["partner1_id"] = e.Partner1ID.String()
+		}
+		if e.Partner2ID != nil {
+			state["partner2_id"] = e.Partner2ID.String()
+		}
+		if e.RelationshipType != "" {
+			state["relationship_type"] = string(e.RelationshipType)
+		}
+		if e.MarriageDate != nil {
+			state["marriage_date"] = e.MarriageDate.String()
+		}
+		if e.MarriagePlace != "" {
+			state["marriage_place"] = e.MarriagePlace
+		}
+		return false, nil
+
+	case domain.FamilyUpdated:
+		for field, value := range e.Changes {
+			if value == nil {
+				delete(state, field)
+			} else {
+				state[field] = normalizeValue(value)
+			}
+		}
+		return false, nil
+
+	case domain.FamilyDeleted:
+		return true, nil
+
+	case domain.ChildLinkedToFamily:
+		// Track children as a list
+		children, ok := state["children"].([]string)
+		if !ok {
+			children = []string{}
+		}
+		children = append(children, e.PersonID.String())
+		state["children"] = children
+		return false, nil
+
+	case domain.ChildUnlinkedFromFamily:
+		children, ok := state["children"].([]string)
+		if ok {
+			newChildren := make([]string, 0, len(children))
+			for _, c := range children {
+				if c != e.PersonID.String() {
+					newChildren = append(newChildren, c)
+				}
+			}
+			state["children"] = newChildren
+		}
+		return false, nil
+
+	// Source events
+	case domain.SourceCreated:
+		state["id"] = e.SourceID.String()
+		state["title"] = e.Title
+		if e.SourceType != "" {
+			state["source_type"] = string(e.SourceType)
+		}
+		if e.Author != "" {
+			state["author"] = e.Author
+		}
+		if e.Publisher != "" {
+			state["publisher"] = e.Publisher
+		}
+		if e.PublishDate != nil {
+			state["publish_date"] = e.PublishDate.String()
+		}
+		if e.URL != "" {
+			state["url"] = e.URL
+		}
+		if e.RepositoryName != "" {
+			state["repository_name"] = e.RepositoryName
+		}
+		if e.CollectionName != "" {
+			state["collection_name"] = e.CollectionName
+		}
+		if e.CallNumber != "" {
+			state["call_number"] = e.CallNumber
+		}
+		if e.Notes != "" {
+			state["notes"] = e.Notes
+		}
+		return false, nil
+
+	case domain.SourceUpdated:
+		for field, value := range e.Changes {
+			if value == nil {
+				delete(state, field)
+			} else {
+				state[field] = normalizeValue(value)
+			}
+		}
+		return false, nil
+
+	case domain.SourceDeleted:
+		return true, nil
+
+	// Citation events
+	case domain.CitationCreated:
+		state["id"] = e.CitationID.String()
+		state["source_id"] = e.SourceID.String()
+		state["fact_type"] = string(e.FactType)
+		state["fact_owner_id"] = e.FactOwnerID.String()
+		if e.Page != "" {
+			state["page"] = e.Page
+		}
+		if e.Volume != "" {
+			state["volume"] = e.Volume
+		}
+		if e.SourceQuality != "" {
+			state["source_quality"] = string(e.SourceQuality)
+		}
+		if e.InformantType != "" {
+			state["informant_type"] = string(e.InformantType)
+		}
+		if e.EvidenceType != "" {
+			state["evidence_type"] = string(e.EvidenceType)
+		}
+		if e.QuotedText != "" {
+			state["quoted_text"] = e.QuotedText
+		}
+		if e.Analysis != "" {
+			state["analysis"] = e.Analysis
+		}
+		if e.TemplateID != "" {
+			state["template_id"] = e.TemplateID
+		}
+		return false, nil
+
+	case domain.CitationUpdated:
+		for field, value := range e.Changes {
+			if value == nil {
+				delete(state, field)
+			} else {
+				state[field] = normalizeValue(value)
+			}
+		}
+		return false, nil
+
+	case domain.CitationDeleted:
+		return true, nil
+
+	default:
+		// Unknown event type, skip
+		return false, nil
+	}
+}
+
+// normalizeValue converts values to string representation for consistent comparison.
+func normalizeValue(v any) any {
+	switch val := v.(type) {
+	case uuid.UUID:
+		return val.String()
+	case *uuid.UUID:
+		if val == nil {
+			return nil
+		}
+		return val.String()
+	case domain.GenDate:
+		return val.String()
+	case *domain.GenDate:
+		if val == nil {
+			return nil
+		}
+		return val.String()
+	default:
+		return v
+	}
+}
+
+// computeStateDiff computes differences between current and target state.
+// Returns a map of field -> target value for fields that differ.
+func (s *RollbackService) computeStateDiff(current, target map[string]any) map[string]any {
+	changes := make(map[string]any)
+
+	// Check fields in target that differ from current
+	for field, targetValue := range target {
+		currentValue, exists := current[field]
+		if !exists || !valuesEqual(currentValue, targetValue) {
+			changes[field] = targetValue
+		}
+	}
+
+	// Check fields in current that don't exist in target (need to be removed)
+	for field := range current {
+		if _, exists := target[field]; !exists {
+			changes[field] = nil
+		}
+	}
+
+	return changes
+}
+
+// valuesEqual compares two values for equality.
+func valuesEqual(a, b any) bool {
+	// Handle nil cases
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	// Convert to strings for comparison
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// eventTypeToAction maps event types to user-friendly action names.
+func (s *RollbackService) eventTypeToAction(eventType string) string {
+	switch eventType {
+	case "PersonCreated", "FamilyCreated", "SourceCreated", "CitationCreated":
+		return "created"
+	case "PersonUpdated", "FamilyUpdated", "SourceUpdated", "CitationUpdated":
+		return "updated"
+	case "PersonDeleted", "FamilyDeleted", "SourceDeleted", "CitationDeleted":
+		return "deleted"
+	case "ChildLinkedToFamily":
+		return "linked"
+	case "ChildUnlinkedFromFamily":
+		return "unlinked"
+	default:
+		return "unknown"
+	}
+}
+
+// isDeletedEvent checks if an event type represents deletion.
+func (s *RollbackService) isDeletedEvent(eventType string) bool {
+	return strings.HasSuffix(eventType, "Deleted")
+}
+
+// buildChangeSummary creates a human-readable summary of what changed in an event.
+func (s *RollbackService) buildChangeSummary(evt repository.StoredEvent) string {
+	domainEvent, err := evt.DecodeEvent()
+	if err != nil {
+		return "unknown change"
+	}
+
+	switch e := domainEvent.(type) {
+	case domain.PersonCreated:
+		return fmt.Sprintf("created %s %s", e.GivenName, e.Surname)
+	case domain.PersonUpdated:
+		return s.summarizeChanges("updated", e.Changes)
+	case domain.PersonDeleted:
+		if e.Reason != "" {
+			return fmt.Sprintf("deleted: %s", e.Reason)
+		}
+		return "deleted"
+
+	case domain.FamilyCreated:
+		return "created family"
+	case domain.FamilyUpdated:
+		return s.summarizeChanges("updated", e.Changes)
+	case domain.FamilyDeleted:
+		return "deleted"
+	case domain.ChildLinkedToFamily:
+		return fmt.Sprintf("linked child %s", e.PersonID.String()[:8])
+	case domain.ChildUnlinkedFromFamily:
+		return fmt.Sprintf("unlinked child %s", e.PersonID.String()[:8])
+
+	case domain.SourceCreated:
+		return fmt.Sprintf("created source: %s", truncate(e.Title, 40))
+	case domain.SourceUpdated:
+		return s.summarizeChanges("updated", e.Changes)
+	case domain.SourceDeleted:
+		return "deleted"
+
+	case domain.CitationCreated:
+		return fmt.Sprintf("created citation for %s", e.FactType)
+	case domain.CitationUpdated:
+		return s.summarizeChanges("updated", e.Changes)
+	case domain.CitationDeleted:
+		return "deleted"
+
+	default:
+		return "unknown change"
+	}
+}
+
+// summarizeChanges creates a summary of field changes.
+func (s *RollbackService) summarizeChanges(action string, changes map[string]any) string {
+	if len(changes) == 0 {
+		return action
+	}
+
+	fields := make([]string, 0, len(changes))
+	for field := range changes {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	if len(fields) <= 3 {
+		return fmt.Sprintf("%s %s", action, strings.Join(fields, ", "))
+	}
+	return fmt.Sprintf("%s %s and %d more", action, strings.Join(fields[:3], ", "), len(fields)-3)
+}
+
+// truncate shortens a string to the specified length.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/query/rollback_queries_test.go
+++ b/internal/query/rollback_queries_test.go
@@ -1,0 +1,1852 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// rollbackMockEventStore implements repository.EventStore for rollback testing.
+type rollbackMockEventStore struct {
+	readStreamFunc func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error)
+}
+
+func (m *rollbackMockEventStore) Append(ctx context.Context, streamID uuid.UUID, streamType string, events []domain.Event, expectedVersion int64) error {
+	return nil
+}
+
+func (m *rollbackMockEventStore) ReadStream(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+	if m.readStreamFunc != nil {
+		return m.readStreamFunc(ctx, streamID)
+	}
+	return nil, repository.ErrStreamNotFound
+}
+
+func (m *rollbackMockEventStore) ReadAll(ctx context.Context, fromPosition int64, limit int) ([]repository.StoredEvent, error) {
+	return nil, nil
+}
+
+func (m *rollbackMockEventStore) GetStreamVersion(ctx context.Context, streamID uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (m *rollbackMockEventStore) ReadByStream(ctx context.Context, streamID uuid.UUID, limit, offset int) (*repository.HistoryPage, error) {
+	return &repository.HistoryPage{}, nil
+}
+
+func (m *rollbackMockEventStore) ReadGlobalByTime(ctx context.Context, fromTime, toTime time.Time, eventTypes []string, limit, offset int) (*repository.HistoryPage, error) {
+	return &repository.HistoryPage{}, nil
+}
+
+func TestNewRollbackService(t *testing.T) {
+	eventStore := &rollbackMockEventStore{}
+	readStore := &mockReadModelStore{}
+
+	service := NewRollbackService(eventStore, readStore)
+
+	assert.NotNil(t, service)
+	assert.Equal(t, eventStore, service.eventStore)
+	assert.Equal(t, readStore, service.readStore)
+}
+
+func TestGetRestorePoints(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personUpdated := domain.PersonUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Changes:   map[string]any{"given_name": "Jonathan"},
+	}
+	updatedData, _ := json.Marshal(personUpdated)
+
+	tests := []struct {
+		name              string
+		entityType        string
+		entityID          uuid.UUID
+		limit             int
+		offset            int
+		mockEvents        []repository.StoredEvent
+		mockError         error
+		wantRestorePoints int
+		wantTotalCount    int
+		wantHasMore       bool
+		wantError         error
+	}{
+		{
+			name:       "single event returns one restore point",
+			entityType: "person",
+			entityID:   personID,
+			limit:      20,
+			offset:     0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantRestorePoints: 1,
+			wantTotalCount:    1,
+			wantHasMore:       false,
+		},
+		{
+			name:       "multiple events returns restore points in reverse order",
+			entityType: "person",
+			entityID:   personID,
+			limit:      20,
+			offset:     0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantRestorePoints: 2,
+			wantTotalCount:    2,
+			wantHasMore:       false,
+		},
+		{
+			name:       "pagination with limit",
+			entityType: "person",
+			entityID:   personID,
+			limit:      1,
+			offset:     0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantRestorePoints: 1,
+			wantTotalCount:    2,
+			wantHasMore:       true,
+		},
+		{
+			name:       "pagination with offset",
+			entityType: "person",
+			entityID:   personID,
+			limit:      1,
+			offset:     1,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantRestorePoints: 1,
+			wantTotalCount:    2,
+			wantHasMore:       false,
+		},
+		{
+			name:       "offset beyond results",
+			entityType: "person",
+			entityID:   personID,
+			limit:      20,
+			offset:     10,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantRestorePoints: 0,
+			wantTotalCount:    1,
+			wantHasMore:       false,
+		},
+		{
+			name:       "no events returns error",
+			entityType: "person",
+			entityID:   personID,
+			limit:      20,
+			offset:     0,
+			mockEvents: []repository.StoredEvent{},
+			wantError:  ErrNoEvents,
+		},
+		{
+			name:       "stream not found returns error",
+			entityType: "person",
+			entityID:   personID,
+			limit:      20,
+			offset:     0,
+			mockError:  repository.ErrStreamNotFound,
+			wantError:  ErrNoEvents,
+		},
+		{
+			name:       "default limit when zero",
+			entityType: "person",
+			entityID:   personID,
+			limit:      0,
+			offset:     0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantRestorePoints: 1,
+			wantTotalCount:    1,
+			wantHasMore:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventStore := &rollbackMockEventStore{
+				readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+					if tt.mockError != nil {
+						return nil, tt.mockError
+					}
+					return tt.mockEvents, nil
+				},
+			}
+
+			service := NewRollbackService(eventStore, &mockReadModelStore{})
+			result, err := service.GetRestorePoints(context.Background(), tt.entityType, tt.entityID, tt.limit, tt.offset)
+
+			if tt.wantError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRestorePoints, len(result.RestorePoints))
+			assert.Equal(t, tt.wantTotalCount, result.TotalCount)
+			assert.Equal(t, tt.wantHasMore, result.HasMore)
+		})
+	}
+}
+
+func TestGetRestorePoints_Properties(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personUpdated := domain.PersonUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Changes:   map[string]any{"given_name": "Jonathan"},
+	}
+	updatedData, _ := json.Marshal(personUpdated)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+	result, err := service.GetRestorePoints(context.Background(), "person", personID, 20, 0)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, len(result.RestorePoints))
+
+	// Current version should be marked as current and not restorable
+	currentPoint := result.RestorePoints[0]
+	assert.Equal(t, int64(2), currentPoint.Version)
+	assert.True(t, currentPoint.IsCurrent)
+	assert.False(t, currentPoint.IsRestorable)
+	assert.Equal(t, "updated", currentPoint.Action)
+
+	// Previous version should be restorable
+	prevPoint := result.RestorePoints[1]
+	assert.Equal(t, int64(1), prevPoint.Version)
+	assert.False(t, prevPoint.IsCurrent)
+	assert.True(t, prevPoint.IsRestorable)
+	assert.Equal(t, "created", prevPoint.Action)
+}
+
+func TestGetStateAtVersion(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent:  domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:   personID,
+		GivenName:  "John",
+		Surname:    "Smith",
+		Gender:     domain.GenderMale,
+		BirthPlace: "New York",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personUpdated := domain.PersonUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Changes:   map[string]any{"given_name": "Jonathan", "birth_place": "Boston"},
+	}
+	updatedData, _ := json.Marshal(personUpdated)
+
+	tests := []struct {
+		name          string
+		entityType    string
+		entityID      uuid.UUID
+		version       int64
+		mockEvents    []repository.StoredEvent
+		mockError     error
+		wantState     map[string]any
+		wantIsDeleted bool
+		wantError     error
+	}{
+		{
+			name:       "state at creation",
+			entityType: "person",
+			entityID:   personID,
+			version:    1,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantState: map[string]any{
+				"id":          personID.String(),
+				"given_name":  "John",
+				"surname":     "Smith",
+				"gender":      "male",
+				"birth_place": "New York",
+			},
+			wantIsDeleted: false,
+		},
+		{
+			name:       "state after update",
+			entityType: "person",
+			entityID:   personID,
+			version:    2,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantState: map[string]any{
+				"id":          personID.String(),
+				"given_name":  "Jonathan",
+				"surname":     "Smith",
+				"gender":      "male",
+				"birth_place": "Boston",
+			},
+			wantIsDeleted: false,
+		},
+		{
+			name:       "invalid version - zero",
+			entityType: "person",
+			entityID:   personID,
+			version:    0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantError: ErrInvalidVersion,
+		},
+		{
+			name:       "invalid version - exceeds current",
+			entityType: "person",
+			entityID:   personID,
+			version:    10,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantError: ErrInvalidVersion,
+		},
+		{
+			name:       "no events",
+			entityType: "person",
+			entityID:   personID,
+			version:    1,
+			mockEvents: []repository.StoredEvent{},
+			wantError:  ErrNoEvents,
+		},
+		{
+			name:       "stream not found",
+			entityType: "person",
+			entityID:   personID,
+			version:    1,
+			mockError:  repository.ErrStreamNotFound,
+			wantError:  ErrNoEvents,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventStore := &rollbackMockEventStore{
+				readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+					if tt.mockError != nil {
+						return nil, tt.mockError
+					}
+					return tt.mockEvents, nil
+				},
+			}
+
+			service := NewRollbackService(eventStore, &mockReadModelStore{})
+			result, err := service.GetStateAtVersion(context.Background(), tt.entityType, tt.entityID, tt.version)
+
+			if tt.wantError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.entityType, result.EntityType)
+			assert.Equal(t, tt.entityID, result.EntityID)
+			assert.Equal(t, tt.version, result.Version)
+			assert.Equal(t, tt.wantIsDeleted, result.IsDeleted)
+
+			for key, wantValue := range tt.wantState {
+				assert.Equal(t, wantValue, result.State[key], "field %s mismatch", key)
+			}
+		})
+	}
+}
+
+func TestGetStateAtVersion_DeletedEntity(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personDeleted := domain.PersonDeleted{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Reason:    "duplicate",
+	}
+	deletedData, _ := json.Marshal(personDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonDeleted",
+					Data:       deletedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// State before deletion
+	result, err := service.GetStateAtVersion(context.Background(), "person", personID, 1)
+	require.NoError(t, err)
+	assert.False(t, result.IsDeleted)
+	assert.Equal(t, "John", result.State["given_name"])
+
+	// State at deletion
+	result, err = service.GetStateAtVersion(context.Background(), "person", personID, 2)
+	require.NoError(t, err)
+	assert.True(t, result.IsDeleted)
+	// State is preserved for potential restoration
+	assert.Equal(t, "John", result.State["given_name"])
+}
+
+func TestComputeRollbackChanges(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent:  domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:   personID,
+		GivenName:  "John",
+		Surname:    "Smith",
+		BirthPlace: "New York",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personUpdated := domain.PersonUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Changes:   map[string]any{"given_name": "Jonathan", "notes": "Some notes"},
+	}
+	updatedData, _ := json.Marshal(personUpdated)
+
+	tests := []struct {
+		name             string
+		entityType       string
+		entityID         uuid.UUID
+		targetVersion    int64
+		mockEvents       []repository.StoredEvent
+		mockError        error
+		wantChanges      map[string]any
+		wantIsRecreation bool
+		wantError        error
+	}{
+		{
+			name:          "rollback to previous version",
+			entityType:    "person",
+			entityID:      personID,
+			targetVersion: 1,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			},
+			wantChanges: map[string]any{
+				"given_name": "John",
+				"notes":      nil, // Field didn't exist at version 1
+			},
+			wantIsRecreation: false,
+		},
+		{
+			name:          "same version returns empty changes",
+			entityType:    "person",
+			entityID:      personID,
+			targetVersion: 1,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantChanges:      map[string]any{},
+			wantIsRecreation: false,
+		},
+		{
+			name:          "invalid version - zero",
+			entityType:    "person",
+			entityID:      personID,
+			targetVersion: 0,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantError: ErrInvalidVersion,
+		},
+		{
+			name:          "invalid version - exceeds current",
+			entityType:    "person",
+			entityID:      personID,
+			targetVersion: 10,
+			mockEvents: []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			},
+			wantError: ErrInvalidVersion,
+		},
+		{
+			name:          "no events",
+			entityType:    "person",
+			entityID:      personID,
+			targetVersion: 1,
+			mockEvents:    []repository.StoredEvent{},
+			wantError:     ErrNoEvents,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventStore := &rollbackMockEventStore{
+				readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+					if tt.mockError != nil {
+						return nil, tt.mockError
+					}
+					return tt.mockEvents, nil
+				},
+			}
+
+			service := NewRollbackService(eventStore, &mockReadModelStore{})
+			result, err := service.ComputeRollbackChanges(context.Background(), tt.entityType, tt.entityID, tt.targetVersion)
+
+			if tt.wantError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.entityType, result.EntityType)
+			assert.Equal(t, tt.entityID, result.EntityID)
+			assert.Equal(t, tt.targetVersion, result.TargetVersion)
+			assert.Equal(t, tt.wantIsRecreation, result.IsRecreation)
+
+			for key, wantValue := range tt.wantChanges {
+				assert.Equal(t, wantValue, result.Changes[key], "field %s mismatch", key)
+			}
+		})
+	}
+}
+
+func TestComputeRollbackChanges_Resurrection(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personDeleted := domain.PersonDeleted{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+		Reason:    "duplicate",
+	}
+	deletedData, _ := json.Marshal(personDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonDeleted",
+					Data:       deletedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+	result, err := service.ComputeRollbackChanges(context.Background(), "person", personID, 1)
+
+	require.NoError(t, err)
+	assert.True(t, result.IsRecreation, "should be marked as recreation when rolling back from deleted state")
+	assert.Equal(t, int64(2), result.CurrentVersion)
+	assert.Equal(t, int64(1), result.TargetVersion)
+}
+
+func TestApplyEventToState_FamilyEvents(t *testing.T) {
+	familyID := uuid.New()
+	partner1ID := uuid.New()
+	partner2ID := uuid.New()
+	childID := uuid.New()
+	now := time.Now().UTC()
+
+	familyCreated := domain.FamilyCreated{
+		BaseEvent:        domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		FamilyID:         familyID,
+		Partner1ID:       &partner1ID,
+		Partner2ID:       &partner2ID,
+		RelationshipType: domain.RelationMarriage,
+		MarriagePlace:    "New York",
+	}
+	createdData, _ := json.Marshal(familyCreated)
+
+	childLinked := domain.ChildLinkedToFamily{
+		BaseEvent:        domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		FamilyID:         familyID,
+		PersonID:         childID,
+		RelationshipType: domain.ChildBiological,
+	}
+	linkedData, _ := json.Marshal(childLinked)
+
+	childUnlinked := domain.ChildUnlinkedFromFamily{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(2 * time.Hour)},
+		FamilyID:  familyID,
+		PersonID:  childID,
+	}
+	unlinkedData, _ := json.Marshal(childUnlinked)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "FamilyCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "ChildLinkedToFamily",
+					Data:       linkedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "ChildUnlinkedFromFamily",
+					Data:       unlinkedData,
+					Version:    3,
+					Position:   3,
+					Timestamp:  now.Add(2 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// State at creation
+	result, err := service.GetStateAtVersion(context.Background(), "family", familyID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, partner1ID.String(), result.State["partner1_id"])
+	assert.Equal(t, partner2ID.String(), result.State["partner2_id"])
+	assert.Equal(t, "marriage", result.State["relationship_type"])
+
+	// State after child linked
+	result, err = service.GetStateAtVersion(context.Background(), "family", familyID, 2)
+	require.NoError(t, err)
+	children, ok := result.State["children"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, children, childID.String())
+
+	// State after child unlinked
+	result, err = service.GetStateAtVersion(context.Background(), "family", familyID, 3)
+	require.NoError(t, err)
+	children, ok = result.State["children"].([]string)
+	require.True(t, ok)
+	assert.NotContains(t, children, childID.String())
+}
+
+func TestApplyEventToState_SourceEvents(t *testing.T) {
+	sourceID := uuid.New()
+	now := time.Now().UTC()
+
+	sourceCreated := domain.SourceCreated{
+		BaseEvent:  domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		SourceID:   sourceID,
+		SourceType: domain.SourceCensus,
+		Title:      "1900 Census",
+		Author:     "US Census Bureau",
+	}
+	createdData, _ := json.Marshal(sourceCreated)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   sourceID,
+					StreamType: "source",
+					EventType:  "SourceCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+	result, err := service.GetStateAtVersion(context.Background(), "source", sourceID, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, sourceID.String(), result.State["id"])
+	assert.Equal(t, "1900 Census", result.State["title"])
+	assert.Equal(t, "census", result.State["source_type"])
+	assert.Equal(t, "US Census Bureau", result.State["author"])
+}
+
+func TestApplyEventToState_CitationEvents(t *testing.T) {
+	citationID := uuid.New()
+	sourceID := uuid.New()
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	citationCreated := domain.CitationCreated{
+		BaseEvent:     domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		CitationID:    citationID,
+		SourceID:      sourceID,
+		FactType:      domain.FactPersonBirth,
+		FactOwnerID:   personID,
+		Page:          "123",
+		SourceQuality: domain.SourceOriginal,
+	}
+	createdData, _ := json.Marshal(citationCreated)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   citationID,
+					StreamType: "citation",
+					EventType:  "CitationCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+	result, err := service.GetStateAtVersion(context.Background(), "citation", citationID, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, citationID.String(), result.State["id"])
+	assert.Equal(t, sourceID.String(), result.State["source_id"])
+	assert.Equal(t, "person_birth", result.State["fact_type"])
+	assert.Equal(t, "123", result.State["page"])
+	assert.Equal(t, "original", result.State["source_quality"])
+}
+
+func TestEventTypeToAction(t *testing.T) {
+	service := &RollbackService{}
+
+	tests := []struct {
+		eventType  string
+		wantAction string
+	}{
+		{"PersonCreated", "created"},
+		{"PersonUpdated", "updated"},
+		{"PersonDeleted", "deleted"},
+		{"FamilyCreated", "created"},
+		{"FamilyUpdated", "updated"},
+		{"FamilyDeleted", "deleted"},
+		{"ChildLinkedToFamily", "linked"},
+		{"ChildUnlinkedFromFamily", "unlinked"},
+		{"SourceCreated", "created"},
+		{"SourceUpdated", "updated"},
+		{"SourceDeleted", "deleted"},
+		{"CitationCreated", "created"},
+		{"CitationUpdated", "updated"},
+		{"CitationDeleted", "deleted"},
+		{"UnknownEvent", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eventType, func(t *testing.T) {
+			action := service.eventTypeToAction(tt.eventType)
+			assert.Equal(t, tt.wantAction, action)
+		})
+	}
+}
+
+func TestIsDeletedEvent(t *testing.T) {
+	service := &RollbackService{}
+
+	tests := []struct {
+		eventType   string
+		wantDeleted bool
+	}{
+		{"PersonDeleted", true},
+		{"FamilyDeleted", true},
+		{"SourceDeleted", true},
+		{"CitationDeleted", true},
+		{"PersonCreated", false},
+		{"PersonUpdated", false},
+		{"ChildLinkedToFamily", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eventType, func(t *testing.T) {
+			isDeleted := service.isDeletedEvent(tt.eventType)
+			assert.Equal(t, tt.wantDeleted, isDeleted)
+		})
+	}
+}
+
+func TestBuildChangeSummary(t *testing.T) {
+	service := &RollbackService{}
+	personID := uuid.New()
+	sourceID := uuid.New()
+	citationID := uuid.New()
+	familyID := uuid.New()
+
+	tests := []struct {
+		name        string
+		event       repository.StoredEvent
+		wantSummary string
+	}{
+		{
+			name: "person created",
+			event: repository.StoredEvent{
+				EventType: "PersonCreated",
+				Data: mustMarshal(domain.PersonCreated{
+					PersonID:  personID,
+					GivenName: "John",
+					Surname:   "Smith",
+				}),
+			},
+			wantSummary: "created John Smith",
+		},
+		{
+			name: "person updated with few fields",
+			event: repository.StoredEvent{
+				EventType: "PersonUpdated",
+				Data: mustMarshal(domain.PersonUpdated{
+					PersonID: personID,
+					Changes:  map[string]any{"given_name": "Jonathan"},
+				}),
+			},
+			wantSummary: "updated given_name",
+		},
+		{
+			name: "person updated with many fields",
+			event: repository.StoredEvent{
+				EventType: "PersonUpdated",
+				Data: mustMarshal(domain.PersonUpdated{
+					PersonID: personID,
+					Changes: map[string]any{
+						"given_name":  "Jonathan",
+						"surname":     "Smithson",
+						"birth_place": "Boston",
+						"notes":       "Some notes",
+					},
+				}),
+			},
+			wantSummary: "updated birth_place, given_name, notes and 1 more",
+		},
+		{
+			name: "person deleted with reason",
+			event: repository.StoredEvent{
+				EventType: "PersonDeleted",
+				Data: mustMarshal(domain.PersonDeleted{
+					PersonID: personID,
+					Reason:   "duplicate entry",
+				}),
+			},
+			wantSummary: "deleted: duplicate entry",
+		},
+		{
+			name: "person deleted without reason",
+			event: repository.StoredEvent{
+				EventType: "PersonDeleted",
+				Data: mustMarshal(domain.PersonDeleted{
+					PersonID: personID,
+				}),
+			},
+			wantSummary: "deleted",
+		},
+		{
+			name: "source created",
+			event: repository.StoredEvent{
+				EventType: "SourceCreated",
+				Data: mustMarshal(domain.SourceCreated{
+					SourceID: sourceID,
+					Title:    "1900 United States Federal Census",
+				}),
+			},
+			wantSummary: "created source: 1900 United States Federal Census",
+		},
+		{
+			name: "source created with long title",
+			event: repository.StoredEvent{
+				EventType: "SourceCreated",
+				Data: mustMarshal(domain.SourceCreated{
+					SourceID: sourceID,
+					Title:    "1900 United States Federal Census for the State of New York, County of Kings",
+				}),
+			},
+			wantSummary: "created source: 1900 United States Federal Census for...",
+		},
+		{
+			name: "citation created",
+			event: repository.StoredEvent{
+				EventType: "CitationCreated",
+				Data: mustMarshal(domain.CitationCreated{
+					CitationID: citationID,
+					FactType:   domain.FactPersonBirth,
+				}),
+			},
+			wantSummary: "created citation for person_birth",
+		},
+		{
+			name: "family created",
+			event: repository.StoredEvent{
+				EventType: "FamilyCreated",
+				Data: mustMarshal(domain.FamilyCreated{
+					FamilyID: familyID,
+				}),
+			},
+			wantSummary: "created family",
+		},
+		{
+			name: "child linked",
+			event: repository.StoredEvent{
+				EventType: "ChildLinkedToFamily",
+				Data: mustMarshal(domain.ChildLinkedToFamily{
+					FamilyID: familyID,
+					PersonID: personID,
+				}),
+			},
+			wantSummary: "linked child " + personID.String()[:8],
+		},
+		{
+			name: "child unlinked",
+			event: repository.StoredEvent{
+				EventType: "ChildUnlinkedFromFamily",
+				Data: mustMarshal(domain.ChildUnlinkedFromFamily{
+					FamilyID: familyID,
+					PersonID: personID,
+				}),
+			},
+			wantSummary: "unlinked child " + personID.String()[:8],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := service.buildChangeSummary(tt.event)
+			assert.Equal(t, tt.wantSummary, summary)
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := truncate(tt.input, tt.maxLen)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValuesEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    any
+		b    any
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"first nil", nil, "value", false},
+		{"second nil", "value", nil, false},
+		{"equal strings", "hello", "hello", true},
+		{"different strings", "hello", "world", false},
+		{"equal numbers", 42, 42, true},
+		{"different numbers", 42, 43, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := valuesEqual(tt.a, tt.b)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestNormalizeValue(t *testing.T) {
+	id := uuid.New()
+
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{"uuid", id, id.String()},
+		{"uuid pointer", &id, id.String()},
+		{"nil uuid pointer", (*uuid.UUID)(nil), nil},
+		{"string", "hello", "hello"},
+		{"int", 42, 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeValue(tt.input)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestComputeStateDiff(t *testing.T) {
+	service := &RollbackService{}
+
+	tests := []struct {
+		name        string
+		current     map[string]any
+		target      map[string]any
+		wantChanges map[string]any
+	}{
+		{
+			name:        "no differences",
+			current:     map[string]any{"a": "1", "b": "2"},
+			target:      map[string]any{"a": "1", "b": "2"},
+			wantChanges: map[string]any{},
+		},
+		{
+			name:        "value changed",
+			current:     map[string]any{"a": "1"},
+			target:      map[string]any{"a": "2"},
+			wantChanges: map[string]any{"a": "2"},
+		},
+		{
+			name:        "field added in target",
+			current:     map[string]any{"a": "1"},
+			target:      map[string]any{"a": "1", "b": "2"},
+			wantChanges: map[string]any{"b": "2"},
+		},
+		{
+			name:        "field removed in target",
+			current:     map[string]any{"a": "1", "b": "2"},
+			target:      map[string]any{"a": "1"},
+			wantChanges: map[string]any{"b": nil},
+		},
+		{
+			name:        "multiple changes",
+			current:     map[string]any{"a": "1", "b": "2", "c": "3"},
+			target:      map[string]any{"a": "changed", "d": "new"},
+			wantChanges: map[string]any{"a": "changed", "b": nil, "c": nil, "d": "new"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.computeStateDiff(tt.current, tt.target)
+			assert.Equal(t, len(tt.wantChanges), len(result))
+			for key, wantValue := range tt.wantChanges {
+				assert.Equal(t, wantValue, result[key], "field %s mismatch", key)
+			}
+		})
+	}
+}
+
+func TestGetRestorePoints_DeletedEntity(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	personDeleted := domain.PersonDeleted{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		PersonID:  personID,
+	}
+	deletedData, _ := json.Marshal(personDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonDeleted",
+					Data:       deletedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+	result, err := service.GetRestorePoints(context.Background(), "person", personID, 20, 0)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, len(result.RestorePoints))
+
+	// When deleted, no version should be restorable (can't update a deleted entity)
+	for _, point := range result.RestorePoints {
+		assert.False(t, point.IsRestorable, "version %d should not be restorable on deleted entity", point.Version)
+	}
+}
+
+func TestApplyEventToState_SourceDeletedAndUpdated(t *testing.T) {
+	sourceID := uuid.New()
+	now := time.Now().UTC()
+
+	sourceCreated := domain.SourceCreated{
+		BaseEvent:      domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		SourceID:       sourceID,
+		SourceType:     domain.SourceCensus,
+		Title:          "1900 Census",
+		Author:         "US Census Bureau",
+		Publisher:      "Government",
+		URL:            "http://example.com",
+		RepositoryName: "NARA",
+		CollectionName: "Census Records",
+		CallNumber:     "T623",
+		Notes:          "Important notes",
+	}
+	createdData, _ := json.Marshal(sourceCreated)
+
+	sourceUpdated := domain.SourceUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		SourceID:  sourceID,
+		Changes:   map[string]any{"title": "1900 Federal Census", "notes": nil},
+	}
+	updatedData, _ := json.Marshal(sourceUpdated)
+
+	sourceDeleted := domain.SourceDeleted{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(2 * time.Hour)},
+		SourceID:  sourceID,
+	}
+	deletedData, _ := json.Marshal(sourceDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   sourceID,
+					StreamType: "source",
+					EventType:  "SourceCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   sourceID,
+					StreamType: "source",
+					EventType:  "SourceUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   sourceID,
+					StreamType: "source",
+					EventType:  "SourceDeleted",
+					Data:       deletedData,
+					Version:    3,
+					Position:   3,
+					Timestamp:  now.Add(2 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// State at creation
+	result, err := service.GetStateAtVersion(context.Background(), "source", sourceID, 1)
+	require.NoError(t, err)
+	assert.False(t, result.IsDeleted)
+	assert.Equal(t, "1900 Census", result.State["title"])
+	assert.Equal(t, "US Census Bureau", result.State["author"])
+	assert.Equal(t, "Government", result.State["publisher"])
+	assert.Equal(t, "http://example.com", result.State["url"])
+	assert.Equal(t, "NARA", result.State["repository_name"])
+	assert.Equal(t, "Census Records", result.State["collection_name"])
+	assert.Equal(t, "T623", result.State["call_number"])
+	assert.Equal(t, "Important notes", result.State["notes"])
+
+	// State after update (notes field removed)
+	result, err = service.GetStateAtVersion(context.Background(), "source", sourceID, 2)
+	require.NoError(t, err)
+	assert.False(t, result.IsDeleted)
+	assert.Equal(t, "1900 Federal Census", result.State["title"])
+	_, hasNotes := result.State["notes"]
+	assert.False(t, hasNotes, "notes should have been deleted")
+
+	// State at deletion
+	result, err = service.GetStateAtVersion(context.Background(), "source", sourceID, 3)
+	require.NoError(t, err)
+	assert.True(t, result.IsDeleted)
+}
+
+func TestApplyEventToState_CitationDeletedAndUpdated(t *testing.T) {
+	citationID := uuid.New()
+	sourceID := uuid.New()
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	citationCreated := domain.CitationCreated{
+		BaseEvent:     domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		CitationID:    citationID,
+		SourceID:      sourceID,
+		FactType:      domain.FactPersonBirth,
+		FactOwnerID:   personID,
+		Page:          "123",
+		Volume:        "Vol 1",
+		SourceQuality: domain.SourceOriginal,
+		InformantType: domain.InformantPrimary,
+		EvidenceType:  domain.EvidenceDirect,
+		QuotedText:    "Born on this date",
+		Analysis:      "Reliable record",
+		TemplateID:    "template-1",
+	}
+	createdData, _ := json.Marshal(citationCreated)
+
+	citationUpdated := domain.CitationUpdated{
+		BaseEvent:  domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		CitationID: citationID,
+		Changes:    map[string]any{"page": "456", "analysis": "Updated analysis"},
+	}
+	updatedData, _ := json.Marshal(citationUpdated)
+
+	citationDeleted := domain.CitationDeleted{
+		BaseEvent:  domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(2 * time.Hour)},
+		CitationID: citationID,
+	}
+	deletedData, _ := json.Marshal(citationDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   citationID,
+					StreamType: "citation",
+					EventType:  "CitationCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   citationID,
+					StreamType: "citation",
+					EventType:  "CitationUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   citationID,
+					StreamType: "citation",
+					EventType:  "CitationDeleted",
+					Data:       deletedData,
+					Version:    3,
+					Position:   3,
+					Timestamp:  now.Add(2 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// State at creation
+	result, err := service.GetStateAtVersion(context.Background(), "citation", citationID, 1)
+	require.NoError(t, err)
+	assert.False(t, result.IsDeleted)
+	assert.Equal(t, "123", result.State["page"])
+	assert.Equal(t, "Vol 1", result.State["volume"])
+	assert.Equal(t, "original", result.State["source_quality"])
+	assert.Equal(t, "primary", result.State["informant_type"])
+	assert.Equal(t, "direct", result.State["evidence_type"])
+	assert.Equal(t, "Born on this date", result.State["quoted_text"])
+	assert.Equal(t, "Reliable record", result.State["analysis"])
+	assert.Equal(t, "template-1", result.State["template_id"])
+
+	// State after update
+	result, err = service.GetStateAtVersion(context.Background(), "citation", citationID, 2)
+	require.NoError(t, err)
+	assert.False(t, result.IsDeleted)
+	assert.Equal(t, "456", result.State["page"])
+	assert.Equal(t, "Updated analysis", result.State["analysis"])
+
+	// State at deletion
+	result, err = service.GetStateAtVersion(context.Background(), "citation", citationID, 3)
+	require.NoError(t, err)
+	assert.True(t, result.IsDeleted)
+}
+
+func TestApplyEventToState_FamilyUpdatedAndDeleted(t *testing.T) {
+	familyID := uuid.New()
+	partner1ID := uuid.New()
+	now := time.Now().UTC()
+
+	familyCreated := domain.FamilyCreated{
+		BaseEvent:        domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		FamilyID:         familyID,
+		Partner1ID:       &partner1ID,
+		RelationshipType: domain.RelationMarriage,
+		MarriagePlace:    "New York",
+	}
+	createdData, _ := json.Marshal(familyCreated)
+
+	familyUpdated := domain.FamilyUpdated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(1 * time.Hour)},
+		FamilyID:  familyID,
+		Changes:   map[string]any{"marriage_place": "Boston"},
+	}
+	updatedData, _ := json.Marshal(familyUpdated)
+
+	familyDeleted := domain.FamilyDeleted{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now.Add(2 * time.Hour)},
+		FamilyID:  familyID,
+	}
+	deletedData, _ := json.Marshal(familyDeleted)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "FamilyCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "FamilyUpdated",
+					Data:       updatedData,
+					Version:    2,
+					Position:   2,
+					Timestamp:  now.Add(1 * time.Hour),
+				},
+				{
+					ID:         uuid.New(),
+					StreamID:   familyID,
+					StreamType: "family",
+					EventType:  "FamilyDeleted",
+					Data:       deletedData,
+					Version:    3,
+					Position:   3,
+					Timestamp:  now.Add(2 * time.Hour),
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// State at creation
+	result, err := service.GetStateAtVersion(context.Background(), "family", familyID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "New York", result.State["marriage_place"])
+
+	// State after update
+	result, err = service.GetStateAtVersion(context.Background(), "family", familyID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "Boston", result.State["marriage_place"])
+
+	// State at deletion
+	result, err = service.GetStateAtVersion(context.Background(), "family", familyID, 3)
+	require.NoError(t, err)
+	assert.True(t, result.IsDeleted)
+}
+
+func TestApplyEventToState_UnknownEventType(t *testing.T) {
+	entityID := uuid.New()
+	now := time.Now().UTC()
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   entityID,
+					StreamType: "unknown",
+					EventType:  "UnknownEvent",
+					Data:       []byte(`{}`),
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// Unknown event types should be handled gracefully (state remains empty, not deleted)
+	_, err := service.GetStateAtVersion(context.Background(), "unknown", entityID, 1)
+	require.Error(t, err) // DecodeEvent will fail for unknown event types
+}
+
+func TestBuildChangeSummary_AdditionalCases(t *testing.T) {
+	service := &RollbackService{}
+	familyID := uuid.New()
+	sourceID := uuid.New()
+	citationID := uuid.New()
+
+	t.Run("family deleted", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "FamilyDeleted",
+			Data: mustMarshal(domain.FamilyDeleted{
+				FamilyID: familyID,
+			}),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "deleted", summary)
+	})
+
+	t.Run("source updated", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "SourceUpdated",
+			Data: mustMarshal(domain.SourceUpdated{
+				SourceID: sourceID,
+				Changes:  map[string]any{"title": "New Title"},
+			}),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "updated title", summary)
+	})
+
+	t.Run("source deleted", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "SourceDeleted",
+			Data: mustMarshal(domain.SourceDeleted{
+				SourceID: sourceID,
+			}),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "deleted", summary)
+	})
+
+	t.Run("citation updated", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "CitationUpdated",
+			Data: mustMarshal(domain.CitationUpdated{
+				CitationID: citationID,
+				Changes:    map[string]any{"page": "200"},
+			}),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "updated page", summary)
+	})
+
+	t.Run("citation deleted", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "CitationDeleted",
+			Data: mustMarshal(domain.CitationDeleted{
+				CitationID: citationID,
+			}),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "deleted", summary)
+	})
+
+	t.Run("invalid event data", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "PersonCreated",
+			Data:      []byte(`invalid json`),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "unknown change", summary)
+	})
+
+	t.Run("unknown event type", func(t *testing.T) {
+		evt := repository.StoredEvent{
+			EventType: "SomeNewEventType",
+			Data:      []byte(`{}`),
+		}
+		summary := service.buildChangeSummary(evt)
+		assert.Equal(t, "unknown change", summary)
+	})
+}
+
+func TestNormalizeValue_GenDate(t *testing.T) {
+	genDate := domain.ParseGenDate("1900-01-15")
+
+	result := normalizeValue(genDate)
+	assert.Equal(t, "1900-01-15", result)
+
+	result = normalizeValue(&genDate)
+	assert.Equal(t, "1900-01-15", result)
+
+	result = normalizeValue((*domain.GenDate)(nil))
+	assert.Nil(t, result)
+}
+
+func TestSummarizeChanges_EmptyChanges(t *testing.T) {
+	service := &RollbackService{}
+
+	result := service.summarizeChanges("updated", map[string]any{})
+	assert.Equal(t, "updated", result)
+}
+
+func TestGetRestorePoints_LimitConstraints(t *testing.T) {
+	personID := uuid.New()
+	now := time.Now().UTC()
+
+	personCreated := domain.PersonCreated{
+		BaseEvent: domain.BaseEvent{ID: uuid.New(), Timestamp: now},
+		PersonID:  personID,
+		GivenName: "John",
+		Surname:   "Smith",
+	}
+	createdData, _ := json.Marshal(personCreated)
+
+	eventStore := &rollbackMockEventStore{
+		readStreamFunc: func(ctx context.Context, streamID uuid.UUID) ([]repository.StoredEvent, error) {
+			return []repository.StoredEvent{
+				{
+					ID:         uuid.New(),
+					StreamID:   personID,
+					StreamType: "person",
+					EventType:  "PersonCreated",
+					Data:       createdData,
+					Version:    1,
+					Position:   1,
+					Timestamp:  now,
+				},
+			}, nil
+		},
+	}
+
+	service := NewRollbackService(eventStore, &mockReadModelStore{})
+
+	// Test limit over 100 gets capped
+	result, err := service.GetRestorePoints(context.Background(), "person", personID, 200, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 100, result.Limit)
+
+	// Test negative offset defaults to 0
+	result, err = service.GetRestorePoints(context.Background(), "person", personID, 20, -5)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Offset)
+}


### PR DESCRIPTION
## Summary

Add the ability to undo changes and restore entities to previous states, implementing a git-inspired workflow for data versioning.

- **RollbackService** - Query service for state reconstruction and restore point listing
- **Rollback commands** - Command handlers for Person, Family, Source, Citation
- **REST API endpoints** - `GET /{entity}/restore-points` and `POST /{entity}/rollback`
- **OpenAPI documentation** - Full specification for all new endpoints
- **Comprehensive tests** - All layers tested, 85%+ coverage maintained

## New Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/persons/{id}/restore-points` | List restore points for a person |
| POST | `/persons/{id}/rollback` | Rollback person to specific version |
| GET | `/families/{id}/restore-points` | List restore points for a family |
| POST | `/families/{id}/rollback` | Rollback family to specific version |
| GET | `/sources/{id}/restore-points` | List restore points for a source |
| POST | `/sources/{id}/rollback` | Rollback source to specific version |
| GET | `/citations/{id}/restore-points` | List restore points for a citation |
| POST | `/citations/{id}/rollback` | Rollback citation to specific version |

## Test Plan

- [x] Unit tests for RollbackService (state reconstruction, restore points, rollback changes)
- [x] Unit tests for rollback command handlers (success, invalid version, deleted entity, concurrency)
- [x] API handler tests (success, validation, error responses)
- [x] Coverage meets 85% per-package threshold

Closes #36

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)