### PR TITLE
Fix link hover states on family and person pages

### DIFF
--- a/web/src/routes/families/[id]/+page.svelte
+++ b/web/src/routes/families/[id]/+page.svelte
@@ -356,9 +356,14 @@
 		border-color: #3b82f6;
 	}
 
+	a.partner-card:hover .partner-name {
+		color: #3b82f6;
+	}
+
 	.partner-name {
 		font-weight: 500;
 		color: #1e293b;
+		transition: color 0.2s;
 	}
 
 	.info-section {

--- a/web/src/routes/persons/[id]/+page.svelte
+++ b/web/src/routes/persons/[id]/+page.svelte
@@ -250,7 +250,7 @@
 				{#if person.family_as_child}
 					<div class="info-section">
 						<h2>Parents</h2>
-						<a href="/families/{person.family_as_child.id}">
+						<a href="/families/{person.family_as_child.id}" class="parent-link">
 							{person.family_as_child.partner1_name || 'Unknown'}
 							{#if person.family_as_child.partner2_name} &amp; {person.family_as_child.partner2_name}{/if}
 						</a>
@@ -455,6 +455,15 @@
 	}
 
 	.family-list a:hover {
+		color: #3b82f6;
+	}
+
+	.parent-link {
+		color: #1e293b;
+		text-decoration: none;
+	}
+
+	.parent-link:hover {
 		color: #3b82f6;
 	}
 


### PR DESCRIPTION
## Summary
- Add visible hover state to parent links on person page
- Enhance partner card hover feedback with text color change on family page

## Changes
- **Person page**: Added parent-link class with hover color transition
- **Family page**: Added text color change on partner card hover, with smooth transition

## Testing
- Hover over parent link on any person page - text should turn blue
- Hover over partner cards on any family page - border and name text should turn blue

Closes #123
Closes #124

---
Generated with [Claude Code](https://claude.com/claude-code)