### PR TITLE
Use PAT for auto-rebase to trigger CI workflows

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Rebase open PRs
         uses: peter-evans/rebase@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           exclude: dependabot/**


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN` in auto-rebase workflow
- `GITHUB_TOKEN` pushes don't trigger other workflows (GitHub's loop prevention
- This ensures CI runs after auto-rebase updates PR branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)