### PR TITLE
Fix release pipeline: use published releases instead of drafts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # release-please-config.json has draft: true
-          # This creates a draft release that GoReleaser can upload to
+          # Creates tag + release, then GoReleaser uploads assets
 
   build-release:
     needs: release-please

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,9 +50,5 @@ release:
   github:
     owner: cacack
     name: my-family
-  # Use the draft release created by release-please
-  use_existing_draft: true
-  # Keep release-please's changelog (don't overwrite)
+  # Upload assets to the release created by release-please
   mode: keep-existing
-  # Publish the release after uploading assets (draft: false is default)
-  draft: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary

Fixes the release pipeline by using published releases instead of drafts.

## Root Cause

Draft releases (`draft: true`) do NOT create git tags. GoReleaser needs tags to checkout code, so it was failing with:
```
A branch or tag with the name 'v0.4.0' could not be found
```

## Solution

With immutable releases now disabled in repository settings:
1. Set `draft: false` in release-please-config.json
2. release-please creates published release WITH tag
3. GoReleaser uploads assets using `mode: keep-existing`

## Changes

- `release-please-config.json`: `draft: false`
- `.goreleaser.yaml`: Removed `use_existing_draft`, kept `mode: keep-existing`
- Updated workflow comment

## Test Plan

- [x] Deleted v0.3.0 and v0.4.0 draft releases
- [ ] Merge this PR
- [ ] Wait for release-please to create a new release PR
- [ ] Merge release PR → should create tag + release + upload assets