### PR TITLE
Add Docker smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
         run: |
           timeout=60
           while [ $timeout -gt 0 ]; do
-            status=$(docker compose ps --format json | jq -r '.[0].Health // "starting"')
+            status=$(docker compose ps --format json | jq -rs '.[0].Health // "starting"')
             if [ "$status" = "healthy" ]; then
               echo "Container is healthy"
               exit 0

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ docker-smoke-test: ## Build and test Docker image
 	@echo "Waiting for container to be healthy..."
 	@timeout=60; \
 	while [ $$timeout -gt 0 ]; do \
-		status=$$(docker compose ps --format json 2>/dev/null | jq -r '.[0].Health // "starting"'); \
+		status=$$(docker compose ps --format json 2>/dev/null | jq -rs '.[0].Health // "starting"'); \
 		if [ "$$status" = "healthy" ]; then \
 			echo "Container is healthy"; \
 			break; \


### PR DESCRIPTION
## Summary
- Add `make docker-smoke-test` target for local Docker validation
- Add `docker-smoke-test` CI job that runs after backend/frontend pass
- Test builds image, waits for healthy status, hits API endpoint

## Test plan
- [ ] CI passes (including new docker-smoke-test job)
- [ ] `make docker-smoke-test` works locally (optional, builds take time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)