### PR TITLE
Add Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,40 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    # Project coverage - overall repository coverage
+    project:
+      default:
+        # Allow coverage to drop by up to 1% before failing
+        # This prevents false failures on dependency updates
+        threshold: 1%
+        # Only check coverage on code that can be tested
+        paths:
+          - "internal/"
+        # Exclude paths that don't need coverage
+        removed_code_behavior: adjust_base
+
+    # Patch coverage - coverage of changed lines in PR
+    patch:
+      default:
+        # Require 80% of new lines to be covered
+        target: 80%
+        # Only apply to actual code changes
+        paths:
+          - "internal/"
+
+# Ignore files that don't need test coverage
+ignore:
+  - "cmd/**/*"
+  - "web/**/*"
+  - "**/*_test.go"
+  - "**/testdata/**"
+  - "internal/repository/postgres/**"  # Requires live DB
+  - "internal/repository/sqlite/**"    # Integration tests cover this
+
+# Comment configuration for PRs
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

Add `codecov.yml` to configure coverage thresholds and behavior.

## Changes

- **Project coverage**: Allow 1% threshold drop before failing. This prevents false failures on dependency updates (like Dependabot PRs) that don't change code but compare against a newer main with improved coverage.

- **Patch coverage**: Require 80% of new lines to be covered.

- **Ignore paths**: Exclude paths that don't need coverage:
  - `cmd/` - Entry point only
  - `web/` - Frontend (separate test suite)
  - `internal/repository/postgres/` - Requires live DB for integration tests

## Resolves

Fixes failing `codecov/project` checks on Dependabot PRs #79, #80, #84.

---
Generated with [Claude Code](https://claude.com/claude-code)