### PR TITLE
Update Dockerfile to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: Frontend
-FROM node:20-alpine AS frontend-builder
+FROM node:22-alpine AS frontend-builder
 
 WORKDIR /app/web
 COPY web/package*.json ./


### PR DESCRIPTION
## Summary
Update frontend build stage to use node:22-alpine to match the Node.js 22 LTS requirement set in #174.

## Test plan
- [ ] Docker build succeeds
- [ ] Container runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)