### PR TITLE
Fix frontend assets path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ COPY . .
 # Remove local replace directive from copied source
 RUN sed -i '/^replace.*=> \//d' go.mod
 
-# Copy built frontend into web/build for embedding
-COPY --from=frontend-builder /app/web/build ./web/build
+# Copy built frontend into internal/web/dist for embedding
+COPY --from=frontend-builder /app/web/build ./internal/web/dist
 
 # Build with CGO enabled for SQLite support
 ENV CGO_ENABLED=1


### PR DESCRIPTION
## Summary

Fix Docker build failure caused by frontend assets being copied to the wrong path.

## Problem

The build fails during Go compilation with:

```
internal/web/embed.go:11:12: pattern all:dist: no matching files found
```

The Go embed directive in `internal/web/embed.go` expects assets at `internal/web/dist`, but the Dockerfile copies them to `web/build`.

## Fix

Change the COPY destination from `./web/build` to `./internal/web/dist`:

```dockerfile
COPY --from=frontend-builder /app/web/build ./internal/web/dist
```