### PR TITLE
Fix nosemgrep rule ID for SQL query suppression

### DIFF
--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -281,7 +281,7 @@ func (s *ReadModelStore) ListPersons(ctx context.Context, opts repository.ListOp
 
 	// Count total (with filter if present)
 	var total int
-	// nosemgrep: go.lang.security.audit.database.string-formatted-query -- whereClause uses parameterized placeholders, not user input
+	// nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- whereClause uses parameterized placeholders, not user input
 	countQuery := "SELECT COUNT(*) FROM persons " + whereClause
 	err := s.db.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&total)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixed nosemgrep comment using truncated rule ID that was not being recognized
- Updated to full rule ID: go.lang.security.audit.database.string-formatted-query.string-formatted-query

## Context
The code scanning alert (#13) was still showing as open because the nosemgrep suppression comment was using a shortened rule ID. The underlying code is safe - it uses parameterized queries with $N placeholders and passes user input through whereArgs.

## Test plan
- [x] make lint passes
- [x] make test passes
- [x] make security passes
- [ ] GitHub code scanning alert resolves after merge

Generated with Claude Code