### PR TITLE
GEDCOM Import Enhancement Bundle

### DIFF
--- a/internal/domain/enums.go
+++ b/internal/domain/enums.go
@@ -165,6 +165,25 @@ func (m MediaType) IsValid() bool {
 	}
 }
 
+// NameType represents the type of name for a person.
+type NameType string
+
+const (
+	NameTypeBirth   NameType = "birth"   // Name at birth
+	NameTypeMarried NameType = "married" // Married name
+	NameTypeAKA     NameType = "aka"     // Also known as
+)
+
+// IsValid checks if the name type value is valid.
+func (n NameType) IsValid() bool {
+	switch n {
+	case NameTypeBirth, NameTypeMarried, NameTypeAKA, "":
+		return true
+	default:
+		return false
+	}
+}
+
 // FactType represents the type of fact that a citation can attach to.
 type FactType string
 

--- a/internal/domain/enums_test.go
+++ b/internal/domain/enums_test.go
@@ -392,3 +392,45 @@ func TestFactType_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestNameType_IsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameType NameType
+		want     bool
+	}{
+		{
+			name:     "birth is valid",
+			nameType: NameTypeBirth,
+			want:     true,
+		},
+		{
+			name:     "married is valid",
+			nameType: NameTypeMarried,
+			want:     true,
+		},
+		{
+			name:     "aka is valid",
+			nameType: NameTypeAKA,
+			want:     true,
+		},
+		{
+			name:     "empty string is valid",
+			nameType: "",
+			want:     true,
+		},
+		{
+			name:     "invalid value",
+			nameType: "invalid",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.nameType.IsValid(); got != tt.want {
+				t.Errorf("NameType(%q).IsValid() = %v, want %v", tt.nameType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -36,16 +36,21 @@ func NewBaseEvent() BaseEvent {
 // PersonCreated event is emitted when a new person is created.
 type PersonCreated struct {
 	BaseEvent
-	PersonID   uuid.UUID `json:"person_id"`
-	GivenName  string    `json:"given_name"`
-	Surname    string    `json:"surname"`
-	Gender     Gender    `json:"gender,omitempty"`
-	BirthDate  *GenDate  `json:"birth_date,omitempty"`
-	BirthPlace string    `json:"birth_place,omitempty"`
-	DeathDate  *GenDate  `json:"death_date,omitempty"`
-	DeathPlace string    `json:"death_place,omitempty"`
-	Notes      string    `json:"notes,omitempty"`
-	GedcomXref string    `json:"gedcom_xref,omitempty"`
+	PersonID      uuid.UUID `json:"person_id"`
+	GivenName     string    `json:"given_name"`
+	Surname       string    `json:"surname"`
+	NamePrefix    string    `json:"name_prefix,omitempty"`
+	NameSuffix    string    `json:"name_suffix,omitempty"`
+	SurnamePrefix string    `json:"surname_prefix,omitempty"`
+	Nickname      string    `json:"nickname,omitempty"`
+	NameType      NameType  `json:"name_type,omitempty"`
+	Gender        Gender    `json:"gender,omitempty"`
+	BirthDate     *GenDate  `json:"birth_date,omitempty"`
+	BirthPlace    string    `json:"birth_place,omitempty"`
+	DeathDate     *GenDate  `json:"death_date,omitempty"`
+	DeathPlace    string    `json:"death_place,omitempty"`
+	Notes         string    `json:"notes,omitempty"`
+	GedcomXref    string    `json:"gedcom_xref,omitempty"`
 }
 
 func (e PersonCreated) EventType() string      { return "PersonCreated" }
@@ -54,17 +59,22 @@ func (e PersonCreated) AggregateID() uuid.UUID { return e.PersonID }
 // NewPersonCreated creates a PersonCreated event from a Person.
 func NewPersonCreated(p *Person) PersonCreated {
 	return PersonCreated{
-		BaseEvent:  NewBaseEvent(),
-		PersonID:   p.ID,
-		GivenName:  p.GivenName,
-		Surname:    p.Surname,
-		Gender:     p.Gender,
-		BirthDate:  p.BirthDate,
-		BirthPlace: p.BirthPlace,
-		DeathDate:  p.DeathDate,
-		DeathPlace: p.DeathPlace,
-		Notes:      p.Notes,
-		GedcomXref: p.GedcomXref,
+		BaseEvent:     NewBaseEvent(),
+		PersonID:      p.ID,
+		GivenName:     p.GivenName,
+		Surname:       p.Surname,
+		NamePrefix:    p.NamePrefix,
+		NameSuffix:    p.NameSuffix,
+		SurnamePrefix: p.SurnamePrefix,
+		Nickname:      p.Nickname,
+		NameType:      p.NameType,
+		Gender:        p.Gender,
+		BirthDate:     p.BirthDate,
+		BirthPlace:    p.BirthPlace,
+		DeathDate:     p.DeathDate,
+		DeathPlace:    p.DeathPlace,
+		Notes:         p.Notes,
+		GedcomXref:    p.GedcomXref,
 	}
 }
 
@@ -273,6 +283,7 @@ type SourceCreated struct {
 	Publisher      string     `json:"publisher,omitempty"`
 	PublishDate    *GenDate   `json:"publish_date,omitempty"`
 	URL            string     `json:"url,omitempty"`
+	RepositoryID   *uuid.UUID `json:"repository_id,omitempty"`
 	RepositoryName string     `json:"repository_name,omitempty"`
 	CollectionName string     `json:"collection_name,omitempty"`
 	CallNumber     string     `json:"call_number,omitempty"`
@@ -294,6 +305,7 @@ func NewSourceCreated(s *Source) SourceCreated {
 		Publisher:      s.Publisher,
 		PublishDate:    s.PublishDate,
 		URL:            s.URL,
+		RepositoryID:   s.RepositoryID,
 		RepositoryName: s.RepositoryName,
 		CollectionName: s.CollectionName,
 		CallNumber:     s.CallNumber,
@@ -493,5 +505,82 @@ func NewMediaDeleted(mediaID uuid.UUID, reason string) MediaDeleted {
 		BaseEvent: NewBaseEvent(),
 		MediaID:   mediaID,
 		Reason:    reason,
+	}
+}
+
+// RepositoryCreated event is emitted when a new repository is created.
+type RepositoryCreated struct {
+	BaseEvent
+	RepositoryID uuid.UUID `json:"repository_id"`
+	Name         string    `json:"name"`
+	Address      string    `json:"address,omitempty"`
+	City         string    `json:"city,omitempty"`
+	State        string    `json:"state,omitempty"`
+	PostalCode   string    `json:"postal_code,omitempty"`
+	Country      string    `json:"country,omitempty"`
+	Phone        string    `json:"phone,omitempty"`
+	Email        string    `json:"email,omitempty"`
+	Website      string    `json:"website,omitempty"`
+	Notes        string    `json:"notes,omitempty"`
+	GedcomXref   string    `json:"gedcom_xref,omitempty"`
+}
+
+func (e RepositoryCreated) EventType() string      { return "RepositoryCreated" }
+func (e RepositoryCreated) AggregateID() uuid.UUID { return e.RepositoryID }
+
+// NewRepositoryCreated creates a RepositoryCreated event from a Repository.
+func NewRepositoryCreated(r *Repository) RepositoryCreated {
+	return RepositoryCreated{
+		BaseEvent:    NewBaseEvent(),
+		RepositoryID: r.ID,
+		Name:         r.Name,
+		Address:      r.Address,
+		City:         r.City,
+		State:        r.State,
+		PostalCode:   r.PostalCode,
+		Country:      r.Country,
+		Phone:        r.Phone,
+		Email:        r.Email,
+		Website:      r.Website,
+		Notes:        r.Notes,
+		GedcomXref:   r.GedcomXref,
+	}
+}
+
+// RepositoryUpdated event is emitted when a repository is updated.
+type RepositoryUpdated struct {
+	BaseEvent
+	RepositoryID uuid.UUID      `json:"repository_id"`
+	Changes      map[string]any `json:"changes"`
+}
+
+func (e RepositoryUpdated) EventType() string      { return "RepositoryUpdated" }
+func (e RepositoryUpdated) AggregateID() uuid.UUID { return e.RepositoryID }
+
+// NewRepositoryUpdated creates a RepositoryUpdated event.
+func NewRepositoryUpdated(repositoryID uuid.UUID, changes map[string]any) RepositoryUpdated {
+	return RepositoryUpdated{
+		BaseEvent:    NewBaseEvent(),
+		RepositoryID: repositoryID,
+		Changes:      changes,
+	}
+}
+
+// RepositoryDeleted event is emitted when a repository is deleted.
+type RepositoryDeleted struct {
+	BaseEvent
+	RepositoryID uuid.UUID `json:"repository_id"`
+	Reason       string    `json:"reason,omitempty"`
+}
+
+func (e RepositoryDeleted) EventType() string      { return "RepositoryDeleted" }
+func (e RepositoryDeleted) AggregateID() uuid.UUID { return e.RepositoryID }
+
+// NewRepositoryDeleted creates a RepositoryDeleted event.
+func NewRepositoryDeleted(repositoryID uuid.UUID, reason string) RepositoryDeleted {
+	return RepositoryDeleted{
+		BaseEvent:    NewBaseEvent(),
+		RepositoryID: repositoryID,
+		Reason:       reason,
 	}
 }

--- a/internal/domain/person.go
+++ b/internal/domain/person.go
@@ -9,17 +9,22 @@ import (
 
 // Person represents an individual in the family tree.
 type Person struct {
-	ID         uuid.UUID `json:"id"`
-	GivenName  string    `json:"given_name"`
-	Surname    string    `json:"surname"`
-	Gender     Gender    `json:"gender,omitempty"`
-	BirthDate  *GenDate  `json:"birth_date,omitempty"`
-	BirthPlace string    `json:"birth_place,omitempty"`
-	DeathDate  *GenDate  `json:"death_date,omitempty"`
-	DeathPlace string    `json:"death_place,omitempty"`
-	Notes      string    `json:"notes,omitempty"`
-	GedcomXref string    `json:"gedcom_xref,omitempty"` // Original GEDCOM @XREF@ for round-trip
-	Version    int64     `json:"version"`               // Optimistic locking version
+	ID            uuid.UUID `json:"id"`
+	GivenName     string    `json:"given_name"`
+	Surname       string    `json:"surname"`
+	NamePrefix    string    `json:"name_prefix,omitempty"`    // Dr., Rev., Sir (NPFX)
+	NameSuffix    string    `json:"name_suffix,omitempty"`    // Jr., III, PhD (NSFX)
+	SurnamePrefix string    `json:"surname_prefix,omitempty"` // von, de, van (SPFX)
+	Nickname      string    `json:"nickname,omitempty"`       // Informal name (NICK)
+	NameType      NameType  `json:"name_type,omitempty"`      // birth, married, aka (TYPE)
+	Gender        Gender    `json:"gender,omitempty"`
+	BirthDate     *GenDate  `json:"birth_date,omitempty"`
+	BirthPlace    string    `json:"birth_place,omitempty"`
+	DeathDate     *GenDate  `json:"death_date,omitempty"`
+	DeathPlace    string    `json:"death_place,omitempty"`
+	Notes         string    `json:"notes,omitempty"`
+	GedcomXref    string    `json:"gedcom_xref,omitempty"` // Original GEDCOM @XREF@ for round-trip
+	Version       int64     `json:"version"`               // Optimistic locking version
 }
 
 // PersonValidationError represents a validation error for a Person.

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -1,0 +1,92 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Repository represents a physical or digital location where source documents are stored.
+// This maps to GEDCOM REPO records and supports GPS-compliant source documentation.
+type Repository struct {
+	ID         uuid.UUID `json:"id"`
+	Name       string    `json:"name"`
+	Address    string    `json:"address,omitempty"`
+	City       string    `json:"city,omitempty"`
+	State      string    `json:"state,omitempty"`
+	PostalCode string    `json:"postal_code,omitempty"`
+	Country    string    `json:"country,omitempty"`
+	Phone      string    `json:"phone,omitempty"`
+	Email      string    `json:"email,omitempty"`
+	Website    string    `json:"website,omitempty"`
+	Notes      string    `json:"notes,omitempty"`
+	GedcomXref string    `json:"gedcom_xref,omitempty"` // Original GEDCOM @XREF@ for round-trip
+	Version    int64     `json:"version"`               // Optimistic locking version
+}
+
+// RepositoryValidationError represents a validation error for a Repository.
+type RepositoryValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e RepositoryValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// NewRepository creates a new Repository with the given name.
+func NewRepository(name string) *Repository {
+	return &Repository{
+		ID:      uuid.New(),
+		Name:    name,
+		Version: 1,
+	}
+}
+
+// Validate checks if the repository has valid data.
+func (r *Repository) Validate() error {
+	var errs []error
+
+	// Required fields
+	if r.Name == "" {
+		errs = append(errs, RepositoryValidationError{Field: "name", Message: "cannot be empty"})
+	}
+	if len(r.Name) > 200 {
+		errs = append(errs, RepositoryValidationError{Field: "name", Message: "cannot exceed 200 characters"})
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// FullAddress returns a formatted address string.
+func (r *Repository) FullAddress() string {
+	parts := []string{}
+	if r.Address != "" {
+		parts = append(parts, r.Address)
+	}
+	if r.City != "" {
+		parts = append(parts, r.City)
+	}
+	if r.State != "" {
+		parts = append(parts, r.State)
+	}
+	if r.PostalCode != "" {
+		parts = append(parts, r.PostalCode)
+	}
+	if r.Country != "" {
+		parts = append(parts, r.Country)
+	}
+
+	result := ""
+	for i, part := range parts {
+		if i > 0 {
+			result += ", "
+		}
+		result += part
+	}
+	return result
+}

--- a/internal/domain/repository_test.go
+++ b/internal/domain/repository_test.go
@@ -1,0 +1,121 @@
+package domain_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/domain"
+)
+
+func TestNewRepository(t *testing.T) {
+	name := "Family History Library"
+	repo := domain.NewRepository(name)
+
+	if repo.Name != name {
+		t.Errorf("Name = %q, want %q", repo.Name, name)
+	}
+	if repo.ID.String() == "" {
+		t.Error("ID should not be empty")
+	}
+	if repo.Version != 1 {
+		t.Errorf("Version = %d, want 1", repo.Version)
+	}
+}
+
+func TestRepository_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		repo    *domain.Repository
+		wantErr bool
+	}{
+		{
+			name:    "valid repository",
+			repo:    domain.NewRepository("Family History Library"),
+			wantErr: false,
+		},
+		{
+			name:    "empty name",
+			repo:    domain.NewRepository(""),
+			wantErr: true,
+		},
+		{
+			name:    "name too long",
+			repo:    domain.NewRepository(strings.Repeat("a", 201)),
+			wantErr: true,
+		},
+		{
+			name:    "name at limit",
+			repo:    domain.NewRepository(strings.Repeat("a", 200)),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.repo.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRepository_FullAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		repo *domain.Repository
+		want string
+	}{
+		{
+			name: "full address",
+			repo: &domain.Repository{
+				Address:    "35 N West Temple St",
+				City:       "Salt Lake City",
+				State:      "UT",
+				PostalCode: "84150",
+				Country:    "USA",
+			},
+			want: "35 N West Temple St, Salt Lake City, UT, 84150, USA",
+		},
+		{
+			name: "city and state only",
+			repo: &domain.Repository{
+				City:  "Springfield",
+				State: "IL",
+			},
+			want: "Springfield, IL",
+		},
+		{
+			name: "empty address",
+			repo: &domain.Repository{},
+			want: "",
+		},
+		{
+			name: "just country",
+			repo: &domain.Repository{
+				Country: "USA",
+			},
+			want: "USA",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.repo.FullAddress()
+			if got != tt.want {
+				t.Errorf("FullAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryValidationError_Error(t *testing.T) {
+	err := domain.RepositoryValidationError{
+		Field:   "name",
+		Message: "cannot be empty",
+	}
+	want := "name: cannot be empty"
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/internal/domain/source.go
+++ b/internal/domain/source.go
@@ -16,7 +16,8 @@ type Source struct {
 	Publisher      string     `json:"publisher,omitempty"`
 	PublishDate    *GenDate   `json:"publish_date,omitempty"`
 	URL            string     `json:"url,omitempty"`
-	RepositoryName string     `json:"repository_name,omitempty"`
+	RepositoryID   *uuid.UUID `json:"repository_id,omitempty"`   // Link to Repository entity
+	RepositoryName string     `json:"repository_name,omitempty"` // Fallback for unlinked repositories
 	CollectionName string     `json:"collection_name,omitempty"`
 	CallNumber     string     `json:"call_number,omitempty"`
 	Notes          string     `json:"notes,omitempty"`

--- a/internal/gedcom/integration_test.go
+++ b/internal/gedcom/integration_test.go
@@ -56,7 +56,7 @@ func TestIntegration_ImportExportRoundTrip(t *testing.T) {
 
 			// Import
 			importer := gedcom.NewImporter()
-			result, persons, families, _, _, err := importer.Import(ctx, bytes.NewReader(data))
+			result, persons, families, _, _, _, err := importer.Import(ctx, bytes.NewReader(data))
 			if err != nil {
 				t.Fatalf("Import failed: %v", err)
 			}
@@ -156,7 +156,7 @@ func TestIntegration_LargeFile(t *testing.T) {
 
 	ctx := context.Background()
 	importer := gedcom.NewImporter()
-	result, persons, families, _, _, err := importer.Import(ctx, bytes.NewReader(data))
+	result, persons, families, _, _, _, err := importer.Import(ctx, bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("Import failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR implements five related GEDCOM import enhancements as a coordinated bundle:

- **Issue #107**: Integrate gedcom-go `ParseDate` validation with warnings for invalid dates
- **Issue #109**: Import enhanced name components (prefix, suffix, surname prefix, nickname, type)
- **Issue #112**: Add Repository entity for GEDCOM REPO records with full address support
- **Issue #118**: Map PEDI (pedigree) linkage types for adopted/foster children
- **Issue #119**: Integrate gedcom-go validator for document-wide validation

### Key Changes

**New Domain Types**:
- `Repository` entity with address, contact info, and notes
- `NameType` enum (birth, married, aka)
- Added name component fields to `Person` (NamePrefix, NameSuffix, SurnamePrefix, Nickname)
- Added RepositoryID to `Source` for linking

**Import Enhancements**:
- `importRepository()` function for GEDCOM REPO records
- Name component parsing from GEDCOM NAME sub-tags (NPFX, NSFX, SPFX, NICK, TYPE)
- `getPedigreeType()` extracts PEDI values for child-family relationships
- Date validation warnings for invalid GEDCOM dates
- Document-wide validation via gedcom-go validator

**Events**:
- `RepositoryCreated`, `RepositoryUpdated`, `RepositoryDeleted`
- Updated `PersonCreated` with name components
- Updated `SourceCreated` with RepositoryID

## Test Plan

- [x] All existing tests pass
- [x] Added `TestImportGedcom_WithRepositories` for repository import
- [x] Added `TestImportGedcom_RepositoryImportError` for error handling
- [x] Added `TestImportCitation_QualityMappings` for citation quality
- [x] Added `TestImportGedcom_ChildLinkingWarning` for child linking
- [x] Added `TestImportGedcom_PedigreeTypes` for PEDI import
- [x] Coverage at 88.1% (exceeds 85% threshold)

Closes #107, closes #109, closes #112, closes #118, closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)