### PR TITLE
Multiple name handling (maiden, aliases, variants)

### DIFF
--- a/.prompts/.batch.json
+++ b/.prompts/.batch.json
@@ -1,7 +1,11 @@
 {
-  "created": "2026-01-04T12:00:00Z",
-  "strategy": "parallel",
-  "source": "/do #32,29,26 -> meta-prompting -> simple prompts",
-  "prompts": ["031-uncertain-data-markers.md", "032-browse-surname-place.md", "033-family-group-sheet.md"],
-  "completed": ["031-uncertain-data-markers.md", "032-browse-surname-place.md", "033-family-group-sheet.md"]
+  "created": "2026-01-12T17:00:00Z",
+  "source": "/create-prompt Issue #33: Multiple name handling",
+  "execution": [
+    {"strategy": "sequential", "prompts": ["001-33-domain-events.md"]},
+    {"strategy": "sequential", "prompts": ["002-33-storage-layer.md"]},
+    {"strategy": "sequential", "prompts": ["003-33-projector-query.md"]},
+    {"strategy": "parallel", "prompts": ["004-33-api-layer.md", "005-33-gedcom-import-export.md"]}
+  ],
+  "completed": ["001-33-domain-events.md", "002-33-storage-layer.md", "003-33-projector-query.md", "004-33-api-layer.md", "005-33-gedcom-import-export.md"]
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -175,8 +175,8 @@ func TestUpdatePerson(t *testing.T) {
 	json.Unmarshal(createRec.Body.Bytes(), &createResp)
 	personID := createResp["id"].(string)
 
-	// Update the person
-	updateBody := `{"given_name":"Jane","version":1}`
+	// Update the person (version is 2 because creating a person also creates a primary name)
+	updateBody := `{"given_name":"Jane","version":2}`
 	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID, strings.NewReader(updateBody))
 	updateReq.Header.Set("Content-Type", "application/json")
 	updateRec := httptest.NewRecorder()
@@ -235,8 +235,8 @@ func TestDeletePerson(t *testing.T) {
 	json.Unmarshal(createRec.Body.Bytes(), &createResp)
 	personID := createResp["id"].(string)
 
-	// Delete the person
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"?version=1", http.NoBody)
+	// Delete the person (version is 2 because creating a person also creates a primary name)
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"?version=2", http.NoBody)
 	deleteRec := httptest.NewRecorder()
 	server.Echo().ServeHTTP(deleteRec, deleteReq)
 

--- a/internal/api/name_handlers_test.go
+++ b/internal/api/name_handlers_test.go
@@ -1,0 +1,439 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/cacack/my-family/internal/config"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+func setupNameTestServer() *api.Server {
+	cfg := &config.Config{
+		Port:      8080,
+		LogFormat: "text",
+	}
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	return api.NewServer(cfg, eventStore, readStore, nil)
+}
+
+func createPersonForNameTest(t *testing.T, server *api.Server) string {
+	t.Helper()
+	body := `{"given_name":"John","surname":"Doe"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Failed to create person: %s", rec.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	return resp["id"].(string)
+}
+
+func TestGetPersonNames(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Get names for the person (should have one primary name created with person)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	total := int(resp["total"].(float64))
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+
+	items := resp["items"].([]any)
+	if len(items) != 1 {
+		t.Errorf("items count = %d, want 1", len(items))
+	}
+
+	// Verify the name is primary
+	name := items[0].(map[string]any)
+	if name["is_primary"] != true {
+		t.Error("Expected first name to be primary")
+	}
+	if name["given_name"] != "John" {
+		t.Errorf("given_name = %v, want John", name["given_name"])
+	}
+}
+
+func TestGetPersonNames_InvalidID(t *testing.T) {
+	server := setupNameTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/invalid-uuid/names", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAddPersonName(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Add a maiden name
+	body := `{"given_name":"Jane","surname":"Smith","name_type":"birth"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if resp["given_name"] != "Jane" {
+		t.Errorf("given_name = %v, want Jane", resp["given_name"])
+	}
+	if resp["surname"] != "Smith" {
+		t.Errorf("surname = %v, want Smith", resp["surname"])
+	}
+	if resp["name_type"] != "birth" {
+		t.Errorf("name_type = %v, want birth", resp["name_type"])
+	}
+	// Second name should not be primary
+	if resp["is_primary"] != false {
+		t.Error("Expected second name to not be primary")
+	}
+}
+
+func TestAddPersonName_AsPrimary(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Add a name as primary (should demote existing primary)
+	body := `{"given_name":"Johnny","surname":"Doe","is_primary":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if resp["is_primary"] != true {
+		t.Error("Expected new name to be primary")
+	}
+
+	// Verify we now have 2 names
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	listRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(listRec, listReq)
+
+	var listResp map[string]any
+	json.Unmarshal(listRec.Body.Bytes(), &listResp)
+
+	total := int(listResp["total"].(float64))
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+
+	// Count primary names (should be exactly 1)
+	items := listResp["items"].([]any)
+	primaryCount := 0
+	for _, item := range items {
+		name := item.(map[string]any)
+		if name["is_primary"] == true {
+			primaryCount++
+		}
+	}
+	if primaryCount != 1 {
+		t.Errorf("primary count = %d, want 1", primaryCount)
+	}
+}
+
+func TestAddPersonName_InvalidPersonID(t *testing.T) {
+	server := setupNameTestServer()
+
+	body := `{"given_name":"Test","surname":"Name"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/invalid-uuid/names", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAddPersonName_MissingGivenName(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	body := `{"surname":"Smith"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpdatePersonName(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Get the existing name ID
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	listRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(listRec, listReq)
+
+	var listResp map[string]any
+	json.Unmarshal(listRec.Body.Bytes(), &listResp)
+	items := listResp["items"].([]any)
+	nameID := items[0].(map[string]any)["id"].(string)
+
+	// Update the name
+	body := `{"given_name":"Jonathan","nickname":"Jon"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID+"/names/"+nameID, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if resp["given_name"] != "Jonathan" {
+		t.Errorf("given_name = %v, want Jonathan", resp["given_name"])
+	}
+	if resp["nickname"] != "Jon" {
+		t.Errorf("nickname = %v, want Jon", resp["nickname"])
+	}
+}
+
+func TestUpdatePersonName_InvalidPersonID(t *testing.T) {
+	server := setupNameTestServer()
+
+	body := `{"given_name":"Test"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/persons/invalid-uuid/names/00000000-0000-0000-0000-000000000001", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpdatePersonName_InvalidNameID(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	body := `{"given_name":"Test"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/persons/"+personID+"/names/invalid-uuid", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestDeletePersonName(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Add a second name (non-primary)
+	addBody := `{"given_name":"Jane","surname":"Doe"}`
+	addReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(addRec, addReq)
+
+	var addResp map[string]any
+	json.Unmarshal(addRec.Body.Bytes(), &addResp)
+	nameID := addResp["id"].(string)
+
+	// Delete the second name
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"/names/"+nameID, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	// Verify we're back to 1 name
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	listRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(listRec, listReq)
+
+	var listResp map[string]any
+	json.Unmarshal(listRec.Body.Bytes(), &listResp)
+
+	total := int(listResp["total"].(float64))
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+}
+
+func TestDeletePersonName_InvalidPersonID(t *testing.T) {
+	server := setupNameTestServer()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/invalid-uuid/names/00000000-0000-0000-0000-000000000001", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestDeletePersonName_InvalidNameID(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"/names/invalid-uuid", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestDeletePersonName_CannotDeletePrimary(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Add a second name so we have 2 names
+	addBody := `{"given_name":"Jane","surname":"Doe"}`
+	addReq := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(addRec, addReq)
+
+	// Get the primary name ID
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	listRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(listRec, listReq)
+
+	var listResp map[string]any
+	json.Unmarshal(listRec.Body.Bytes(), &listResp)
+	items := listResp["items"].([]any)
+
+	var primaryNameID string
+	for _, item := range items {
+		name := item.(map[string]any)
+		if name["is_primary"] == true {
+			primaryNameID = name["id"].(string)
+			break
+		}
+	}
+
+	// Try to delete the primary name
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"/names/"+primaryNameID, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	// Should fail
+	if rec.Code == http.StatusNoContent {
+		t.Error("Should not be able to delete primary name")
+	}
+}
+
+func TestDeletePersonName_CannotDeleteLast(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Get the only name ID
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/names", http.NoBody)
+	listRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(listRec, listReq)
+
+	var listResp map[string]any
+	json.Unmarshal(listRec.Body.Bytes(), &listResp)
+	items := listResp["items"].([]any)
+	nameID := items[0].(map[string]any)["id"].(string)
+
+	// Try to delete the only name
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/persons/"+personID+"/names/"+nameID, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	// Should fail
+	if rec.Code == http.StatusNoContent {
+		t.Error("Should not be able to delete the last name")
+	}
+}
+
+func TestAddPersonName_WithAllFields(t *testing.T) {
+	server := setupNameTestServer()
+	personID := createPersonForNameTest(t, server)
+
+	// Add a name with all optional fields
+	body := `{
+		"given_name":"Dr",
+		"surname":"Smith",
+		"name_prefix":"Dr.",
+		"name_suffix":"Jr.",
+		"surname_prefix":"von",
+		"nickname":"Smitty",
+		"name_type":"professional"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons/"+personID+"/names", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if resp["name_prefix"] != "Dr." {
+		t.Errorf("name_prefix = %v, want Dr.", resp["name_prefix"])
+	}
+	if resp["name_suffix"] != "Jr." {
+		t.Errorf("name_suffix = %v, want Jr.", resp["name_suffix"])
+	}
+	if resp["surname_prefix"] != "von" {
+		t.Errorf("surname_prefix = %v, want von", resp["surname_prefix"])
+	}
+	if resp["nickname"] != "Smitty" {
+		t.Errorf("nickname = %v, want Smitty", resp["nickname"])
+	}
+	if resp["name_type"] != "professional" {
+		t.Errorf("name_type = %v, want professional", resp["name_type"])
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1341,6 +1341,104 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /persons/{id}/names:
+    parameters:
+      - $ref: '#/components/parameters/personId'
+
+    get:
+      operationId: getPersonNames
+      summary: Get all names for a person
+      description: Returns all name variants for a person (birth name, married name, aliases, etc.)
+      tags: [persons]
+      responses:
+        '200':
+          description: List of person names
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonNameList'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      operationId: addPersonName
+      summary: Add a name to a person
+      description: |
+        Add a new name variant to a person. If is_primary is true, the existing
+        primary name will be demoted to non-primary.
+      tags: [persons]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonNameCreate'
+      responses:
+        '201':
+          description: Name added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonName'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /persons/{id}/names/{nameId}:
+    parameters:
+      - $ref: '#/components/parameters/personId'
+      - name: nameId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    put:
+      operationId: updatePersonName
+      summary: Update a person's name
+      description: |
+        Update an existing name variant. If is_primary is set to true, the existing
+        primary name will be demoted to non-primary.
+      tags: [persons]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonNameUpdate'
+      responses:
+        '200':
+          description: Name updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonName'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      operationId: deletePersonName
+      summary: Remove a name from a person
+      description: |
+        Remove a name variant from a person. Cannot delete the last remaining name
+        or the primary name (must transfer primary status first).
+      tags: [persons]
+      responses:
+        '204':
+          description: Name removed
+        '400':
+          description: Cannot delete last name or primary name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # Export endpoints
   /export/tree:
     get:
@@ -1628,6 +1726,11 @@ components:
         - $ref: '#/components/schemas/Person'
         - type: object
           properties:
+            names:
+              type: array
+              description: All name variants for the person (birth, married, aliases, etc.)
+              items:
+                $ref: '#/components/schemas/PersonName'
             families_as_partner:
               type: array
               items:
@@ -2439,6 +2542,101 @@ components:
           type: integer
         query:
           type: string
+
+    # PersonName schemas
+    PersonName:
+      type: object
+      required: [id, person_id, given_name, surname, name_type, is_primary]
+      properties:
+        id:
+          type: string
+          format: uuid
+        person_id:
+          type: string
+          format: uuid
+        given_name:
+          type: string
+          maxLength: 100
+        surname:
+          type: string
+          maxLength: 100
+        full_name:
+          type: string
+          readOnly: true
+        name_prefix:
+          type: string
+        name_suffix:
+          type: string
+        surname_prefix:
+          type: string
+        nickname:
+          type: string
+        name_type:
+          type: string
+          enum: [birth, married, aka, immigrant, religious, professional]
+        is_primary:
+          type: boolean
+
+    PersonNameCreate:
+      type: object
+      required: [given_name, surname, name_type]
+      properties:
+        given_name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        surname:
+          type: string
+          maxLength: 100
+        name_prefix:
+          type: string
+        name_suffix:
+          type: string
+        surname_prefix:
+          type: string
+        nickname:
+          type: string
+        name_type:
+          type: string
+          enum: [birth, married, aka, immigrant, religious, professional]
+        is_primary:
+          type: boolean
+          default: false
+
+    PersonNameUpdate:
+      type: object
+      properties:
+        given_name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        surname:
+          type: string
+          maxLength: 100
+        name_prefix:
+          type: string
+        name_suffix:
+          type: string
+        surname_prefix:
+          type: string
+        nickname:
+          type: string
+        name_type:
+          type: string
+          enum: [birth, married, aka, immigrant, religious, professional]
+        is_primary:
+          type: boolean
+
+    PersonNameList:
+      type: object
+      required: [items, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonName'
+        total:
+          type: integer
 
     # Citation schemas
     Citation:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -152,6 +152,12 @@ func (s *Server) registerRoutes() {
 	// Person citations (nested under persons)
 	api.GET("/persons/:id/citations", s.getCitationsForPerson)
 
+	// Person names (nested under persons)
+	api.GET("/persons/:id/names", s.getPersonNames)
+	api.POST("/persons/:id/names", s.addPersonName)
+	api.PUT("/persons/:id/names/:nameId", s.updatePersonName)
+	api.DELETE("/persons/:id/names/:nameId", s.deletePersonName)
+
 	// GEDCOM (placeholder - will be implemented in Phase 5)
 	api.POST("/gedcom/import", s.importGedcom)
 	api.GET("/gedcom/export", s.exportGedcom)

--- a/internal/command/name_commands.go
+++ b/internal/command/name_commands.go
@@ -1,0 +1,321 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// Name command errors.
+var (
+	ErrNameNotFound        = errors.New("name not found")
+	ErrCannotDeleteLast    = errors.New("cannot delete the last remaining name")
+	ErrCannotDeletePrimary = errors.New("cannot delete the primary name; transfer primary status first")
+)
+
+// AddNameInput contains the data for adding a name to a person.
+type AddNameInput struct {
+	PersonID      uuid.UUID
+	GivenName     string
+	Surname       string
+	NamePrefix    string
+	NameSuffix    string
+	SurnamePrefix string
+	Nickname      string
+	NameType      string
+	IsPrimary     bool
+}
+
+// AddNameResult contains the result of adding a name.
+type AddNameResult struct {
+	ID        uuid.UUID
+	PersonID  uuid.UUID
+	IsPrimary bool
+}
+
+// AddName adds a new name variant to a person.
+func (h *Handler) AddName(ctx context.Context, input AddNameInput) (*AddNameResult, error) {
+	// Validate required fields
+	if input.GivenName == "" {
+		return nil, fmt.Errorf("%w: given_name is required", ErrInvalidInput)
+	}
+
+	// Verify person exists
+	person, err := h.readStore.GetPerson(ctx, input.PersonID)
+	if err != nil {
+		return nil, err
+	}
+	if person == nil {
+		return nil, ErrPersonNotFound
+	}
+
+	// Get existing names to check primary status
+	existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the person name entity
+	pn := domain.NewPersonName(input.PersonID, input.GivenName, input.Surname)
+	pn.NamePrefix = input.NamePrefix
+	pn.NameSuffix = input.NameSuffix
+	pn.SurnamePrefix = input.SurnamePrefix
+	pn.Nickname = input.Nickname
+	if input.NameType != "" {
+		pn.NameType = domain.NameType(input.NameType)
+	}
+	pn.IsPrimary = input.IsPrimary
+
+	// Validate the name
+	if err := pn.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+
+	// If this is the first name, make it primary
+	if len(existingNames) == 0 {
+		pn.IsPrimary = true
+	}
+
+	// If setting as primary, we need to demote the existing primary
+	var events []domain.Event
+	if pn.IsPrimary {
+		for _, existing := range existingNames {
+			if existing.IsPrimary {
+				// Create updated name to demote
+				demoted := &domain.PersonName{
+					ID:            existing.ID,
+					PersonID:      existing.PersonID,
+					GivenName:     existing.GivenName,
+					Surname:       existing.Surname,
+					NamePrefix:    existing.NamePrefix,
+					NameSuffix:    existing.NameSuffix,
+					SurnamePrefix: existing.SurnamePrefix,
+					Nickname:      existing.Nickname,
+					NameType:      existing.NameType,
+					IsPrimary:     false,
+				}
+				events = append(events, domain.NewNameUpdated(demoted))
+				break
+			}
+		}
+	}
+
+	// Add the new name event
+	events = append(events, domain.NewNameAdded(pn))
+
+	// Execute command
+	_, err = h.execute(ctx, input.PersonID.String(), "Person", events, person.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AddNameResult{
+		ID:        pn.ID,
+		PersonID:  input.PersonID,
+		IsPrimary: pn.IsPrimary,
+	}, nil
+}
+
+// UpdateNameInput contains the data for updating a name.
+type UpdateNameInput struct {
+	PersonID      uuid.UUID
+	NameID        uuid.UUID
+	GivenName     *string
+	Surname       *string
+	NamePrefix    *string
+	NameSuffix    *string
+	SurnamePrefix *string
+	Nickname      *string
+	NameType      *string
+	IsPrimary     *bool
+}
+
+// UpdateNameResult contains the result of updating a name.
+type UpdateNameResult struct {
+	ID        uuid.UUID
+	PersonID  uuid.UUID
+	IsPrimary bool
+}
+
+// applyNameUpdates applies the non-nil fields from input to the PersonName.
+func applyNameUpdates(pn *domain.PersonName, input UpdateNameInput) {
+	if input.GivenName != nil {
+		pn.GivenName = *input.GivenName
+	}
+	if input.Surname != nil {
+		pn.Surname = *input.Surname
+	}
+	if input.NamePrefix != nil {
+		pn.NamePrefix = *input.NamePrefix
+	}
+	if input.NameSuffix != nil {
+		pn.NameSuffix = *input.NameSuffix
+	}
+	if input.SurnamePrefix != nil {
+		pn.SurnamePrefix = *input.SurnamePrefix
+	}
+	if input.Nickname != nil {
+		pn.Nickname = *input.Nickname
+	}
+	if input.NameType != nil {
+		pn.NameType = domain.NameType(*input.NameType)
+	}
+	if input.IsPrimary != nil {
+		pn.IsPrimary = *input.IsPrimary
+	}
+}
+
+// UpdateName updates an existing name variant.
+func (h *Handler) UpdateName(ctx context.Context, input UpdateNameInput) (*UpdateNameResult, error) {
+	person, existingName, err := h.validateNameUpdate(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build updated name from existing
+	pn := personNameFromReadModel(existingName)
+	applyNameUpdates(pn, input)
+
+	if err := pn.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+
+	events, err := h.buildNameUpdateEvents(ctx, pn, existingName, input)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = h.execute(ctx, input.PersonID.String(), "Person", events, person.Version); err != nil {
+		return nil, err
+	}
+
+	return &UpdateNameResult{
+		ID:        pn.ID,
+		PersonID:  input.PersonID,
+		IsPrimary: pn.IsPrimary,
+	}, nil
+}
+
+// validateNameUpdate verifies person exists and name belongs to them.
+func (h *Handler) validateNameUpdate(ctx context.Context, input UpdateNameInput) (*repository.PersonReadModel, *repository.PersonNameReadModel, error) {
+	person, err := h.readStore.GetPerson(ctx, input.PersonID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if person == nil {
+		return nil, nil, ErrPersonNotFound
+	}
+
+	existingName, err := h.readStore.GetPersonName(ctx, input.NameID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if existingName == nil || existingName.PersonID != input.PersonID {
+		return nil, nil, ErrNameNotFound
+	}
+
+	return person, existingName, nil
+}
+
+// personNameFromReadModel creates a PersonName from a read model.
+func personNameFromReadModel(rm *repository.PersonNameReadModel) *domain.PersonName {
+	return &domain.PersonName{
+		ID:            rm.ID,
+		PersonID:      rm.PersonID,
+		GivenName:     rm.GivenName,
+		Surname:       rm.Surname,
+		NamePrefix:    rm.NamePrefix,
+		NameSuffix:    rm.NameSuffix,
+		SurnamePrefix: rm.SurnamePrefix,
+		Nickname:      rm.Nickname,
+		NameType:      rm.NameType,
+		IsPrimary:     rm.IsPrimary,
+	}
+}
+
+// buildNameUpdateEvents creates the events needed for a name update, including demoting existing primary if needed.
+func (h *Handler) buildNameUpdateEvents(ctx context.Context, pn *domain.PersonName, existingName *repository.PersonNameReadModel, input UpdateNameInput) ([]domain.Event, error) {
+	var events []domain.Event
+
+	// If setting as primary and it wasn't before, demote existing primary
+	if pn.IsPrimary && !existingName.IsPrimary {
+		existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
+		if err != nil {
+			return nil, err
+		}
+		for _, existing := range existingNames {
+			if existing.IsPrimary && existing.ID != input.NameID {
+				demoted := personNameFromReadModel(&existing)
+				demoted.IsPrimary = false
+				events = append(events, domain.NewNameUpdated(demoted))
+				break
+			}
+		}
+	}
+
+	events = append(events, domain.NewNameUpdated(pn))
+	return events, nil
+}
+
+// DeleteNameInput contains the data for deleting a name.
+type DeleteNameInput struct {
+	PersonID uuid.UUID
+	NameID   uuid.UUID
+}
+
+// DeleteName removes a name from a person.
+func (h *Handler) DeleteName(ctx context.Context, input DeleteNameInput) error {
+	// Verify person exists
+	person, err := h.readStore.GetPerson(ctx, input.PersonID)
+	if err != nil {
+		return err
+	}
+	if person == nil {
+		return ErrPersonNotFound
+	}
+
+	// Get all names for the person
+	existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
+	if err != nil {
+		return err
+	}
+
+	// Find the name to delete
+	var nameToDelete *domain.PersonName
+	for _, n := range existingNames {
+		if n.ID == input.NameID {
+			nameToDelete = &domain.PersonName{
+				ID:        n.ID,
+				PersonID:  n.PersonID,
+				IsPrimary: n.IsPrimary,
+			}
+			break
+		}
+	}
+
+	if nameToDelete == nil {
+		return ErrNameNotFound
+	}
+
+	// Cannot delete the last remaining name
+	if len(existingNames) <= 1 {
+		return ErrCannotDeleteLast
+	}
+
+	// Cannot delete primary name
+	if nameToDelete.IsPrimary {
+		return ErrCannotDeletePrimary
+	}
+
+	// Create delete event
+	event := domain.NewNameRemoved(input.PersonID, input.NameID)
+
+	// Execute command
+	_, err = h.execute(ctx, input.PersonID.String(), "Person", []domain.Event{event}, person.Version)
+	return err
+}

--- a/internal/command/name_commands_test.go
+++ b/internal/command/name_commands_test.go
@@ -1,0 +1,615 @@
+package command_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/command"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+func TestAddName_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// First create a person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add a name
+	nameInput := command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "Johann",
+		Surname:   "Doe",
+		NameType:  "immigrant",
+		IsPrimary: false,
+	}
+	result, err := handler.AddName(ctx, nameInput)
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	if result.PersonID != personResult.ID {
+		t.Errorf("Expected PersonID %s, got %s", personResult.ID, result.PersonID)
+	}
+	if result.ID == uuid.Nil {
+		t.Error("Expected non-nil ID")
+	}
+}
+
+func TestAddName_FirstNameBecomesPrimary(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a person (no names yet in person_names table)
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add first name - should become primary even if IsPrimary=false
+	nameInput := command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+		IsPrimary: false,
+	}
+	result, err := handler.AddName(ctx, nameInput)
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	if !result.IsPrimary {
+		t.Error("First name should become primary")
+	}
+}
+
+func TestAddName_DemoteExistingPrimary(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add first name (becomes primary)
+	_, err = handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Add second name as primary (should demote first)
+	result, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "Johann",
+		Surname:   "Doe",
+		NameType:  "immigrant",
+		IsPrimary: true,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	if !result.IsPrimary {
+		t.Error("New name should be primary")
+	}
+}
+
+func TestAddName_PersonNotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	nameInput := command.AddNameInput{
+		PersonID:  uuid.New(), // Non-existent
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	}
+	_, err := handler.AddName(ctx, nameInput)
+	if err == nil {
+		t.Fatal("Expected error for non-existent person")
+	}
+}
+
+func TestAddName_InvalidInput(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person first
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Empty given name should fail
+	nameInput := command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "",
+		Surname:   "Doe",
+		NameType:  "birth",
+	}
+	_, err = handler.AddName(ctx, nameInput)
+	if err == nil {
+		t.Fatal("Expected error for empty given_name")
+	}
+}
+
+func TestUpdateName_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person and add a name
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	nameResult, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Update the name
+	newGiven := "Johnny"
+	updateInput := command.UpdateNameInput{
+		PersonID:  personResult.ID,
+		NameID:    nameResult.ID,
+		GivenName: &newGiven,
+	}
+	result, err := handler.UpdateName(ctx, updateInput)
+	if err != nil {
+		t.Fatalf("UpdateName failed: %v", err)
+	}
+
+	if result.ID != nameResult.ID {
+		t.Errorf("Expected ID %s, got %s", nameResult.ID, result.ID)
+	}
+}
+
+func TestUpdateName_SetAsPrimary(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add primary name
+	_, err = handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+		IsPrimary: true,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Add secondary name
+	secondName, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "Johann",
+		Surname:   "Doe",
+		NameType:  "immigrant",
+		IsPrimary: false,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Update second name to be primary
+	isPrimary := true
+	result, err := handler.UpdateName(ctx, command.UpdateNameInput{
+		PersonID:  personResult.ID,
+		NameID:    secondName.ID,
+		IsPrimary: &isPrimary,
+	})
+	if err != nil {
+		t.Fatalf("UpdateName failed: %v", err)
+	}
+
+	if !result.IsPrimary {
+		t.Error("Updated name should be primary")
+	}
+}
+
+func TestUpdateName_NameNotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	newGiven := "Johnny"
+	_, err = handler.UpdateName(ctx, command.UpdateNameInput{
+		PersonID:  personResult.ID,
+		NameID:    uuid.New(), // Non-existent
+		GivenName: &newGiven,
+	})
+	if err == nil {
+		t.Fatal("Expected error for non-existent name")
+	}
+}
+
+func TestUpdateName_PersonNotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	newGiven := "Johnny"
+	_, err := handler.UpdateName(ctx, command.UpdateNameInput{
+		PersonID:  uuid.New(), // Non-existent
+		NameID:    uuid.New(),
+		GivenName: &newGiven,
+	})
+	if err == nil {
+		t.Fatal("Expected error for non-existent person")
+	}
+}
+
+func TestDeleteName_Success(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add primary name
+	_, err = handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+		IsPrimary: true,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Add secondary name
+	secondName, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "Johann",
+		Surname:   "Doe",
+		NameType:  "immigrant",
+		IsPrimary: false,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Delete secondary name
+	err = handler.DeleteName(ctx, command.DeleteNameInput{
+		PersonID: personResult.ID,
+		NameID:   secondName.ID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteName failed: %v", err)
+	}
+}
+
+func TestDeleteName_CannotDeleteLast(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add one name
+	nameResult, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Try to delete the only name
+	err = handler.DeleteName(ctx, command.DeleteNameInput{
+		PersonID: personResult.ID,
+		NameID:   nameResult.ID,
+	})
+	if err == nil {
+		t.Fatal("Expected error when deleting last name")
+	}
+}
+
+func TestDeleteName_CannotDeletePrimary(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add primary name
+	primaryName, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+		IsPrimary: true,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Add secondary name
+	_, err = handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "Johann",
+		Surname:   "Doe",
+		NameType:  "immigrant",
+		IsPrimary: false,
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Try to delete primary name
+	err = handler.DeleteName(ctx, command.DeleteNameInput{
+		PersonID: personResult.ID,
+		NameID:   primaryName.ID,
+	})
+	if err == nil {
+		t.Fatal("Expected error when deleting primary name")
+	}
+}
+
+func TestDeleteName_PersonNotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	err := handler.DeleteName(ctx, command.DeleteNameInput{
+		PersonID: uuid.New(), // Non-existent
+		NameID:   uuid.New(),
+	})
+	if err == nil {
+		t.Fatal("Expected error for non-existent person")
+	}
+}
+
+func TestDeleteName_NameNotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add a name first so there's at least one
+	_, err = handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Try to delete non-existent name
+	err = handler.DeleteName(ctx, command.DeleteNameInput{
+		PersonID: personResult.ID,
+		NameID:   uuid.New(), // Non-existent
+	})
+	if err == nil {
+		t.Fatal("Expected error for non-existent name")
+	}
+}
+
+func TestAddName_WithAllFields(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	// Add name with all fields
+	nameInput := command.AddNameInput{
+		PersonID:      personResult.ID,
+		GivenName:     "Johannes",
+		Surname:       "von Doe",
+		NamePrefix:    "Dr.",
+		NameSuffix:    "Jr.",
+		SurnamePrefix: "von",
+		Nickname:      "Johnny",
+		NameType:      "birth",
+		IsPrimary:     true,
+	}
+	result, err := handler.AddName(ctx, nameInput)
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	if result.ID == uuid.Nil {
+		t.Error("Expected non-nil ID")
+	}
+	if !result.IsPrimary {
+		t.Error("Expected primary to be true")
+	}
+}
+
+func TestUpdateName_AllFields(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create person and add a name
+	personInput := command.CreatePersonInput{
+		GivenName: "John",
+		Surname:   "Doe",
+		Gender:    "male",
+	}
+	personResult, err := handler.CreatePerson(ctx, personInput)
+	if err != nil {
+		t.Fatalf("CreatePerson failed: %v", err)
+	}
+
+	nameResult, err := handler.AddName(ctx, command.AddNameInput{
+		PersonID:  personResult.ID,
+		GivenName: "John",
+		Surname:   "Doe",
+		NameType:  "birth",
+	})
+	if err != nil {
+		t.Fatalf("AddName failed: %v", err)
+	}
+
+	// Update all fields
+	givenName := "Johannes"
+	surname := "von Doe"
+	namePrefix := "Dr."
+	nameSuffix := "Jr."
+	surnamePrefix := "von"
+	nickname := "Johnny"
+	nameType := "married"
+
+	updateInput := command.UpdateNameInput{
+		PersonID:      personResult.ID,
+		NameID:        nameResult.ID,
+		GivenName:     &givenName,
+		Surname:       &surname,
+		NamePrefix:    &namePrefix,
+		NameSuffix:    &nameSuffix,
+		SurnamePrefix: &surnamePrefix,
+		Nickname:      &nickname,
+		NameType:      &nameType,
+	}
+	result, err := handler.UpdateName(ctx, updateInput)
+	if err != nil {
+		t.Fatalf("UpdateName failed: %v", err)
+	}
+
+	if result.ID != nameResult.ID {
+		t.Errorf("Expected ID %s, got %s", nameResult.ID, result.ID)
+	}
+}

--- a/internal/domain/enums.go
+++ b/internal/domain/enums.go
@@ -169,15 +169,18 @@ func (m MediaType) IsValid() bool {
 type NameType string
 
 const (
-	NameTypeBirth   NameType = "birth"   // Name at birth
-	NameTypeMarried NameType = "married" // Married name
-	NameTypeAKA     NameType = "aka"     // Also known as
+	NameTypeBirth        NameType = "birth"        // Name at birth
+	NameTypeMarried      NameType = "married"      // Married name
+	NameTypeAKA          NameType = "aka"          // Also known as
+	NameTypeImmigrant    NameType = "immigrant"    // Name after immigration (anglicized, etc.)
+	NameTypeReligious    NameType = "religious"    // Religious name (confirmation, ordination)
+	NameTypeProfessional NameType = "professional" // Professional/stage name
 )
 
 // IsValid checks if the name type value is valid.
 func (n NameType) IsValid() bool {
 	switch n {
-	case NameTypeBirth, NameTypeMarried, NameTypeAKA, "":
+	case NameTypeBirth, NameTypeMarried, NameTypeAKA, NameTypeImmigrant, NameTypeReligious, NameTypeProfessional, "":
 		return true
 	default:
 		return false

--- a/internal/domain/enums_test.go
+++ b/internal/domain/enums_test.go
@@ -520,6 +520,21 @@ func TestNameType_IsValid(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "immigrant is valid",
+			nameType: NameTypeImmigrant,
+			want:     true,
+		},
+		{
+			name:     "religious is valid",
+			nameType: NameTypeReligious,
+			want:     true,
+		},
+		{
+			name:     "professional is valid",
+			nameType: NameTypeProfessional,
+			want:     true,
+		},
+		{
 			name:     "empty string is valid",
 			nameType: "",
 			want:     true,

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -726,3 +726,92 @@ func NewAttributeDeleted(attributeID uuid.UUID, reason string) AttributeDeleted 
 		Reason:      reason,
 	}
 }
+
+// NameAdded event is emitted when a name is added to a person.
+type NameAdded struct {
+	BaseEvent
+	PersonID      uuid.UUID `json:"person_id"`
+	NameID        uuid.UUID `json:"name_id"`
+	GivenName     string    `json:"given_name"`
+	Surname       string    `json:"surname,omitempty"`
+	NamePrefix    string    `json:"name_prefix,omitempty"`
+	NameSuffix    string    `json:"name_suffix,omitempty"`
+	SurnamePrefix string    `json:"surname_prefix,omitempty"`
+	Nickname      string    `json:"nickname,omitempty"`
+	NameType      NameType  `json:"name_type,omitempty"`
+	IsPrimary     bool      `json:"is_primary"`
+}
+
+func (e NameAdded) EventType() string      { return "NameAdded" }
+func (e NameAdded) AggregateID() uuid.UUID { return e.PersonID }
+
+// NewNameAdded creates a NameAdded event from a PersonName.
+func NewNameAdded(pn *PersonName) NameAdded {
+	return NameAdded{
+		BaseEvent:     NewBaseEvent(),
+		PersonID:      pn.PersonID,
+		NameID:        pn.ID,
+		GivenName:     pn.GivenName,
+		Surname:       pn.Surname,
+		NamePrefix:    pn.NamePrefix,
+		NameSuffix:    pn.NameSuffix,
+		SurnamePrefix: pn.SurnamePrefix,
+		Nickname:      pn.Nickname,
+		NameType:      pn.NameType,
+		IsPrimary:     pn.IsPrimary,
+	}
+}
+
+// NameUpdated event is emitted when a name is modified.
+type NameUpdated struct {
+	BaseEvent
+	PersonID      uuid.UUID `json:"person_id"`
+	NameID        uuid.UUID `json:"name_id"`
+	GivenName     string    `json:"given_name"`
+	Surname       string    `json:"surname,omitempty"`
+	NamePrefix    string    `json:"name_prefix,omitempty"`
+	NameSuffix    string    `json:"name_suffix,omitempty"`
+	SurnamePrefix string    `json:"surname_prefix,omitempty"`
+	Nickname      string    `json:"nickname,omitempty"`
+	NameType      NameType  `json:"name_type,omitempty"`
+	IsPrimary     bool      `json:"is_primary"`
+}
+
+func (e NameUpdated) EventType() string      { return "NameUpdated" }
+func (e NameUpdated) AggregateID() uuid.UUID { return e.PersonID }
+
+// NewNameUpdated creates a NameUpdated event from a PersonName.
+func NewNameUpdated(pn *PersonName) NameUpdated {
+	return NameUpdated{
+		BaseEvent:     NewBaseEvent(),
+		PersonID:      pn.PersonID,
+		NameID:        pn.ID,
+		GivenName:     pn.GivenName,
+		Surname:       pn.Surname,
+		NamePrefix:    pn.NamePrefix,
+		NameSuffix:    pn.NameSuffix,
+		SurnamePrefix: pn.SurnamePrefix,
+		Nickname:      pn.Nickname,
+		NameType:      pn.NameType,
+		IsPrimary:     pn.IsPrimary,
+	}
+}
+
+// NameRemoved event is emitted when a name is deleted.
+type NameRemoved struct {
+	BaseEvent
+	PersonID uuid.UUID `json:"person_id"`
+	NameID   uuid.UUID `json:"name_id"`
+}
+
+func (e NameRemoved) EventType() string      { return "NameRemoved" }
+func (e NameRemoved) AggregateID() uuid.UUID { return e.PersonID }
+
+// NewNameRemoved creates a NameRemoved event.
+func NewNameRemoved(personID, nameID uuid.UUID) NameRemoved {
+	return NameRemoved{
+		BaseEvent: NewBaseEvent(),
+		PersonID:  personID,
+		NameID:    nameID,
+	}
+}

--- a/internal/domain/events_test.go
+++ b/internal/domain/events_test.go
@@ -1081,6 +1081,155 @@ func TestRepositoryDeleted_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestNameAdded_RoundTrip(t *testing.T) {
+	personID := uuid.New()
+	pn := NewPersonName(personID, "Mary", "Smith")
+	pn.NamePrefix = "Mrs."
+	pn.NameSuffix = "Jr."
+	pn.SurnamePrefix = "van"
+	pn.Nickname = "Molly"
+	pn.NameType = NameTypeMarried
+	pn.IsPrimary = true
+
+	event := NewNameAdded(pn)
+
+	// Verify event type
+	if event.EventType() != "NameAdded" {
+		t.Errorf("EventType() = %v, want NameAdded", event.EventType())
+	}
+
+	// Verify aggregate ID (should be PersonID for name events)
+	if event.AggregateID() != personID {
+		t.Errorf("AggregateID() = %v, want %v", event.AggregateID(), personID)
+	}
+
+	// JSON round-trip
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded NameAdded
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.PersonID != personID {
+		t.Errorf("PersonID = %v, want %v", decoded.PersonID, personID)
+	}
+	if decoded.NameID != pn.ID {
+		t.Errorf("NameID = %v, want %v", decoded.NameID, pn.ID)
+	}
+	if decoded.GivenName != "Mary" {
+		t.Errorf("GivenName = %v, want Mary", decoded.GivenName)
+	}
+	if decoded.Surname != "Smith" {
+		t.Errorf("Surname = %v, want Smith", decoded.Surname)
+	}
+	if decoded.NamePrefix != "Mrs." {
+		t.Errorf("NamePrefix = %v, want Mrs.", decoded.NamePrefix)
+	}
+	if decoded.NameSuffix != "Jr." {
+		t.Errorf("NameSuffix = %v, want Jr.", decoded.NameSuffix)
+	}
+	if decoded.SurnamePrefix != "van" {
+		t.Errorf("SurnamePrefix = %v, want van", decoded.SurnamePrefix)
+	}
+	if decoded.Nickname != "Molly" {
+		t.Errorf("Nickname = %v, want Molly", decoded.Nickname)
+	}
+	if decoded.NameType != NameTypeMarried {
+		t.Errorf("NameType = %v, want %v", decoded.NameType, NameTypeMarried)
+	}
+	if decoded.IsPrimary != true {
+		t.Errorf("IsPrimary = %v, want true", decoded.IsPrimary)
+	}
+}
+
+func TestNameUpdated_RoundTrip(t *testing.T) {
+	personID := uuid.New()
+	pn := NewPersonName(personID, "Maria", "Kowalski")
+	pn.NameType = NameTypeImmigrant
+	pn.IsPrimary = false
+
+	event := NewNameUpdated(pn)
+
+	// Verify event type
+	if event.EventType() != "NameUpdated" {
+		t.Errorf("EventType() = %v, want NameUpdated", event.EventType())
+	}
+
+	// Verify aggregate ID
+	if event.AggregateID() != personID {
+		t.Errorf("AggregateID() = %v, want %v", event.AggregateID(), personID)
+	}
+
+	// JSON round-trip
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded NameUpdated
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.PersonID != personID {
+		t.Errorf("PersonID = %v, want %v", decoded.PersonID, personID)
+	}
+	if decoded.NameID != pn.ID {
+		t.Errorf("NameID = %v, want %v", decoded.NameID, pn.ID)
+	}
+	if decoded.GivenName != "Maria" {
+		t.Errorf("GivenName = %v, want Maria", decoded.GivenName)
+	}
+	if decoded.Surname != "Kowalski" {
+		t.Errorf("Surname = %v, want Kowalski", decoded.Surname)
+	}
+	if decoded.NameType != NameTypeImmigrant {
+		t.Errorf("NameType = %v, want %v", decoded.NameType, NameTypeImmigrant)
+	}
+	if decoded.IsPrimary != false {
+		t.Errorf("IsPrimary = %v, want false", decoded.IsPrimary)
+	}
+}
+
+func TestNameRemoved_RoundTrip(t *testing.T) {
+	personID := uuid.New()
+	nameID := uuid.New()
+
+	event := NewNameRemoved(personID, nameID)
+
+	// Verify event type
+	if event.EventType() != "NameRemoved" {
+		t.Errorf("EventType() = %v, want NameRemoved", event.EventType())
+	}
+
+	// Verify aggregate ID
+	if event.AggregateID() != personID {
+		t.Errorf("AggregateID() = %v, want %v", event.AggregateID(), personID)
+	}
+
+	// JSON round-trip
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded NameRemoved
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.PersonID != personID {
+		t.Errorf("PersonID = %v, want %v", decoded.PersonID, personID)
+	}
+	if decoded.NameID != nameID {
+		t.Errorf("NameID = %v, want %v", decoded.NameID, nameID)
+	}
+}
+
 // Tests for AggregateID methods that were previously uncovered
 func TestEventAggregateIDs(t *testing.T) {
 	tests := []struct {

--- a/internal/query/history_queries_test.go
+++ b/internal/query/history_queries_test.go
@@ -99,6 +99,21 @@ func (m *mockReadModelStore) SavePerson(ctx context.Context, person *repository.
 func (m *mockReadModelStore) DeletePerson(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
+
+// Person name stub methods
+func (m *mockReadModelStore) SavePersonName(ctx context.Context, name *repository.PersonNameReadModel) error {
+	return nil
+}
+func (m *mockReadModelStore) GetPersonName(ctx context.Context, nameID uuid.UUID) (*repository.PersonNameReadModel, error) {
+	return nil, nil
+}
+func (m *mockReadModelStore) GetPersonNames(ctx context.Context, personID uuid.UUID) ([]repository.PersonNameReadModel, error) {
+	return nil, nil
+}
+func (m *mockReadModelStore) DeletePersonName(ctx context.Context, nameID uuid.UUID) error {
+	return nil
+}
+
 func (m *mockReadModelStore) ListFamilies(ctx context.Context, opts repository.ListOptions) ([]repository.FamilyReadModel, int, error) {
 	return nil, 0, nil
 }

--- a/internal/repository/eventstore.go
+++ b/internal/repository/eventstore.go
@@ -187,6 +187,24 @@ func (e *StoredEvent) DecodeEvent() (domain.Event, error) {
 			return nil, err
 		}
 		return event, nil
+	case "NameAdded":
+		var event domain.NameAdded
+		if err := json.Unmarshal(e.Data, &event); err != nil {
+			return nil, err
+		}
+		return event, nil
+	case "NameUpdated":
+		var event domain.NameUpdated
+		if err := json.Unmarshal(e.Data, &event); err != nil {
+			return nil, err
+		}
+		return event, nil
+	case "NameRemoved":
+		var event domain.NameRemoved
+		if err := json.Unmarshal(e.Data, &event); err != nil {
+			return nil, err
+		}
+		return event, nil
 	default:
 		return nil, errors.New("unknown event type: " + e.EventType)
 	}

--- a/internal/repository/eventstore_test.go
+++ b/internal/repository/eventstore_test.go
@@ -471,6 +471,45 @@ func TestStoredEvent_DecodeEvent_AllTypes(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:      "NameAdded",
+			event:     domain.NewNameAdded(domain.NewPersonName(uuid.New(), "John", "Doe")),
+			eventType: "NameAdded",
+			validate: func(t *testing.T, decoded domain.Event) {
+				e, ok := decoded.(domain.NameAdded)
+				if !ok {
+					t.Fatalf("Expected NameAdded, got %T", decoded)
+				}
+				if e.GivenName != "John" {
+					t.Errorf("GivenName = %s, want John", e.GivenName)
+				}
+			},
+		},
+		{
+			name:      "NameUpdated",
+			event:     domain.NewNameUpdated(domain.NewPersonName(uuid.New(), "Jane", "Smith")),
+			eventType: "NameUpdated",
+			validate: func(t *testing.T, decoded domain.Event) {
+				e, ok := decoded.(domain.NameUpdated)
+				if !ok {
+					t.Fatalf("Expected NameUpdated, got %T", decoded)
+				}
+				if e.GivenName != "Jane" {
+					t.Errorf("GivenName = %s, want Jane", e.GivenName)
+				}
+			},
+		},
+		{
+			name:      "NameRemoved",
+			event:     domain.NewNameRemoved(uuid.New(), uuid.New()),
+			eventType: "NameRemoved",
+			validate: func(t *testing.T, decoded domain.Event) {
+				_, ok := decoded.(domain.NameRemoved)
+				if !ok {
+					t.Fatalf("Expected NameRemoved, got %T", decoded)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/repository/readmodel.go
+++ b/internal/repository/readmodel.go
@@ -164,6 +164,12 @@ type ReadModelStore interface {
 	SavePerson(ctx context.Context, person *PersonReadModel) error
 	DeletePerson(ctx context.Context, id uuid.UUID) error
 
+	// Person name operations
+	SavePersonName(ctx context.Context, name *PersonNameReadModel) error
+	GetPersonName(ctx context.Context, nameID uuid.UUID) (*PersonNameReadModel, error)
+	GetPersonNames(ctx context.Context, personID uuid.UUID) ([]PersonNameReadModel, error)
+	DeletePersonName(ctx context.Context, nameID uuid.UUID) error
+
 	// Family operations
 	GetFamily(ctx context.Context, id uuid.UUID) (*FamilyReadModel, error)
 	ListFamilies(ctx context.Context, opts ListOptions) ([]FamilyReadModel, int, error)
@@ -245,6 +251,22 @@ type PlaceEntry struct {
 	FullName    string `json:"full_name"`
 	Count       int    `json:"count"`
 	HasChildren bool   `json:"has_children"`
+}
+
+// PersonNameReadModel represents a name variant for a person in the read model.
+type PersonNameReadModel struct {
+	ID            uuid.UUID       `json:"id"`
+	PersonID      uuid.UUID       `json:"person_id"`
+	GivenName     string          `json:"given_name"`
+	Surname       string          `json:"surname"`
+	FullName      string          `json:"full_name"`
+	NamePrefix    string          `json:"name_prefix,omitempty"`
+	NameSuffix    string          `json:"name_suffix,omitempty"`
+	SurnamePrefix string          `json:"surname_prefix,omitempty"`
+	Nickname      string          `json:"nickname,omitempty"`
+	NameType      domain.NameType `json:"name_type"`
+	IsPrimary     bool            `json:"is_primary"`
+	UpdatedAt     time.Time       `json:"updated_at"`
 }
 
 // ListOptions contains options for list queries.


### PR DESCRIPTION
## Summary
- Add multiple name support per person (maiden names, aliases, spelling variants)
- Implement full GEDCOM 5.5.1 name compliance
- Add API endpoints for name CRUD operations

## Changes
- **Domain**: PersonName entity, NameAdded/Updated/Removed events, expanded NameType enum
- **Storage**: person_names table in SQLite/PostgreSQL/Memory with FTS search
- **API**: Name CRUD endpoints at `/persons/{id}/names`
- **GEDCOM**: Import all names (not just first), export with TYPE tags
- **Auto-create**: Primary name created when person is created via API

## Test plan
- [x] All existing tests pass
- [x] Coverage threshold met (88.1%)
- [x] Lint passes
- [x] New unit tests for name commands
- [x] New API handler tests for name endpoints
- [x] Query tests for GetPersonNames

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)