### PR TITLE
Use draft releases for release-please + GoReleaser integration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,14 +15,13 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      body: ${{ steps.release.outputs.body }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # Skip creating GitHub release - GoReleaser will create it with assets
-          skip-github-release: true
+          # release-please-config.json has draft: true
+          # This creates a draft release that GoReleaser can upload to
 
   build-release:
     needs: release-please
@@ -59,17 +58,11 @@ jobs:
           mkdir -p internal/web/dist
           cp -r web/build/* internal/web/dist/
 
-      - name: Write release notes
-        run: |
-          cat << 'EOF' > RELEASE_NOTES.md
-          ${{ needs.release-please.outputs.body }}
-          EOF
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --release-notes=RELEASE_NOTES.md
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,3 +50,9 @@ release:
   github:
     owner: cacack
     name: my-family
+  # Use the draft release created by release-please
+  use_existing_draft: true
+  # Keep release-please's changelog (don't overwrite)
+  mode: keep-existing
+  # Publish the release after uploading assets (draft: false is default)
+  draft: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary

Fixes the release pipeline to properly handle GitHub's immutable releases feature.

## Root Cause

When immutable releases are enabled:
1. release-please was creating **published** releases immediately
2. Published releases become immutable - no assets can be uploaded
3. GoReleaser failed with "Cannot upload assets to an immutable release"

## Solution

Use the **draft release pattern** recommended by GitHub for immutable releases:

1. **release-please-config.json**: Set `draft: true` - creates draft releases
2. **.goreleaser.yaml**:
   - `use_existing_draft: true` - uses the draft created by release-please
   - `mode: keep-existing` - preserves release-please's changelog
   - `draft: false` - publishes after uploading assets

## How it works now

```
release-please creates draft release
         ↓
GoReleaser uploads assets to draft
         ↓
GoReleaser publishes release (now immutable with all assets)
```

## References

- [GoReleaser Release Configuration](https://goreleaser.com/customization/release/)
- [GitHub Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)

## Test Plan

- [ ] Merge this PR
- [ ] Wait for release-please to create a new release PR
- [ ] Merge the release PR
- [ ] Verify GoReleaser uploads assets and publishes the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
