### PR TITLE
Fix release pipeline to avoid immutable release errors

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,11 +15,14 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      body: ${{ steps.release.outputs.body }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Skip creating GitHub release - GoReleaser will create it with assets
+          skip-github-release: true
 
   build-release:
     needs: release-please
@@ -56,11 +59,17 @@ jobs:
           mkdir -p internal/web/dist
           cp -r web/build/* internal/web/dist/
 
+      - name: Write release notes
+        run: |
+          cat << 'EOF' > RELEASE_NOTES.md
+          ${{ needs.release-please.outputs.body }}
+          EOF
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --release-notes=RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,5 +50,3 @@ release:
   github:
     owner: cacack
     name: my-family
-  # Append to existing release created by release-please
-  mode: append


### PR DESCRIPTION
## Summary
- Let GoReleaser create releases instead of release-please to avoid "Cannot upload assets to an immutable release" errors
- Pass release notes from release-please to GoReleaser via file

## Root cause
The release-please action was creating and publishing releases before the build-release job could run GoReleaser. Once published, releases are immutable and GoReleaser's `mode: append` failed with HTTP 422.

## Changes
- Added `skip-github-release: true` to release-please-action
- GoReleaser now creates the full release with assets
- Release notes from release-please are passed via `--release-notes` flag
- Removed `mode: append` from `.goreleaser.yaml`

## Test plan
- [ ] Merge this PR
- [ ] Once release-please PR is created/updated, merge it to trigger v0.2.1 release
- [ ] Verify GoReleaser creates release with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
