### PR TITLE
Add relationship calculator

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -45,6 +45,8 @@ tags:
     description: Genealogical reports (Ahnentafel, etc.)
   - name: snapshots
     description: Research milestone snapshots
+  - name: relationships
+    description: Relationship calculation between people
 
 paths:
   /persons:
@@ -1806,6 +1808,39 @@ paths:
                 $ref: '#/components/schemas/SnapshotComparisonResult'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /relationship/{personId1}/{personId2}:
+    get:
+      operationId: getRelationship
+      summary: Calculate relationship between two people
+      tags:
+        - relationships
+      parameters:
+        - name: personId1
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: personId2
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Relationship calculated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RelationshipResult'
+        '404':
+          description: One or both persons not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:
@@ -3570,3 +3605,44 @@ components:
         older_first:
           type: boolean
           description: True if snapshot1 is the older (lower position) snapshot
+
+    RelationshipPath:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Relationship name (e.g., "1st cousin once removed")
+        pathFromA:
+          type: array
+          items:
+            type: string
+            format: uuid
+        pathFromB:
+          type: array
+          items:
+            type: string
+            format: uuid
+        commonAncestorId:
+          type: string
+          format: uuid
+        generationDistanceA:
+          type: integer
+        generationDistanceB:
+          type: integer
+
+    RelationshipResult:
+      type: object
+      properties:
+        personA:
+          $ref: '#/components/schemas/Person'
+        personB:
+          $ref: '#/components/schemas/Person'
+        paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelationshipPath'
+        isRelated:
+          type: boolean
+        summary:
+          type: string
+          description: Human-readable relationship summary

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -18,23 +18,24 @@ import (
 
 // Server wraps the Echo server with application dependencies.
 type Server struct {
-	echo               *echo.Echo
-	config             *config.Config
-	readStore          repository.ReadModelStore
-	commandHandler     *command.Handler
-	personService      *query.PersonService
-	familyService      *query.FamilyService
-	pedigreeService    *query.PedigreeService
-	descendancyService *query.DescendancyService
-	ahnentafelService  *query.AhnentafelService
-	sourceService      *query.SourceService
-	historyService     *query.HistoryService
-	rollbackService    *query.RollbackService
-	browseService      *query.BrowseService
-	qualityService     *query.QualityService
-	snapshotService    *query.SnapshotService
-	validationService  *query.ValidationService
-	frontendFS         fs.FS
+	echo                *echo.Echo
+	config              *config.Config
+	readStore           repository.ReadModelStore
+	commandHandler      *command.Handler
+	personService       *query.PersonService
+	familyService       *query.FamilyService
+	pedigreeService     *query.PedigreeService
+	descendancyService  *query.DescendancyService
+	ahnentafelService   *query.AhnentafelService
+	sourceService       *query.SourceService
+	historyService      *query.HistoryService
+	rollbackService     *query.RollbackService
+	browseService       *query.BrowseService
+	qualityService      *query.QualityService
+	snapshotService     *query.SnapshotService
+	validationService   *query.ValidationService
+	relationshipService *query.RelationshipService
+	frontendFS          fs.FS
 }
 
 // NewServer creates a new API server with all dependencies.
@@ -84,25 +85,27 @@ func NewServer(
 	qualitySvc := query.NewQualityService(readStore)
 	snapshotSvc := query.NewSnapshotService(snapshotStore, eventStore, historySvc)
 	validationSvc := query.NewValidationService(readStore)
+	relationshipSvc := query.NewRelationshipService(readStore)
 
 	server := &Server{
-		echo:               e,
-		config:             cfg,
-		readStore:          readStore,
-		commandHandler:     cmdHandler,
-		personService:      personSvc,
-		familyService:      familySvc,
-		pedigreeService:    pedigreeSvc,
-		descendancyService: descendancySvc,
-		ahnentafelService:  ahnentafelSvc,
-		sourceService:      sourceSvc,
-		historyService:     historySvc,
-		rollbackService:    rollbackSvc,
-		browseService:      browseSvc,
-		qualityService:     qualitySvc,
-		snapshotService:    snapshotSvc,
-		validationService:  validationSvc,
-		frontendFS:         frontendFS,
+		echo:                e,
+		config:              cfg,
+		readStore:           readStore,
+		commandHandler:      cmdHandler,
+		personService:       personSvc,
+		familyService:       familySvc,
+		pedigreeService:     pedigreeSvc,
+		descendancyService:  descendancySvc,
+		ahnentafelService:   ahnentafelSvc,
+		sourceService:       sourceSvc,
+		historyService:      historySvc,
+		rollbackService:     rollbackSvc,
+		browseService:       browseSvc,
+		qualityService:      qualitySvc,
+		snapshotService:     snapshotSvc,
+		validationService:   validationSvc,
+		relationshipService: relationshipSvc,
+		frontendFS:          frontendFS,
 	}
 
 	// Register routes

--- a/internal/query/relationship_queries.go
+++ b/internal/query/relationship_queries.go
@@ -1,0 +1,474 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// RelationshipService provides relationship calculation queries between two people.
+type RelationshipService struct {
+	readStore       repository.ReadModelStore
+	pedigreeService *PedigreeService
+}
+
+// NewRelationshipService creates a new relationship query service.
+func NewRelationshipService(readStore repository.ReadModelStore) *RelationshipService {
+	return &RelationshipService{
+		readStore:       readStore,
+		pedigreeService: NewPedigreeService(readStore),
+	}
+}
+
+// RelationshipPath represents a single path of relationship through a common ancestor.
+type RelationshipPath struct {
+	Name                string      `json:"name"`                  // Human-readable relationship name (e.g., "1st cousin")
+	PathFromA           []uuid.UUID `json:"path_from_a"`           // Path from PersonA to common ancestor
+	PathFromB           []uuid.UUID `json:"path_from_b"`           // Path from PersonB to common ancestor
+	CommonAncestor      *Person     `json:"common_ancestor"`       // The lowest common ancestor
+	GenerationDistanceA int         `json:"generation_distance_a"` // Generations from A to common ancestor
+	GenerationDistanceB int         `json:"generation_distance_b"` // Generations from B to common ancestor
+}
+
+// RelationshipResult contains the complete relationship analysis between two people.
+type RelationshipResult struct {
+	PersonA   *Person            `json:"person_a"`
+	PersonB   *Person            `json:"person_b"`
+	Paths     []RelationshipPath `json:"paths"`
+	IsRelated bool               `json:"is_related"`
+	Summary   string             `json:"summary"` // Human-readable summary
+}
+
+// ancestorInfo stores information about an ancestor for LCA calculation.
+type ancestorInfo struct {
+	person     Person
+	generation int
+	path       []uuid.UUID // Path from the starting person to this ancestor
+}
+
+// maxGenerations is the limit for ancestor search to prevent excessive recursion.
+const maxRelationshipGenerations = 15
+
+// GetRelationship calculates the relationship between two people.
+func (s *RelationshipService) GetRelationship(ctx context.Context, personID1, personID2 uuid.UUID) (*RelationshipResult, error) {
+	// Get person A
+	personARM, err := s.readStore.GetPerson(ctx, personID1)
+	if err != nil {
+		return nil, err
+	}
+	if personARM == nil {
+		return nil, ErrNotFound
+	}
+	personA := convertReadModelToPerson(*personARM)
+
+	// Get person B
+	personBRM, err := s.readStore.GetPerson(ctx, personID2)
+	if err != nil {
+		return nil, err
+	}
+	if personBRM == nil {
+		return nil, ErrNotFound
+	}
+	personB := convertReadModelToPerson(*personBRM)
+
+	result := &RelationshipResult{
+		PersonA: &personA,
+		PersonB: &personB,
+		Paths:   []RelationshipPath{},
+	}
+
+	// Handle same person case
+	if personID1 == personID2 {
+		result.IsRelated = true
+		result.Summary = "same person"
+		result.Paths = []RelationshipPath{{
+			Name:                "self",
+			PathFromA:           []uuid.UUID{personID1},
+			PathFromB:           []uuid.UUID{personID2},
+			GenerationDistanceA: 0,
+			GenerationDistanceB: 0,
+		}}
+		return result, nil
+	}
+
+	// Build ancestor maps for both persons with paths
+	ancestorsA := s.buildAncestorMap(ctx, personID1)
+	ancestorsB := s.buildAncestorMap(ctx, personID2)
+
+	// Check if A is an ancestor of B (direct line down from A's perspective)
+	if info, ok := ancestorsB[personID1]; ok {
+		path := RelationshipPath{
+			PathFromA:           []uuid.UUID{personID1},
+			PathFromB:           info.path,
+			CommonAncestor:      &personA,
+			GenerationDistanceA: 0,
+			GenerationDistanceB: info.generation,
+		}
+		path.Name = s.getRelationshipName(0, info.generation)
+		result.Paths = append(result.Paths, path)
+	}
+
+	// Check if B is an ancestor of A (direct line up from A's perspective)
+	if info, ok := ancestorsA[personID2]; ok {
+		path := RelationshipPath{
+			PathFromA:           info.path,
+			PathFromB:           []uuid.UUID{personID2},
+			CommonAncestor:      &personB,
+			GenerationDistanceA: info.generation,
+			GenerationDistanceB: 0,
+		}
+		path.Name = s.getRelationshipName(info.generation, 0)
+		result.Paths = append(result.Paths, path)
+	}
+
+	// Find common ancestors (excluding the case where A or B are direct ancestors)
+	commonAncestors := s.findCommonAncestors(ancestorsA, ancestorsB)
+
+	// For each common ancestor, create a relationship path
+	for _, ca := range commonAncestors {
+		infoA := ancestorsA[ca.person.ID]
+		infoB := ancestorsB[ca.person.ID]
+
+		path := RelationshipPath{
+			PathFromA:           infoA.path,
+			PathFromB:           infoB.path,
+			CommonAncestor:      &ca.person,
+			GenerationDistanceA: infoA.generation,
+			GenerationDistanceB: infoB.generation,
+		}
+		path.Name = s.getRelationshipName(infoA.generation, infoB.generation)
+		result.Paths = append(result.Paths, path)
+	}
+
+	// Set overall result
+	result.IsRelated = len(result.Paths) > 0
+	if result.IsRelated {
+		result.Summary = s.buildSummary(result.Paths)
+	} else {
+		result.Summary = "not related"
+	}
+
+	return result, nil
+}
+
+// buildAncestorMap builds a map of all ancestors with their generation distance and path.
+func (s *RelationshipService) buildAncestorMap(ctx context.Context, personID uuid.UUID) map[uuid.UUID]ancestorInfo {
+	ancestors := make(map[uuid.UUID]ancestorInfo)
+	visited := make(map[uuid.UUID]bool)
+
+	s.collectAncestorsWithPath(ctx, personID, 0, []uuid.UUID{personID}, visited, ancestors)
+
+	return ancestors
+}
+
+// collectAncestorsWithPath recursively collects ancestors with their generation and path.
+func (s *RelationshipService) collectAncestorsWithPath(
+	ctx context.Context,
+	personID uuid.UUID,
+	generation int,
+	currentPath []uuid.UUID,
+	visited map[uuid.UUID]bool,
+	ancestors map[uuid.UUID]ancestorInfo,
+) {
+	if generation >= maxRelationshipGenerations {
+		return
+	}
+	if visited[personID] {
+		return
+	}
+	visited[personID] = true
+
+	edge, err := s.readStore.GetPedigreeEdge(ctx, personID)
+	if err != nil || edge == nil {
+		return
+	}
+
+	// Process father
+	if edge.FatherID != nil {
+		fatherPath := make([]uuid.UUID, len(currentPath))
+		copy(fatherPath, currentPath)
+		fatherPath = append(fatherPath, *edge.FatherID)
+
+		father, err := s.readStore.GetPerson(ctx, *edge.FatherID)
+		if err == nil && father != nil {
+			// Only add if not already present or if this path is shorter
+			if existing, ok := ancestors[*edge.FatherID]; !ok || generation+1 < existing.generation {
+				ancestors[*edge.FatherID] = ancestorInfo{
+					person:     convertReadModelToPerson(*father),
+					generation: generation + 1,
+					path:       fatherPath,
+				}
+			}
+			s.collectAncestorsWithPath(ctx, *edge.FatherID, generation+1, fatherPath, visited, ancestors)
+		}
+	}
+
+	// Process mother
+	if edge.MotherID != nil {
+		motherPath := make([]uuid.UUID, len(currentPath))
+		copy(motherPath, currentPath)
+		motherPath = append(motherPath, *edge.MotherID)
+
+		mother, err := s.readStore.GetPerson(ctx, *edge.MotherID)
+		if err == nil && mother != nil {
+			// Only add if not already present or if this path is shorter
+			if existing, ok := ancestors[*edge.MotherID]; !ok || generation+1 < existing.generation {
+				ancestors[*edge.MotherID] = ancestorInfo{
+					person:     convertReadModelToPerson(*mother),
+					generation: generation + 1,
+					path:       motherPath,
+				}
+			}
+			s.collectAncestorsWithPath(ctx, *edge.MotherID, generation+1, motherPath, visited, ancestors)
+		}
+	}
+}
+
+// findCommonAncestors finds common ancestors between two ancestor maps.
+// Returns the lowest common ancestors (smallest total generation distance).
+func (s *RelationshipService) findCommonAncestors(ancestorsA, ancestorsB map[uuid.UUID]ancestorInfo) []ancestorInfo {
+	var common []ancestorInfo
+
+	for id, infoA := range ancestorsA {
+		if infoB, ok := ancestorsB[id]; ok {
+			// This is a common ancestor
+			common = append(common, ancestorInfo{
+				person:     infoA.person,
+				generation: infoA.generation + infoB.generation, // Total distance for sorting
+			})
+		}
+	}
+
+	// Sort by total generation distance (lowest first)
+	for i := 0; i < len(common)-1; i++ {
+		for j := i + 1; j < len(common); j++ {
+			if common[j].generation < common[i].generation {
+				common[i], common[j] = common[j], common[i]
+			}
+		}
+	}
+
+	// Keep only the lowest common ancestors (filter out ancestors of common ancestors)
+	return s.filterToLowestCommonAncestors(common, ancestorsA, ancestorsB)
+}
+
+// filterToLowestCommonAncestors removes common ancestors that are ancestors of other common ancestors.
+func (s *RelationshipService) filterToLowestCommonAncestors(common []ancestorInfo, ancestorsA, ancestorsB map[uuid.UUID]ancestorInfo) []ancestorInfo {
+	if len(common) <= 1 {
+		return common
+	}
+
+	// Build set of common ancestor IDs
+	commonIDs := make(map[uuid.UUID]bool)
+	for _, ca := range common {
+		commonIDs[ca.person.ID] = true
+	}
+
+	// Filter out ancestors that have common ancestors as descendants
+	// A common ancestor X is "lower" than Y if X is an ancestor of Y
+	filtered := make([]ancestorInfo, 0, len(common))
+
+	for _, ca := range common {
+		isLowest := true
+		caInfoA := ancestorsA[ca.person.ID]
+		caInfoB := ancestorsB[ca.person.ID]
+
+		// Check if any other common ancestor is a descendant of this one
+		// (i.e., this one has higher generation numbers for both paths)
+		for _, other := range common {
+			if other.person.ID == ca.person.ID {
+				continue
+			}
+			otherInfoA := ancestorsA[other.person.ID]
+			otherInfoB := ancestorsB[other.person.ID]
+
+			// If other has lower generation distances on both sides, it's closer to the people
+			if otherInfoA.generation < caInfoA.generation && otherInfoB.generation < caInfoB.generation {
+				isLowest = false
+				break
+			}
+		}
+
+		if isLowest {
+			filtered = append(filtered, ca)
+		}
+	}
+
+	return filtered
+}
+
+// getRelationshipName returns the human-readable relationship name based on generation distances.
+// The name describes what PersonB is to PersonA (e.g., "PersonB is PersonA's parent").
+// genA = generations from PersonA to common ancestor
+// genB = generations from PersonB to common ancestor
+func (s *RelationshipService) getRelationshipName(genA, genB int) string {
+	// Direct line cases
+	if genA == 0 && genB == 0 {
+		return "self"
+	}
+
+	// A is an ancestor of B (genA=0): PersonB is PersonA's descendant
+	if genA == 0 {
+		return s.getDescendantName(genB)
+	}
+
+	// B is an ancestor of A (genB=0): PersonB is PersonA's ancestor
+	if genB == 0 {
+		return s.getAncestorName(genA)
+	}
+
+	// Siblings: both at generation 1 from common ancestor
+	if genA == 1 && genB == 1 {
+		return "sibling"
+	}
+
+	// Uncle/Aunt: PersonB is 1 gen from LCA, PersonA is 2 gens (PersonB is PersonA's uncle/aunt)
+	// Nephew/Niece: PersonB is 2 gens from LCA, PersonA is 1 gen (PersonB is PersonA's nephew/niece)
+	if genA == 2 && genB == 1 {
+		return "uncle/aunt"
+	}
+	if genA == 1 && genB == 2 {
+		return "nephew/niece"
+	}
+
+	// Grand-uncle/aunt: PersonB is 1 gen from LCA, PersonA is 3+ gens
+	// genA=3, genB=1 -> grand-uncle/aunt (grandparent's sibling)
+	// genA=4, genB=1 -> great-grand-uncle/aunt (great-grandparent's sibling)
+	// Grand-nephew/niece: PersonB is 3+ gens from LCA, PersonA is 1 gen
+	if genB == 1 && genA > 2 {
+		return s.getGreatPrefix(genA-3) + "grand-uncle/aunt"
+	}
+	if genA == 1 && genB > 2 {
+		return s.getGreatPrefix(genB-3) + "grand-nephew/niece"
+	}
+
+	// Cousins
+	// Cousin degree = min(genA, genB) - 1
+	// Removed = |genA - genB|
+	minGen := genA
+	if genB < minGen {
+		minGen = genB
+	}
+
+	degree := minGen - 1
+	removed := genA - genB
+	if removed < 0 {
+		removed = -removed
+	}
+
+	return s.getCousinName(degree, removed)
+}
+
+// getAncestorName returns the name for an ancestor at the given generation.
+func (s *RelationshipService) getAncestorName(gen int) string {
+	switch gen {
+	case 1:
+		return "parent"
+	case 2:
+		return "grandparent"
+	default:
+		return s.getGreatPrefix(gen-2) + "grandparent"
+	}
+}
+
+// getDescendantName returns the name for a descendant at the given generation.
+func (s *RelationshipService) getDescendantName(gen int) string {
+	switch gen {
+	case 1:
+		return "child"
+	case 2:
+		return "grandchild"
+	default:
+		return s.getGreatPrefix(gen-2) + "grandchild"
+	}
+}
+
+// getGreatPrefix returns the "great-" prefix for a given count.
+func (s *RelationshipService) getGreatPrefix(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	if count == 1 {
+		return "great-"
+	}
+	if count == 2 {
+		return "great-great-"
+	}
+	// For 3+, use ordinal: "3rd great-", "4th great-", etc.
+	return fmt.Sprintf("%s great-", s.ordinal(count))
+}
+
+// getCousinName returns the name for a cousin relationship.
+func (s *RelationshipService) getCousinName(degree, removed int) string {
+	if degree <= 0 {
+		return "related"
+	}
+
+	ordinalDegree := s.ordinal(degree)
+
+	if removed == 0 {
+		return ordinalDegree + " cousin"
+	}
+
+	removedStr := "once"
+	if removed == 2 {
+		removedStr = "twice"
+	} else if removed == 3 {
+		removedStr = "thrice"
+	} else if removed > 3 {
+		removedStr = fmt.Sprintf("%d times", removed)
+	}
+
+	return fmt.Sprintf("%s cousin %s removed", ordinalDegree, removedStr)
+}
+
+// ordinal returns the ordinal string for a number (1st, 2nd, 3rd, etc.).
+func (s *RelationshipService) ordinal(n int) string {
+	suffix := "th"
+	switch n % 10 {
+	case 1:
+		if n%100 != 11 {
+			suffix = "st"
+		}
+	case 2:
+		if n%100 != 12 {
+			suffix = "nd"
+		}
+	case 3:
+		if n%100 != 13 {
+			suffix = "rd"
+		}
+	}
+	return fmt.Sprintf("%d%s", n, suffix)
+}
+
+// buildSummary creates a human-readable summary of the relationship.
+func (s *RelationshipService) buildSummary(paths []RelationshipPath) string {
+	if len(paths) == 0 {
+		return "not related"
+	}
+
+	if len(paths) == 1 {
+		return paths[0].Name
+	}
+
+	// Multiple paths - summarize uniquely
+	names := make([]string, 0, len(paths))
+	seen := make(map[string]bool)
+	for _, p := range paths {
+		if !seen[p.Name] {
+			names = append(names, p.Name)
+			seen[p.Name] = true
+		}
+	}
+
+	if len(names) == 1 {
+		return fmt.Sprintf("%s (via %d paths)", names[0], len(paths))
+	}
+
+	return strings.Join(names, "; ")
+}

--- a/internal/query/relationship_queries_test.go
+++ b/internal/query/relationship_queries_test.go
@@ -1,0 +1,1208 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/query"
+	"github.com/cacack/my-family/internal/repository"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+// Helper to create a person with minimal data.
+func createPerson(t *testing.T, ctx context.Context, store *memory.ReadModelStore, givenName, surname string, gender domain.Gender) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	err := store.SavePerson(ctx, &repository.PersonReadModel{
+		ID:        id,
+		GivenName: givenName,
+		Surname:   surname,
+		FullName:  givenName + " " + surname,
+		Gender:    gender,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// Helper to create a parent-child relationship.
+func createParentChild(t *testing.T, ctx context.Context, store *memory.ReadModelStore, childID uuid.UUID, fatherID, motherID *uuid.UUID, fatherName, motherName string) {
+	t.Helper()
+	edge := &repository.PedigreeEdge{
+		PersonID:   childID,
+		FatherID:   fatherID,
+		MotherID:   motherID,
+		FatherName: fatherName,
+		MotherName: motherName,
+	}
+	if err := store.SavePedigreeEdge(ctx, edge); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetRelationship_SamePerson(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	person := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+
+	result, err := svc.GetRelationship(ctx, person, person)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true for same person")
+	}
+	if result.Summary != "same person" {
+		t.Errorf("Expected summary 'same person', got '%s'", result.Summary)
+	}
+	if len(result.Paths) != 1 {
+		t.Errorf("Expected 1 path, got %d", len(result.Paths))
+	}
+	if result.Paths[0].Name != "self" {
+		t.Errorf("Expected path name 'self', got '%s'", result.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_PersonNotFound(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	person := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	nonExistent := uuid.New()
+
+	// Test when first person doesn't exist
+	_, err := svc.GetRelationship(ctx, nonExistent, person)
+	if err != query.ErrNotFound {
+		t.Errorf("Expected ErrNotFound for non-existent person A, got %v", err)
+	}
+
+	// Test when second person doesn't exist
+	_, err = svc.GetRelationship(ctx, person, nonExistent)
+	if err != query.ErrNotFound {
+		t.Errorf("Expected ErrNotFound for non-existent person B, got %v", err)
+	}
+}
+
+func TestGetRelationship_Unrelated(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	personA := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	personB := createPerson(t, ctx, store, "Jane", "Smith", domain.GenderFemale)
+
+	result, err := svc.GetRelationship(ctx, personA, personB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.IsRelated {
+		t.Error("Expected IsRelated to be false for unrelated persons")
+	}
+	if result.Summary != "not related" {
+		t.Errorf("Expected summary 'not related', got '%s'", result.Summary)
+	}
+	if len(result.Paths) != 0 {
+		t.Errorf("Expected 0 paths, got %d", len(result.Paths))
+	}
+}
+
+func TestGetRelationship_ParentChild(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "Junior", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, child, &father, nil, "John Doe", "")
+
+	// Test child to parent
+	result, err := svc.GetRelationship(ctx, child, father)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if len(result.Paths) != 1 {
+		t.Errorf("Expected 1 path, got %d", len(result.Paths))
+	}
+	if result.Paths[0].Name != "parent" {
+		t.Errorf("Expected 'parent', got '%s'", result.Paths[0].Name)
+	}
+	if result.Paths[0].GenerationDistanceA != 1 {
+		t.Errorf("Expected generation distance A = 1, got %d", result.Paths[0].GenerationDistanceA)
+	}
+	if result.Paths[0].GenerationDistanceB != 0 {
+		t.Errorf("Expected generation distance B = 0, got %d", result.Paths[0].GenerationDistanceB)
+	}
+
+	// Test parent to child
+	result2, err := svc.GetRelationship(ctx, father, child)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result2.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if len(result2.Paths) != 1 {
+		t.Errorf("Expected 1 path, got %d", len(result2.Paths))
+	}
+	if result2.Paths[0].Name != "child" {
+		t.Errorf("Expected 'child', got '%s'", result2.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_Grandparent(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "Junior", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "John Doe", "")
+
+	// Test child to grandparent
+	result, err := svc.GetRelationship(ctx, child, grandfather)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if len(result.Paths) != 1 {
+		t.Errorf("Expected 1 path, got %d", len(result.Paths))
+	}
+	if result.Paths[0].Name != "grandparent" {
+		t.Errorf("Expected 'grandparent', got '%s'", result.Paths[0].Name)
+	}
+
+	// Test grandparent to child
+	result2, err := svc.GetRelationship(ctx, grandfather, child)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result2.Paths[0].Name != "grandchild" {
+		t.Errorf("Expected 'grandchild', got '%s'", result2.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_GreatGrandparent(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	greatGrandfather := createPerson(t, ctx, store, "Great", "Doe", domain.GenderMale)
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "Junior", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, grandfather, &greatGrandfather, nil, "Great Doe", "")
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "John Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child, greatGrandfather)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if result.Paths[0].Name != "great-grandparent" {
+		t.Errorf("Expected 'great-grandparent', got '%s'", result.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_Siblings(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	mother := createPerson(t, ctx, store, "Jane", "Doe", domain.GenderFemale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	child2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, child1, &father, &mother, "John Doe", "Jane Doe")
+	createParentChild(t, ctx, store, child2, &father, &mother, "John Doe", "Jane Doe")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	// Should have paths through both parents
+	foundSibling := false
+	for _, path := range result.Paths {
+		if path.Name == "sibling" {
+			foundSibling = true
+			if path.GenerationDistanceA != 1 || path.GenerationDistanceB != 1 {
+				t.Errorf("Expected generation distances (1, 1), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundSibling {
+		t.Error("Expected to find 'sibling' relationship")
+	}
+}
+
+func TestGetRelationship_FirstCousins(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree:
+	// grandfather
+	// ├── father -> child1
+	// └── uncle -> child2 (cousin)
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "James", "Doe", domain.GenderMale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	child2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, child1, &father, nil, "John Doe", "")
+	createParentChild(t, ctx, store, child2, &uncle, nil, "James Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundCousin := false
+	for _, path := range result.Paths {
+		if path.Name == "1st cousin" {
+			foundCousin = true
+			if path.GenerationDistanceA != 2 || path.GenerationDistanceB != 2 {
+				t.Errorf("Expected generation distances (2, 2), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundCousin {
+		t.Error("Expected to find '1st cousin' relationship")
+	}
+}
+
+func TestGetRelationship_FirstCousinOnceRemoved(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree:
+	// grandfather
+	// ├── father -> child1 -> grandchild1
+	// └── uncle -> cousin2
+	// grandchild1 and cousin2 are 1st cousins once removed
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "James", "Doe", domain.GenderMale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	cousin2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+	grandchild1 := createPerson(t, ctx, store, "Carol", "Doe", domain.GenderFemale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, child1, &father, nil, "John Doe", "")
+	createParentChild(t, ctx, store, cousin2, &uncle, nil, "James Doe", "")
+	createParentChild(t, ctx, store, grandchild1, &child1, nil, "Alice Doe", "")
+
+	result, err := svc.GetRelationship(ctx, grandchild1, cousin2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundCousinRemoved := false
+	for _, path := range result.Paths {
+		if path.Name == "1st cousin once removed" {
+			foundCousinRemoved = true
+			// grandchild1 is gen 3 from grandfather, cousin2 is gen 2
+			if path.GenerationDistanceA != 3 || path.GenerationDistanceB != 2 {
+				t.Errorf("Expected generation distances (3, 2), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundCousinRemoved {
+		t.Error("Expected to find '1st cousin once removed' relationship")
+	}
+}
+
+func TestGetRelationship_SecondCousins(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree:
+	// great-grandfather
+	// ├── grandfather1 -> father1 -> child1
+	// └── grandfather2 -> father2 -> child2
+	// child1 and child2 are 2nd cousins
+	greatGrandfather := createPerson(t, ctx, store, "Great", "Doe", domain.GenderMale)
+	grandfather1 := createPerson(t, ctx, store, "George1", "Doe", domain.GenderMale)
+	grandfather2 := createPerson(t, ctx, store, "George2", "Doe", domain.GenderMale)
+	father1 := createPerson(t, ctx, store, "John1", "Doe", domain.GenderMale)
+	father2 := createPerson(t, ctx, store, "John2", "Doe", domain.GenderMale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	child2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, grandfather1, &greatGrandfather, nil, "Great Doe", "")
+	createParentChild(t, ctx, store, grandfather2, &greatGrandfather, nil, "Great Doe", "")
+	createParentChild(t, ctx, store, father1, &grandfather1, nil, "George1 Doe", "")
+	createParentChild(t, ctx, store, father2, &grandfather2, nil, "George2 Doe", "")
+	createParentChild(t, ctx, store, child1, &father1, nil, "John1 Doe", "")
+	createParentChild(t, ctx, store, child2, &father2, nil, "John2 Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundSecondCousin := false
+	for _, path := range result.Paths {
+		if path.Name == "2nd cousin" {
+			foundSecondCousin = true
+			// Both are gen 3 from great-grandfather
+			if path.GenerationDistanceA != 3 || path.GenerationDistanceB != 3 {
+				t.Errorf("Expected generation distances (3, 3), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundSecondCousin {
+		t.Error("Expected to find '2nd cousin' relationship")
+	}
+}
+
+func TestGetRelationship_UncleNiece(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree:
+	// grandfather
+	// ├── father -> niece
+	// └── uncle
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "James", "Doe", domain.GenderMale)
+	niece := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, niece, &father, nil, "John Doe", "")
+
+	// Test niece to uncle
+	result, err := svc.GetRelationship(ctx, niece, uncle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundUncle := false
+	for _, path := range result.Paths {
+		if path.Name == "uncle/aunt" {
+			foundUncle = true
+			if path.GenerationDistanceA != 2 || path.GenerationDistanceB != 1 {
+				t.Errorf("Expected generation distances (2, 1), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundUncle {
+		t.Error("Expected to find 'uncle/aunt' relationship")
+	}
+
+	// Test uncle to niece
+	result2, err := svc.GetRelationship(ctx, uncle, niece)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundNephew := false
+	for _, path := range result2.Paths {
+		if path.Name == "nephew/niece" {
+			foundNephew = true
+		}
+	}
+	if !foundNephew {
+		t.Error("Expected to find 'nephew/niece' relationship")
+	}
+}
+
+func TestGetRelationship_MultiplePaths(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree where siblings share both parents:
+	// father --- mother
+	//    \      /
+	//    child1  child2
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	mother := createPerson(t, ctx, store, "Jane", "Doe", domain.GenderFemale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	child2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, child1, &father, &mother, "John Doe", "Jane Doe")
+	createParentChild(t, ctx, store, child2, &father, &mother, "John Doe", "Jane Doe")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	// Should have 2 paths - one through father and one through mother
+	if len(result.Paths) < 2 {
+		t.Errorf("Expected at least 2 paths for full siblings, got %d", len(result.Paths))
+	}
+}
+
+func TestGetRelationship_CycleDetection(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Create a circular reference (which shouldn't happen in real data)
+	person1 := createPerson(t, ctx, store, "Person1", "Test", domain.GenderMale)
+	person2 := createPerson(t, ctx, store, "Person2", "Test", domain.GenderFemale)
+
+	// Create circular edge (person1's father is person2, person2's father is person1)
+	createParentChild(t, ctx, store, person1, &person2, nil, "Person2 Test", "")
+	createParentChild(t, ctx, store, person2, &person1, nil, "Person1 Test", "")
+
+	// Should not infinite loop
+	result, err := svc.GetRelationship(ctx, person1, person2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be related (person2 is father of person1)
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+}
+
+func TestGetRelationship_GreatGreatGrandparent(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build 5 generations
+	gen4 := createPerson(t, ctx, store, "Gen4", "Doe", domain.GenderMale)
+	gen3 := createPerson(t, ctx, store, "Gen3", "Doe", domain.GenderMale)
+	gen2 := createPerson(t, ctx, store, "Gen2", "Doe", domain.GenderMale)
+	gen1 := createPerson(t, ctx, store, "Gen1", "Doe", domain.GenderMale)
+	gen0 := createPerson(t, ctx, store, "Gen0", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, gen3, &gen4, nil, "Gen4 Doe", "")
+	createParentChild(t, ctx, store, gen2, &gen3, nil, "Gen3 Doe", "")
+	createParentChild(t, ctx, store, gen1, &gen2, nil, "Gen2 Doe", "")
+	createParentChild(t, ctx, store, gen0, &gen1, nil, "Gen1 Doe", "")
+
+	result, err := svc.GetRelationship(ctx, gen0, gen4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if result.Paths[0].Name != "great-great-grandparent" {
+		t.Errorf("Expected 'great-great-grandparent', got '%s'", result.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_ThirdCousins(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build family tree for 3rd cousins (share great-great-grandparent)
+	ggGrandfather := createPerson(t, ctx, store, "GG", "Doe", domain.GenderMale)
+
+	gGrandfather1 := createPerson(t, ctx, store, "GGF1", "Doe", domain.GenderMale)
+	gGrandfather2 := createPerson(t, ctx, store, "GGF2", "Doe", domain.GenderMale)
+
+	grandfather1 := createPerson(t, ctx, store, "GF1", "Doe", domain.GenderMale)
+	grandfather2 := createPerson(t, ctx, store, "GF2", "Doe", domain.GenderMale)
+
+	father1 := createPerson(t, ctx, store, "F1", "Doe", domain.GenderMale)
+	father2 := createPerson(t, ctx, store, "F2", "Doe", domain.GenderMale)
+
+	child1 := createPerson(t, ctx, store, "C1", "Doe", domain.GenderMale)
+	child2 := createPerson(t, ctx, store, "C2", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, gGrandfather1, &ggGrandfather, nil, "GG Doe", "")
+	createParentChild(t, ctx, store, gGrandfather2, &ggGrandfather, nil, "GG Doe", "")
+	createParentChild(t, ctx, store, grandfather1, &gGrandfather1, nil, "GGF1 Doe", "")
+	createParentChild(t, ctx, store, grandfather2, &gGrandfather2, nil, "GGF2 Doe", "")
+	createParentChild(t, ctx, store, father1, &grandfather1, nil, "GF1 Doe", "")
+	createParentChild(t, ctx, store, father2, &grandfather2, nil, "GF2 Doe", "")
+	createParentChild(t, ctx, store, child1, &father1, nil, "F1 Doe", "")
+	createParentChild(t, ctx, store, child2, &father2, nil, "F2 Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundThirdCousin := false
+	for _, path := range result.Paths {
+		if path.Name == "3rd cousin" {
+			foundThirdCousin = true
+			// Both are gen 4 from gg-grandfather
+			if path.GenerationDistanceA != 4 || path.GenerationDistanceB != 4 {
+				t.Errorf("Expected generation distances (4, 4), got (%d, %d)",
+					path.GenerationDistanceA, path.GenerationDistanceB)
+			}
+		}
+	}
+	if !foundThirdCousin {
+		t.Error("Expected to find '3rd cousin' relationship")
+	}
+}
+
+func TestGetRelationship_FirstCousinTwiceRemoved(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// grandfather -> father -> child -> grandchild -> greatGrandchild
+	//            \-> uncle -> cousin
+	// greatGrandchild and cousin are 1st cousins twice removed
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "U", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+	cousin := createPerson(t, ctx, store, "Cousin", "Doe", domain.GenderMale)
+	grandchild := createPerson(t, ctx, store, "GC", "Doe", domain.GenderMale)
+	greatGrandchild := createPerson(t, ctx, store, "GGC", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+	createParentChild(t, ctx, store, cousin, &uncle, nil, "U Doe", "")
+	createParentChild(t, ctx, store, grandchild, &child, nil, "C Doe", "")
+	createParentChild(t, ctx, store, greatGrandchild, &grandchild, nil, "GC Doe", "")
+
+	result, err := svc.GetRelationship(ctx, greatGrandchild, cousin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundCousinTwiceRemoved := false
+	for _, path := range result.Paths {
+		if path.Name == "1st cousin twice removed" {
+			foundCousinTwiceRemoved = true
+		}
+	}
+	if !foundCousinTwiceRemoved {
+		t.Error("Expected to find '1st cousin twice removed' relationship")
+	}
+}
+
+func TestGetRelationship_GrandUncle(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// great-grandfather
+	// ├── grandfather -> father -> child
+	// └── grand-uncle
+	greatGrandfather := createPerson(t, ctx, store, "GGF", "Doe", domain.GenderMale)
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	grandUncle := createPerson(t, ctx, store, "GU", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, grandfather, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, grandUncle, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child, grandUncle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundGrandUncle := false
+	for _, path := range result.Paths {
+		if path.Name == "grand-uncle/aunt" {
+			foundGrandUncle = true
+		}
+	}
+	if !foundGrandUncle {
+		t.Error("Expected to find 'grand-uncle/aunt' relationship")
+	}
+}
+
+func TestGetRelationship_GreatGrandUncle(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// 2nd-great-grandfather
+	// ├── great-grandfather -> grandfather -> father -> child
+	// └── great-grand-uncle
+	ggGrandfather := createPerson(t, ctx, store, "GGG", "Doe", domain.GenderMale)
+	greatGrandfather := createPerson(t, ctx, store, "GGF", "Doe", domain.GenderMale)
+	greatGrandUncle := createPerson(t, ctx, store, "GGU", "Doe", domain.GenderMale)
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, greatGrandfather, &ggGrandfather, nil, "GGG Doe", "")
+	createParentChild(t, ctx, store, greatGrandUncle, &ggGrandfather, nil, "GGG Doe", "")
+	createParentChild(t, ctx, store, grandfather, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child, greatGrandUncle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundGreatGrandUncle := false
+	for _, path := range result.Paths {
+		if path.Name == "great-grand-uncle/aunt" {
+			foundGreatGrandUncle = true
+		}
+	}
+	if !foundGreatGrandUncle {
+		t.Error("Expected to find 'great-grand-uncle/aunt' relationship")
+	}
+}
+
+func TestGetRelationship_GrandNephew(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// great-grandfather
+	// ├── grandfather -> father -> child
+	// └── grand-uncle
+	// Test: grand-uncle to child (grand-nephew/niece)
+	greatGrandfather := createPerson(t, ctx, store, "GGF", "Doe", domain.GenderMale)
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	grandUncle := createPerson(t, ctx, store, "GU", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, grandfather, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, grandUncle, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+
+	result, err := svc.GetRelationship(ctx, grandUncle, child)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundGrandNephew := false
+	for _, path := range result.Paths {
+		if path.Name == "grand-nephew/niece" {
+			foundGrandNephew = true
+		}
+	}
+	if !foundGrandNephew {
+		t.Error("Expected to find 'grand-nephew/niece' relationship")
+	}
+}
+
+func TestRelationshipService_OrdinalNumbers(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Create a structure for 11th cousin (requires 12 generations to common ancestor)
+	// This tests the ordinal function for special cases like 11th, 12th, 13th
+	// For simplicity, we'll just verify 4th cousin (which uses "4th")
+
+	// 3rd-great-grandfather
+	// ├── 2nd-great-grandfather1 -> great-grandfather1 -> grandfather1 -> father1 -> child1
+	// └── 2nd-great-grandfather2 -> great-grandfather2 -> grandfather2 -> father2 -> child2
+
+	ancestor := createPerson(t, ctx, store, "Ancestor", "Doe", domain.GenderMale)
+
+	// Build left branch
+	left1 := createPerson(t, ctx, store, "L1", "Doe", domain.GenderMale)
+	left2 := createPerson(t, ctx, store, "L2", "Doe", domain.GenderMale)
+	left3 := createPerson(t, ctx, store, "L3", "Doe", domain.GenderMale)
+	left4 := createPerson(t, ctx, store, "L4", "Doe", domain.GenderMale)
+	left5 := createPerson(t, ctx, store, "L5", "Doe", domain.GenderMale)
+
+	// Build right branch
+	right1 := createPerson(t, ctx, store, "R1", "Doe", domain.GenderMale)
+	right2 := createPerson(t, ctx, store, "R2", "Doe", domain.GenderMale)
+	right3 := createPerson(t, ctx, store, "R3", "Doe", domain.GenderMale)
+	right4 := createPerson(t, ctx, store, "R4", "Doe", domain.GenderMale)
+	right5 := createPerson(t, ctx, store, "R5", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, left1, &ancestor, nil, "Ancestor Doe", "")
+	createParentChild(t, ctx, store, left2, &left1, nil, "L1 Doe", "")
+	createParentChild(t, ctx, store, left3, &left2, nil, "L2 Doe", "")
+	createParentChild(t, ctx, store, left4, &left3, nil, "L3 Doe", "")
+	createParentChild(t, ctx, store, left5, &left4, nil, "L4 Doe", "")
+
+	createParentChild(t, ctx, store, right1, &ancestor, nil, "Ancestor Doe", "")
+	createParentChild(t, ctx, store, right2, &right1, nil, "R1 Doe", "")
+	createParentChild(t, ctx, store, right3, &right2, nil, "R2 Doe", "")
+	createParentChild(t, ctx, store, right4, &right3, nil, "R3 Doe", "")
+	createParentChild(t, ctx, store, right5, &right4, nil, "R4 Doe", "")
+
+	result, err := svc.GetRelationship(ctx, left5, right5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundFourthCousin := false
+	for _, path := range result.Paths {
+		if path.Name == "4th cousin" {
+			foundFourthCousin = true
+		}
+	}
+	if !foundFourthCousin {
+		t.Error("Expected to find '4th cousin' relationship")
+	}
+}
+
+func TestGetRelationship_SummaryWithMultiplePaths(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Full siblings have paths through both parents
+	father := createPerson(t, ctx, store, "Father", "Doe", domain.GenderMale)
+	mother := createPerson(t, ctx, store, "Mother", "Doe", domain.GenderFemale)
+	child1 := createPerson(t, ctx, store, "Child1", "Doe", domain.GenderMale)
+	child2 := createPerson(t, ctx, store, "Child2", "Doe", domain.GenderFemale)
+
+	createParentChild(t, ctx, store, child1, &father, &mother, "Father Doe", "Mother Doe")
+	createParentChild(t, ctx, store, child2, &father, &mother, "Father Doe", "Mother Doe")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Summary should indicate multiple paths
+	if result.Summary == "" {
+		t.Error("Expected non-empty summary")
+	}
+}
+
+func TestGetRelationship_PathContainsCorrectIDs(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child, grandfather)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Paths) != 1 {
+		t.Fatalf("Expected 1 path, got %d", len(result.Paths))
+	}
+
+	path := result.Paths[0]
+
+	// PathFromA should be: child -> father -> grandfather
+	if len(path.PathFromA) != 3 {
+		t.Errorf("Expected PathFromA length 3, got %d", len(path.PathFromA))
+	}
+	if path.PathFromA[0] != child {
+		t.Error("PathFromA[0] should be child")
+	}
+	if path.PathFromA[1] != father {
+		t.Error("PathFromA[1] should be father")
+	}
+	if path.PathFromA[2] != grandfather {
+		t.Error("PathFromA[2] should be grandfather")
+	}
+
+	// PathFromB should be just: grandfather
+	if len(path.PathFromB) != 1 {
+		t.Errorf("Expected PathFromB length 1, got %d", len(path.PathFromB))
+	}
+	if path.PathFromB[0] != grandfather {
+		t.Error("PathFromB[0] should be grandfather")
+	}
+}
+
+func TestGetRelationship_CommonAncestorField(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	grandfather := createPerson(t, ctx, store, "George", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "John", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "James", "Doe", domain.GenderMale)
+	child1 := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	child2 := createPerson(t, ctx, store, "Bob", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "George Doe", "")
+	createParentChild(t, ctx, store, child1, &father, nil, "John Doe", "")
+	createParentChild(t, ctx, store, child2, &uncle, nil, "James Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child1, child2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Paths) == 0 {
+		t.Fatal("Expected at least one path")
+	}
+
+	// Common ancestor should be grandfather
+	if result.Paths[0].CommonAncestor == nil {
+		t.Fatal("CommonAncestor should not be nil")
+	}
+	if result.Paths[0].CommonAncestor.ID != grandfather {
+		t.Errorf("Expected common ancestor ID %v, got %v", grandfather, result.Paths[0].CommonAncestor.ID)
+	}
+	if result.Paths[0].CommonAncestor.GivenName != "George" {
+		t.Errorf("Expected common ancestor name 'George', got '%s'", result.Paths[0].CommonAncestor.GivenName)
+	}
+}
+
+func TestGetRelationship_PersonAAndBFields(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	personA := createPerson(t, ctx, store, "Alice", "Doe", domain.GenderFemale)
+	personB := createPerson(t, ctx, store, "Bob", "Smith", domain.GenderMale)
+
+	result, err := svc.GetRelationship(ctx, personA, personB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.PersonA == nil {
+		t.Fatal("PersonA should not be nil")
+	}
+	if result.PersonB == nil {
+		t.Fatal("PersonB should not be nil")
+	}
+
+	if result.PersonA.ID != personA {
+		t.Errorf("Expected PersonA ID %v, got %v", personA, result.PersonA.ID)
+	}
+	if result.PersonA.GivenName != "Alice" {
+		t.Errorf("Expected PersonA name 'Alice', got '%s'", result.PersonA.GivenName)
+	}
+
+	if result.PersonB.ID != personB {
+		t.Errorf("Expected PersonB ID %v, got %v", personB, result.PersonB.ID)
+	}
+	if result.PersonB.GivenName != "Bob" {
+		t.Errorf("Expected PersonB name 'Bob', got '%s'", result.PersonB.GivenName)
+	}
+}
+
+func TestGetRelationship_3rdGreatGrandparent(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Build 6 generations for 3rd great-grandparent
+	gen5 := createPerson(t, ctx, store, "Gen5", "Doe", domain.GenderMale)
+	gen4 := createPerson(t, ctx, store, "Gen4", "Doe", domain.GenderMale)
+	gen3 := createPerson(t, ctx, store, "Gen3", "Doe", domain.GenderMale)
+	gen2 := createPerson(t, ctx, store, "Gen2", "Doe", domain.GenderMale)
+	gen1 := createPerson(t, ctx, store, "Gen1", "Doe", domain.GenderMale)
+	gen0 := createPerson(t, ctx, store, "Gen0", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, gen4, &gen5, nil, "Gen5 Doe", "")
+	createParentChild(t, ctx, store, gen3, &gen4, nil, "Gen4 Doe", "")
+	createParentChild(t, ctx, store, gen2, &gen3, nil, "Gen3 Doe", "")
+	createParentChild(t, ctx, store, gen1, &gen2, nil, "Gen2 Doe", "")
+	createParentChild(t, ctx, store, gen0, &gen1, nil, "Gen1 Doe", "")
+
+	result, err := svc.GetRelationship(ctx, gen0, gen5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+	if result.Paths[0].Name != "3rd great-grandparent" {
+		t.Errorf("Expected '3rd great-grandparent', got '%s'", result.Paths[0].Name)
+	}
+
+	// Test reverse direction (3rd great-grandchild)
+	result2, err := svc.GetRelationship(ctx, gen5, gen0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2.Paths[0].Name != "3rd great-grandchild" {
+		t.Errorf("Expected '3rd great-grandchild', got '%s'", result2.Paths[0].Name)
+	}
+}
+
+func TestGetRelationship_1stCousinThreeTimesRemoved(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Create family tree for 1st cousin 3 times removed
+	// grandfather -> father -> child -> grandchild -> greatGrandchild -> ggGreatGrandchild
+	//            \-> uncle -> cousin
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "U", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+	cousin := createPerson(t, ctx, store, "Cousin", "Doe", domain.GenderMale)
+	grandchild := createPerson(t, ctx, store, "GC", "Doe", domain.GenderMale)
+	greatGrandchild := createPerson(t, ctx, store, "GGC", "Doe", domain.GenderMale)
+	ggGreatGrandchild := createPerson(t, ctx, store, "GGGC", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+	createParentChild(t, ctx, store, cousin, &uncle, nil, "U Doe", "")
+	createParentChild(t, ctx, store, grandchild, &child, nil, "C Doe", "")
+	createParentChild(t, ctx, store, greatGrandchild, &grandchild, nil, "GC Doe", "")
+	createParentChild(t, ctx, store, ggGreatGrandchild, &greatGrandchild, nil, "GGC Doe", "")
+
+	result, err := svc.GetRelationship(ctx, ggGreatGrandchild, cousin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundCousinThrice := false
+	for _, path := range result.Paths {
+		if path.Name == "1st cousin thrice removed" {
+			foundCousinThrice = true
+		}
+	}
+	if !foundCousinThrice {
+		t.Errorf("Expected to find '1st cousin thrice removed' relationship, got paths: %v", result.Paths)
+	}
+}
+
+func TestGetRelationship_1stCousinFourTimesRemoved(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Create family tree for 1st cousin 4 times removed
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	uncle := createPerson(t, ctx, store, "U", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+	cousin := createPerson(t, ctx, store, "Cousin", "Doe", domain.GenderMale)
+	grandchild := createPerson(t, ctx, store, "GC", "Doe", domain.GenderMale)
+	greatGrandchild := createPerson(t, ctx, store, "GGC", "Doe", domain.GenderMale)
+	ggGreatGrandchild := createPerson(t, ctx, store, "GGGC", "Doe", domain.GenderMale)
+	gggGreatGrandchild := createPerson(t, ctx, store, "GGGGC", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, uncle, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+	createParentChild(t, ctx, store, cousin, &uncle, nil, "U Doe", "")
+	createParentChild(t, ctx, store, grandchild, &child, nil, "C Doe", "")
+	createParentChild(t, ctx, store, greatGrandchild, &grandchild, nil, "GC Doe", "")
+	createParentChild(t, ctx, store, ggGreatGrandchild, &greatGrandchild, nil, "GGC Doe", "")
+	createParentChild(t, ctx, store, gggGreatGrandchild, &ggGreatGrandchild, nil, "GGGC Doe", "")
+
+	result, err := svc.GetRelationship(ctx, gggGreatGrandchild, cousin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundCousinFourTimes := false
+	for _, path := range result.Paths {
+		if path.Name == "1st cousin 4 times removed" {
+			foundCousinFourTimes = true
+		}
+	}
+	if !foundCousinFourTimes {
+		t.Errorf("Expected to find '1st cousin 4 times removed' relationship, got paths: %v", result.Paths)
+	}
+}
+
+func TestGetRelationship_2ndGreatGrandUncle(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// 3rd-great-grandfather
+	// ├── 2nd-great-grandfather -> great-grandfather -> grandfather -> father -> child
+	// └── 2nd-great-grand-uncle
+	gggGrandfather := createPerson(t, ctx, store, "GGGG", "Doe", domain.GenderMale)
+	ggGrandfather := createPerson(t, ctx, store, "GGG", "Doe", domain.GenderMale)
+	ggGrandUncle := createPerson(t, ctx, store, "GGGU", "Doe", domain.GenderMale)
+	greatGrandfather := createPerson(t, ctx, store, "GGF", "Doe", domain.GenderMale)
+	grandfather := createPerson(t, ctx, store, "GF", "Doe", domain.GenderMale)
+	father := createPerson(t, ctx, store, "F", "Doe", domain.GenderMale)
+	child := createPerson(t, ctx, store, "C", "Doe", domain.GenderMale)
+
+	createParentChild(t, ctx, store, ggGrandfather, &gggGrandfather, nil, "GGGG Doe", "")
+	createParentChild(t, ctx, store, ggGrandUncle, &gggGrandfather, nil, "GGGG Doe", "")
+	createParentChild(t, ctx, store, greatGrandfather, &ggGrandfather, nil, "GGG Doe", "")
+	createParentChild(t, ctx, store, grandfather, &greatGrandfather, nil, "GGF Doe", "")
+	createParentChild(t, ctx, store, father, &grandfather, nil, "GF Doe", "")
+	createParentChild(t, ctx, store, child, &father, nil, "F Doe", "")
+
+	result, err := svc.GetRelationship(ctx, child, ggGrandUncle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	foundGGGrandUncle := false
+	for _, path := range result.Paths {
+		if path.Name == "great-great-grand-uncle/aunt" {
+			foundGGGrandUncle = true
+		}
+	}
+	if !foundGGGrandUncle {
+		t.Errorf("Expected to find 'great-great-grand-uncle/aunt' relationship, got paths: %v", result.Paths)
+	}
+}
+
+func TestGetRelationship_OrdinalEdgeCases(t *testing.T) {
+	store := memory.NewReadModelStore()
+	svc := query.NewRelationshipService(store)
+	ctx := context.Background()
+
+	// Create 11th cousin (requires 12 generations to common ancestor)
+	// Testing ordinal 11th (11th ends in 1 but is "th" not "st")
+	// Build a deep family tree
+
+	// For 11th cousins, both need to be 12 generations from common ancestor
+	// That's a lot of people, so let's just test the naming directly
+	// by creating a simpler structure that tests the ordinal edge cases
+
+	// Create 5th cousins (gen 6 from common ancestor)
+	ancestor := createPerson(t, ctx, store, "Ancestor", "Doe", domain.GenderMale)
+
+	// Build branches
+	var leftBranch [6]uuid.UUID
+	var rightBranch [6]uuid.UUID
+
+	leftBranch[0] = createPerson(t, ctx, store, "L0", "Doe", domain.GenderMale)
+	createParentChild(t, ctx, store, leftBranch[0], &ancestor, nil, "Ancestor Doe", "")
+
+	for i := 1; i < 6; i++ {
+		leftBranch[i] = createPerson(t, ctx, store, "L"+string(rune('0'+i)), "Doe", domain.GenderMale)
+		createParentChild(t, ctx, store, leftBranch[i], &leftBranch[i-1], nil, "L"+string(rune('0'+i-1))+" Doe", "")
+	}
+
+	rightBranch[0] = createPerson(t, ctx, store, "R0", "Doe", domain.GenderMale)
+	createParentChild(t, ctx, store, rightBranch[0], &ancestor, nil, "Ancestor Doe", "")
+
+	for i := 1; i < 6; i++ {
+		rightBranch[i] = createPerson(t, ctx, store, "R"+string(rune('0'+i)), "Doe", domain.GenderMale)
+		createParentChild(t, ctx, store, rightBranch[i], &rightBranch[i-1], nil, "R"+string(rune('0'+i-1))+" Doe", "")
+	}
+
+	result, err := svc.GetRelationship(ctx, leftBranch[5], rightBranch[5])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.IsRelated {
+		t.Error("Expected IsRelated to be true")
+	}
+
+	found5thCousin := false
+	for _, path := range result.Paths {
+		if path.Name == "5th cousin" {
+			found5thCousin = true
+		}
+	}
+	if !found5thCousin {
+		t.Errorf("Expected to find '5th cousin' relationship, got paths: %v", result.Paths)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -418,6 +418,24 @@ export interface MediaListResponse {
 	total: number;
 }
 
+// Relationship types
+export interface RelationshipPath {
+	name?: string;
+	pathFromA?: string[];
+	pathFromB?: string[];
+	commonAncestorId?: string;
+	generationDistanceA?: number;
+	generationDistanceB?: number;
+}
+
+export interface RelationshipResult {
+	personA?: Person;
+	personB?: Person;
+	paths?: RelationshipPath[];
+	isRelated?: boolean;
+	summary?: string;
+}
+
 // Browse types
 export interface SurnameIndexResponse {
 	items: SurnameEntry[];
@@ -951,6 +969,14 @@ class ApiClient {
 		return this.request<PersonList>(
 			'GET',
 			`/browse/places/${encodeURIComponent(place)}/persons${query ? `?${query}` : ''}`
+		);
+	}
+
+	// Relationship endpoint
+	async getRelationship(personId1: string, personId2: string): Promise<RelationshipResult> {
+		return this.request<RelationshipResult>(
+			'GET',
+			`/relationship/${encodeURIComponent(personId1)}/${encodeURIComponent(personId2)}`
 		);
 	}
 }

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -1118,6 +1118,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/relationship/{personId1}/{personId2}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Calculate relationship between two people */
+        get: operations["getRelationship"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2117,6 +2134,24 @@ export interface components {
             has_more: boolean;
             /** @description True if snapshot1 is the older (lower position) snapshot */
             older_first: boolean;
+        };
+        RelationshipPath: {
+            /** @description Relationship name (e.g., "1st cousin once removed") */
+            name?: string;
+            pathFromA?: string[];
+            pathFromB?: string[];
+            /** Format: uuid */
+            commonAncestorId?: string;
+            generationDistanceA?: number;
+            generationDistanceB?: number;
+        };
+        RelationshipResult: {
+            personA?: components["schemas"]["Person"];
+            personB?: components["schemas"]["Person"];
+            paths?: components["schemas"]["RelationshipPath"][];
+            isRelated?: boolean;
+            /** @description Human-readable relationship summary */
+            summary?: string;
         };
     };
     responses: {
@@ -4125,6 +4160,38 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
+        };
+    };
+    getRelationship: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                personId1: string;
+                personId2: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Relationship calculated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelationshipResult"];
+                };
+            };
+            /** @description One or both persons not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
 }

--- a/web/src/lib/components/PersonSelector.svelte
+++ b/web/src/lib/components/PersonSelector.svelte
@@ -1,0 +1,527 @@
+<script lang="ts">
+	import { api, type SearchResult, type Person, formatPersonName, formatLifespan } from '$lib/api/client';
+
+	interface Props {
+		label: string;
+		selectedPerson?: Person | SearchResult | null;
+		onSelect?: (person: SearchResult | null) => void;
+		placeholder?: string;
+		disabled?: boolean;
+	}
+
+	let { label, selectedPerson = null, onSelect, placeholder = 'Search for a person...', disabled = false }: Props = $props();
+
+	let query = $state('');
+	let results: SearchResult[] = $state([]);
+	let loading = $state(false);
+	let showDropdown = $state(false);
+	let highlightedIndex = $state(-1);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let inputRef: HTMLInputElement | undefined = $state();
+	let dropdownRef: HTMLDivElement | undefined = $state();
+
+	// Computed aria-activedescendant value
+	let activeDescendant = $derived(
+		highlightedIndex >= 0 ? `person-selector-result-${highlightedIndex}` : undefined
+	);
+
+	// Reset highlighted index when results change
+	$effect(() => {
+		results;
+		highlightedIndex = -1;
+	});
+
+	// Scroll highlighted item into view
+	$effect(() => {
+		if (highlightedIndex >= 0 && dropdownRef) {
+			const highlightedEl = dropdownRef.querySelector(`#person-selector-result-${highlightedIndex}`);
+			highlightedEl?.scrollIntoView({ block: 'nearest' });
+		}
+	});
+
+	async function search(searchQuery: string) {
+		if (searchQuery.length < 2) {
+			results = [];
+			return;
+		}
+
+		loading = true;
+		try {
+			const response = await api.searchPersons({
+				q: searchQuery,
+				fuzzy: true,
+				limit: 8
+			});
+			results = response.items;
+		} catch {
+			results = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleInput(e: Event) {
+		const input = e.target as HTMLInputElement;
+		query = input.value;
+		showDropdown = true;
+
+		// Debounce search
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+		debounceTimer = setTimeout(() => {
+			search(query);
+		}, 300);
+	}
+
+	function handleSelect(person: SearchResult) {
+		query = '';
+		showDropdown = false;
+		highlightedIndex = -1;
+		results = [];
+		onSelect?.(person);
+	}
+
+	function handleClear() {
+		query = '';
+		showDropdown = false;
+		highlightedIndex = -1;
+		results = [];
+		onSelect?.(null);
+		inputRef?.focus();
+	}
+
+	function handleFocus() {
+		if (query.length >= 2 && results.length > 0) {
+			showDropdown = true;
+		}
+	}
+
+	function handleBlur() {
+		// Delay hiding dropdown to allow click events to fire
+		setTimeout(() => {
+			showDropdown = false;
+			highlightedIndex = -1;
+		}, 200);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		// Handle Escape
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			showDropdown = false;
+			highlightedIndex = -1;
+			return;
+		}
+
+		// Handle Tab
+		if (e.key === 'Tab') {
+			showDropdown = false;
+			highlightedIndex = -1;
+			return;
+		}
+
+		// Only handle navigation keys when dropdown is open with results
+		if (!showDropdown || results.length === 0) {
+			return;
+		}
+
+		switch (e.key) {
+			case 'ArrowDown':
+				e.preventDefault();
+				highlightedIndex = (highlightedIndex + 1) % results.length;
+				break;
+			case 'ArrowUp':
+				e.preventDefault();
+				highlightedIndex = highlightedIndex <= 0 ? results.length - 1 : highlightedIndex - 1;
+				break;
+			case 'Enter':
+				if (highlightedIndex >= 0) {
+					e.preventDefault();
+					handleSelect(results[highlightedIndex]);
+				}
+				break;
+		}
+	}
+
+	function getGenderBgClass(gender?: string): string {
+		if (gender === 'male') return 'bg-blue-100 text-blue-600';
+		if (gender === 'female') return 'bg-pink-100 text-pink-600';
+		return 'bg-slate-100 text-slate-500';
+	}
+</script>
+
+<div class="person-selector">
+	<span class="selector-label" id="person-selector-label-{label.replace(/\s+/g, '-').toLowerCase()}">{label}</span>
+
+	{#if selectedPerson}
+		<!-- Selected person display -->
+		<div class="selected-person" data-gender={selectedPerson.gender}>
+			<div class="person-avatar {getGenderBgClass(selectedPerson.gender)}">
+				<svg viewBox="0 0 24 24" fill="currentColor">
+					<path d="M12 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM6 8a6 6 0 1 1 12 0A6 6 0 0 1 6 8zm2 10a3 3 0 0 0-3 3 1 1 0 1 1-2 0 5 5 0 0 1 5-5h8a5 5 0 0 1 5 5 1 1 0 1 1-2 0 3 3 0 0 0-3-3H8z" />
+				</svg>
+			</div>
+			<div class="person-info">
+				<span class="person-name">{formatPersonName(selectedPerson)}</span>
+				<span class="person-lifespan">{formatLifespan(selectedPerson)}</span>
+			</div>
+			<button
+				type="button"
+				class="clear-btn"
+				onclick={handleClear}
+				aria-label="Clear selection"
+				{disabled}
+			>
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M18 6L6 18M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	{:else}
+		<!-- Search input -->
+		<div class="input-wrapper">
+			<svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<circle cx="11" cy="11" r="8" />
+				<path d="m21 21-4.35-4.35" />
+			</svg>
+			<input
+				bind:this={inputRef}
+				type="text"
+				value={query}
+				oninput={handleInput}
+				onfocus={handleFocus}
+				onblur={handleBlur}
+				onkeydown={handleKeydown}
+				{placeholder}
+				{disabled}
+				aria-label={label}
+				aria-expanded={showDropdown}
+				aria-haspopup="listbox"
+				aria-controls="person-selector-listbox"
+				aria-autocomplete="list"
+				aria-activedescendant={activeDescendant}
+				role="combobox"
+			/>
+			{#if loading}
+				<span class="loading-indicator"></span>
+			{/if}
+		</div>
+
+		<!-- Screen reader announcement -->
+		<div class="sr-only" aria-live="polite" aria-atomic="true">
+			{#if results.length > 0}
+				{results.length} result{results.length === 1 ? '' : 's'} found
+			{:else if query.length >= 2 && !loading && showDropdown}
+				No results found
+			{/if}
+		</div>
+
+		<!-- Dropdown results -->
+		{#if showDropdown && (results.length > 0 || (query.length >= 2 && !loading))}
+			<div
+				bind:this={dropdownRef}
+				class="dropdown"
+				role="listbox"
+				id="person-selector-listbox"
+				aria-label="Search results"
+			>
+				{#if results.length === 0}
+					<div class="no-results">No people found</div>
+				{:else}
+					{#each results as person, index}
+						<button
+							id="person-selector-result-{index}"
+							type="button"
+							class="result-item"
+							class:highlighted={index === highlightedIndex}
+							onclick={() => handleSelect(person)}
+							role="option"
+							aria-selected={index === highlightedIndex}
+						>
+							<div class="result-avatar {getGenderBgClass(person.gender)}">
+								<svg viewBox="0 0 24 24" fill="currentColor">
+									<path d="M12 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM6 8a6 6 0 1 1 12 0A6 6 0 0 1 6 8zm2 10a3 3 0 0 0-3 3 1 1 0 1 1-2 0 5 5 0 0 1 5-5h8a5 5 0 0 1 5 5 1 1 0 1 1-2 0 3 3 0 0 0-3-3H8z" />
+								</svg>
+							</div>
+							<div class="result-info">
+								<span class="result-name">{formatPersonName(person)}</span>
+								<span class="result-lifespan">{formatLifespan(person)}</span>
+							</div>
+						</button>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.person-selector {
+		position: relative;
+		width: 100%;
+	}
+
+	.selector-label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: #374151;
+		cursor: default;
+	}
+
+	/* Selected person display */
+	.selected-person {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		background: white;
+		border: 2px solid #3b82f6;
+		border-radius: 8px;
+	}
+
+	.person-avatar {
+		flex-shrink: 0;
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.person-avatar svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	.person-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.person-name {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: #1e293b;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.person-lifespan {
+		font-size: 0.8125rem;
+		color: #64748b;
+	}
+
+	.clear-btn {
+		flex-shrink: 0;
+		padding: 0.375rem;
+		border: none;
+		border-radius: 6px;
+		background: transparent;
+		color: #94a3b8;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.clear-btn:hover:not(:disabled) {
+		background: #f1f5f9;
+		color: #64748b;
+	}
+
+	.clear-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.clear-btn svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	/* Search input */
+	.input-wrapper {
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+
+	.search-icon {
+		position: absolute;
+		left: 0.75rem;
+		width: 1.125rem;
+		height: 1.125rem;
+		color: #94a3b8;
+		pointer-events: none;
+	}
+
+	input {
+		width: 100%;
+		padding: 0.75rem 2.5rem 0.75rem 2.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 8px;
+		font-size: 0.9375rem;
+		background: white;
+		transition: border-color 0.15s, box-shadow 0.15s;
+	}
+
+	input:focus {
+		outline: none;
+		border-color: #3b82f6;
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+	}
+
+	input:disabled {
+		background: #f9fafb;
+		cursor: not-allowed;
+	}
+
+	.loading-indicator {
+		position: absolute;
+		right: 0.75rem;
+		width: 1rem;
+		height: 1rem;
+		border: 2px solid #e2e8f0;
+		border-top-color: #3b82f6;
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* Screen reader only */
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	/* Dropdown */
+	.dropdown {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		right: 0;
+		background: white;
+		border: 1px solid #e2e8f0;
+		border-radius: 8px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		z-index: 100;
+		max-height: 280px;
+		overflow-y: auto;
+	}
+
+	.no-results {
+		padding: 1rem;
+		color: #94a3b8;
+		font-size: 0.875rem;
+		text-align: center;
+	}
+
+	.result-item {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		width: 100%;
+		padding: 0.75rem 1rem;
+		border: none;
+		background: none;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.15s;
+	}
+
+	.result-item:hover,
+	.result-item.highlighted {
+		background: #f1f5f9;
+	}
+
+	.result-item.highlighted {
+		outline: 2px solid #3b82f6;
+		outline-offset: -2px;
+	}
+
+	.result-item:first-child {
+		border-radius: 8px 8px 0 0;
+	}
+
+	.result-item:last-child {
+		border-radius: 0 0 8px 8px;
+	}
+
+	.result-item:only-child {
+		border-radius: 8px;
+	}
+
+	.result-avatar {
+		flex-shrink: 0;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.result-avatar svg {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	.result-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.result-name {
+		font-size: 0.875rem;
+		color: #1e293b;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.result-lifespan {
+		font-size: 0.75rem;
+		color: #94a3b8;
+	}
+
+	/* Tailwind-like utility classes for avatar colors */
+	.bg-blue-100 {
+		background-color: #dbeafe;
+	}
+	.text-blue-600 {
+		color: #2563eb;
+	}
+	.bg-pink-100 {
+		background-color: #fce7f3;
+	}
+	.text-pink-600 {
+		color: #db2777;
+	}
+	.bg-slate-100 {
+		background-color: #f1f5f9;
+	}
+	.text-slate-500 {
+		color: #64748b;
+	}
+</style>

--- a/web/src/lib/components/RelationshipCalculator.svelte
+++ b/web/src/lib/components/RelationshipCalculator.svelte
@@ -1,0 +1,773 @@
+<script lang="ts">
+	import { api, type RelationshipResult, type RelationshipPath, type Person, type SearchResult, formatPersonName } from '$lib/api/client';
+	import PersonSelector from './PersonSelector.svelte';
+
+	interface Props {
+		initialPersonA?: Person | null;
+		initialPersonB?: Person | null;
+	}
+
+	let { initialPersonA = null, initialPersonB = null }: Props = $props();
+
+	let personA = $state<Person | SearchResult | null>(initialPersonA);
+	let personB = $state<Person | SearchResult | null>(initialPersonB);
+	let result = $state<RelationshipResult | null>(null);
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let hasCalculated = $state(false);
+
+	// Track if inputs have changed since last calculation
+	let inputsChanged = $derived.by(() => {
+		const currentA = personA?.id;
+		const currentB = personB?.id;
+		const resultA = result?.personA?.id;
+		const resultB = result?.personB?.id;
+		return !result || currentA !== resultA || currentB !== resultB;
+	});
+
+	async function calculateRelationship() {
+		if (!personA || !personB) return;
+
+		// Check if same person is selected twice
+		if (personA.id === personB.id) {
+			error = 'Please select two different people to find their relationship.';
+			result = null;
+			hasCalculated = true;
+			return;
+		}
+
+		loading = true;
+		error = null;
+		result = null;
+		hasCalculated = true;
+
+		try {
+			result = await api.getRelationship(personA.id, personB.id);
+		} catch (e) {
+			const apiError = e as { message?: string; code?: string };
+			if (apiError.code === 'NOT_FOUND') {
+				error = 'One or both people could not be found.';
+			} else {
+				error = apiError.message || 'Failed to calculate relationship. Please try again.';
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handlePersonASelect(person: SearchResult | null) {
+		personA = person;
+		// Reset result when person changes
+		if (hasCalculated) {
+			result = null;
+			error = null;
+		}
+	}
+
+	function handlePersonBSelect(person: SearchResult | null) {
+		personB = person;
+		// Reset result when person changes
+		if (hasCalculated) {
+			result = null;
+			error = null;
+		}
+	}
+
+	function swapPeople() {
+		const temp = personA;
+		personA = personB;
+		personB = temp;
+		if (hasCalculated) {
+			result = null;
+			error = null;
+		}
+	}
+
+	function clearAll() {
+		personA = null;
+		personB = null;
+		result = null;
+		error = null;
+		hasCalculated = false;
+	}
+
+	// Get the primary relationship name (first path)
+	function getPrimaryRelationship(paths?: RelationshipPath[]): string {
+		if (!paths || paths.length === 0) return 'No relationship found';
+		return paths[0].name || 'Related';
+	}
+
+	// Get additional relationship paths (after the first)
+	function getAdditionalPaths(paths?: RelationshipPath[]): RelationshipPath[] {
+		if (!paths || paths.length <= 1) return [];
+		return paths.slice(1);
+	}
+
+	// Format the path as a visual chain
+	function formatPathChain(path: RelationshipPath, personA: Person | undefined, personB: Person | undefined): string[] {
+		const chain: string[] = [];
+
+		// Add person A's path to common ancestor
+		if (path.pathFromA && path.pathFromA.length > 0) {
+			chain.push(...path.pathFromA);
+		}
+
+		// Add person B's path from common ancestor (reversed)
+		if (path.pathFromB && path.pathFromB.length > 0) {
+			chain.push(...path.pathFromB.slice().reverse());
+		}
+
+		return chain;
+	}
+</script>
+
+<div class="relationship-calculator">
+	<div class="calculator-header">
+		<h2 class="title">Relationship Calculator</h2>
+		<p class="subtitle">Select two people to discover how they are related</p>
+	</div>
+
+	<div class="selector-section">
+		<div class="selectors-grid">
+			<div class="selector-container">
+				<PersonSelector
+					label="First Person"
+					selectedPerson={personA}
+					onSelect={handlePersonASelect}
+					placeholder="Search for first person..."
+					disabled={loading}
+				/>
+			</div>
+
+			<div class="swap-container">
+				<button
+					type="button"
+					class="swap-btn"
+					onclick={swapPeople}
+					disabled={loading || (!personA && !personB)}
+					aria-label="Swap people"
+					title="Swap people"
+				>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M7 16V4m0 0L3 8m4-4l4 4m6 4v12m0 0l4-4m-4 4l-4-4" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="selector-container">
+				<PersonSelector
+					label="Second Person"
+					selectedPerson={personB}
+					onSelect={handlePersonBSelect}
+					placeholder="Search for second person..."
+					disabled={loading}
+				/>
+			</div>
+		</div>
+
+		<div class="action-buttons">
+			<button
+				type="button"
+				class="calculate-btn"
+				onclick={calculateRelationship}
+				disabled={loading || !personA || !personB}
+			>
+				{#if loading}
+					<span class="spinner"></span>
+					Calculating...
+				{:else}
+					Calculate Relationship
+				{/if}
+			</button>
+
+			{#if personA || personB || result}
+				<button
+					type="button"
+					class="clear-btn"
+					onclick={clearAll}
+					disabled={loading}
+				>
+					Clear All
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Results Section -->
+	{#if hasCalculated && !loading}
+		<div class="results-section" role="region" aria-label="Relationship results">
+			{#if error}
+				<div class="error-message" role="alert">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<circle cx="12" cy="12" r="10" />
+						<path d="M12 8v4m0 4h.01" />
+					</svg>
+					<span>{error}</span>
+				</div>
+			{:else if result}
+				{#if result.isRelated && result.paths && result.paths.length > 0}
+					<!-- Primary relationship result -->
+					<div class="primary-result">
+						<div class="relationship-badge">
+							<span class="relationship-label">Relationship</span>
+							<span class="relationship-name">{getPrimaryRelationship(result.paths)}</span>
+						</div>
+
+						{#if result.summary}
+							<p class="relationship-summary">{result.summary}</p>
+						{/if}
+					</div>
+
+					<!-- Relationship Path Visualization -->
+					{#if result.paths[0]}
+						<div class="path-visualization">
+							<h3 class="path-title">Relationship Path</h3>
+							<div class="path-chain">
+								<!-- Person A -->
+								<div class="path-node person-node" data-gender={result.personA?.gender}>
+									<div class="node-avatar">
+										<svg viewBox="0 0 24 24" fill="currentColor">
+											<path d="M12 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM6 8a6 6 0 1 1 12 0A6 6 0 0 1 6 8zm2 10a3 3 0 0 0-3 3 1 1 0 1 1-2 0 5 5 0 0 1 5-5h8a5 5 0 0 1 5 5 1 1 0 1 1-2 0 3 3 0 0 0-3-3H8z" />
+										</svg>
+									</div>
+									<span class="node-name">{result.personA ? formatPersonName(result.personA) : 'Person A'}</span>
+								</div>
+
+								<!-- Path from A to common ancestor -->
+								{#if result.paths[0].pathFromA && result.paths[0].pathFromA.length > 0}
+									{#each result.paths[0].pathFromA as step}
+										<div class="path-connector">
+											<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+												<path d="M12 5v14m-7-7l7 7 7-7" />
+											</svg>
+										</div>
+										<div class="path-step">
+											<span class="step-label">{step}</span>
+										</div>
+									{/each}
+								{/if}
+
+								<!-- Common ancestor indicator -->
+								{#if result.paths[0].commonAncestorId}
+									<div class="path-connector common-ancestor-connector">
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<circle cx="12" cy="12" r="4" />
+										</svg>
+									</div>
+									<div class="path-node common-ancestor-node">
+										<span class="node-label">Common Ancestor</span>
+									</div>
+								{/if}
+
+								<!-- Path from common ancestor to B (reversed) -->
+								{#if result.paths[0].pathFromB && result.paths[0].pathFromB.length > 0}
+									{#each result.paths[0].pathFromB.slice().reverse() as step}
+										<div class="path-connector">
+											<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+												<path d="M12 5v14m-7-7l7 7 7-7" />
+											</svg>
+										</div>
+										<div class="path-step">
+											<span class="step-label">{step}</span>
+										</div>
+									{/each}
+								{/if}
+
+								<div class="path-connector">
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M12 5v14m-7-7l7 7 7-7" />
+									</svg>
+								</div>
+
+								<!-- Person B -->
+								<div class="path-node person-node" data-gender={result.personB?.gender}>
+									<div class="node-avatar">
+										<svg viewBox="0 0 24 24" fill="currentColor">
+											<path d="M12 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM6 8a6 6 0 1 1 12 0A6 6 0 0 1 6 8zm2 10a3 3 0 0 0-3 3 1 1 0 1 1-2 0 5 5 0 0 1 5-5h8a5 5 0 0 1 5 5 1 1 0 1 1-2 0 3 3 0 0 0-3-3H8z" />
+										</svg>
+									</div>
+									<span class="node-name">{result.personB ? formatPersonName(result.personB) : 'Person B'}</span>
+								</div>
+							</div>
+
+							<!-- Generation distances -->
+							{#if result.paths[0].generationDistanceA !== undefined || result.paths[0].generationDistanceB !== undefined}
+								<div class="generation-info">
+									{#if result.paths[0].generationDistanceA !== undefined}
+										<span class="gen-distance">
+											{result.personA ? formatPersonName(result.personA) : 'Person A'}: {result.paths[0].generationDistanceA} generation{result.paths[0].generationDistanceA !== 1 ? 's' : ''} to common ancestor
+										</span>
+									{/if}
+									{#if result.paths[0].generationDistanceB !== undefined}
+										<span class="gen-distance">
+											{result.personB ? formatPersonName(result.personB) : 'Person B'}: {result.paths[0].generationDistanceB} generation{result.paths[0].generationDistanceB !== 1 ? 's' : ''} to common ancestor
+										</span>
+									{/if}
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<!-- Additional relationships -->
+					{#if getAdditionalPaths(result.paths).length > 0}
+						<div class="additional-relationships">
+							<h3 class="additional-title">Also Related As</h3>
+							<ul class="additional-list">
+								{#each getAdditionalPaths(result.paths) as path}
+									<li class="additional-item">
+										<span class="additional-name">{path.name || 'Related'}</span>
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				{:else}
+					<!-- Not related -->
+					<div class="not-related">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<circle cx="12" cy="12" r="10" />
+							<path d="M8 12h8" />
+						</svg>
+						<h3>No Relationship Found</h3>
+						<p>These two people do not appear to be related in your family tree, or their connection has not yet been documented.</p>
+					</div>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.relationship-calculator {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+
+	.calculator-header {
+		text-align: center;
+		margin-bottom: 2rem;
+	}
+
+	.title {
+		margin: 0 0 0.5rem;
+		font-size: 1.75rem;
+		font-weight: 700;
+		color: #1e293b;
+	}
+
+	.subtitle {
+		margin: 0;
+		font-size: 1rem;
+		color: #64748b;
+	}
+
+	/* Selector Section */
+	.selector-section {
+		background: white;
+		border-radius: 12px;
+		padding: 1.5rem;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+		margin-bottom: 1.5rem;
+	}
+
+	.selectors-grid {
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		gap: 1rem;
+		align-items: end;
+		margin-bottom: 1.5rem;
+	}
+
+	@media (max-width: 640px) {
+		.selectors-grid {
+			grid-template-columns: 1fr;
+			gap: 1rem;
+		}
+
+		.swap-container {
+			order: -1;
+			justify-self: center;
+		}
+	}
+
+	.selector-container {
+		min-width: 0;
+	}
+
+	.swap-container {
+		display: flex;
+		align-items: flex-end;
+		padding-bottom: 0.5rem;
+	}
+
+	.swap-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.5rem;
+		height: 2.5rem;
+		padding: 0;
+		border: 1px solid #d1d5db;
+		border-radius: 50%;
+		background: white;
+		color: #64748b;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.swap-btn:hover:not(:disabled) {
+		background: #f1f5f9;
+		border-color: #9ca3af;
+		color: #374151;
+	}
+
+	.swap-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.swap-btn svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	.action-buttons {
+		display: flex;
+		gap: 0.75rem;
+		justify-content: center;
+		flex-wrap: wrap;
+	}
+
+	.calculate-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1.5rem;
+		border: none;
+		border-radius: 8px;
+		background: #3b82f6;
+		color: white;
+		font-size: 1rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s;
+		min-width: 200px;
+	}
+
+	.calculate-btn:hover:not(:disabled) {
+		background: #2563eb;
+	}
+
+	.calculate-btn:disabled {
+		background: #94a3b8;
+		cursor: not-allowed;
+	}
+
+	.spinner {
+		width: 1rem;
+		height: 1rem;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top-color: white;
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.clear-btn {
+		padding: 0.75rem 1.5rem;
+		border: 1px solid #d1d5db;
+		border-radius: 8px;
+		background: white;
+		color: #64748b;
+		font-size: 1rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.clear-btn:hover:not(:disabled) {
+		background: #f1f5f9;
+		border-color: #9ca3af;
+	}
+
+	.clear-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	/* Results Section */
+	.results-section {
+		background: white;
+		border-radius: 12px;
+		padding: 1.5rem;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	}
+
+	.error-message {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 1rem;
+		background: #fef2f2;
+		border: 1px solid #fecaca;
+		border-radius: 8px;
+		color: #dc2626;
+	}
+
+	.error-message svg {
+		flex-shrink: 0;
+		width: 1.5rem;
+		height: 1.5rem;
+	}
+
+	/* Primary Result */
+	.primary-result {
+		text-align: center;
+		margin-bottom: 1.5rem;
+	}
+
+	.relationship-badge {
+		display: inline-flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 1rem 2rem;
+		background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+		border: 2px solid #3b82f6;
+		border-radius: 12px;
+	}
+
+	.relationship-label {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 0.25rem;
+	}
+
+	.relationship-name {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: #1e293b;
+	}
+
+	@media (max-width: 640px) {
+		.relationship-name {
+			font-size: 1.25rem;
+		}
+	}
+
+	.relationship-summary {
+		margin: 1rem 0 0;
+		font-size: 0.9375rem;
+		color: #475569;
+	}
+
+	/* Path Visualization */
+	.path-visualization {
+		margin-top: 1.5rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid #e2e8f0;
+	}
+
+	.path-title {
+		margin: 0 0 1rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: #374151;
+		text-align: center;
+	}
+
+	.path-chain {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.path-node {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1.5rem;
+		background: #f8fafc;
+		border: 1px solid #e2e8f0;
+		border-radius: 8px;
+		min-width: 160px;
+	}
+
+	.path-node.person-node {
+		background: white;
+		border-width: 2px;
+	}
+
+	.path-node.person-node[data-gender="male"] {
+		border-color: #3b82f6;
+		background: #eff6ff;
+	}
+
+	.path-node.person-node[data-gender="female"] {
+		border-color: #ec4899;
+		background: #fdf2f8;
+	}
+
+	.node-avatar {
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #f1f5f9;
+		color: #64748b;
+	}
+
+	.path-node.person-node[data-gender="male"] .node-avatar {
+		background: #dbeafe;
+		color: #3b82f6;
+	}
+
+	.path-node.person-node[data-gender="female"] .node-avatar {
+		background: #fce7f3;
+		color: #ec4899;
+	}
+
+	.node-avatar svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	.node-name {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: #1e293b;
+		text-align: center;
+	}
+
+	.node-label {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: #64748b;
+	}
+
+	.common-ancestor-node {
+		background: #fef3c7;
+		border-color: #f59e0b;
+	}
+
+	.path-connector {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: #94a3b8;
+	}
+
+	.path-connector svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	.common-ancestor-connector svg {
+		color: #f59e0b;
+	}
+
+	.path-step {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem 1rem;
+		background: #f1f5f9;
+		border-radius: 9999px;
+	}
+
+	.step-label {
+		font-size: 0.8125rem;
+		color: #475569;
+	}
+
+	.generation-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		margin-top: 1rem;
+		padding: 0.75rem;
+		background: #f8fafc;
+		border-radius: 8px;
+		text-align: center;
+	}
+
+	.gen-distance {
+		font-size: 0.8125rem;
+		color: #64748b;
+	}
+
+	/* Additional Relationships */
+	.additional-relationships {
+		margin-top: 1.5rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid #e2e8f0;
+	}
+
+	.additional-title {
+		margin: 0 0 0.75rem;
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: #374151;
+	}
+
+	.additional-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.additional-item {
+		padding: 0.375rem 0.75rem;
+		background: #f1f5f9;
+		border-radius: 9999px;
+	}
+
+	.additional-name {
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	/* Not Related */
+	.not-related {
+		text-align: center;
+		padding: 2rem;
+	}
+
+	.not-related svg {
+		width: 3rem;
+		height: 3rem;
+		color: #94a3b8;
+		margin-bottom: 1rem;
+	}
+
+	.not-related h3 {
+		margin: 0 0 0.5rem;
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: #374151;
+	}
+
+	.not-related p {
+		margin: 0;
+		font-size: 0.9375rem;
+		color: #64748b;
+		max-width: 400px;
+		margin-inline: auto;
+	}
+</style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -77,6 +77,7 @@
 			<a href="/sources" class:active={$page.url.pathname.startsWith('/sources')}>Sources</a>
 			<a href="/history" class:active={$page.url.pathname.startsWith('/history')}>History</a>
 			<a href="/analytics" class:active={$page.url.pathname.startsWith('/analytics')}>Analytics</a>
+			<a href="/relationship" class:active={$page.url.pathname.startsWith('/relationship')}>Relationship</a>
 			<a href="/import" class:active={$page.url.pathname === '/import'}>Import</a>
 		</nav>
 		<div class="header-controls">

--- a/web/src/routes/relationship/+page.svelte
+++ b/web/src/routes/relationship/+page.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
+	import { api, type Person } from '$lib/api/client';
+	import RelationshipCalculator from '$lib/components/RelationshipCalculator.svelte';
+
+	let initialPersonA: Person | null = $state(null);
+	let initialPersonB: Person | null = $state(null);
+	let loading = $state(true);
+
+	onMount(async () => {
+		// Check for query parameters to pre-populate the selectors
+		const params = $page.url.searchParams;
+		const personIdA = params.get('personA');
+		const personIdB = params.get('personB');
+
+		const loadPromises: Promise<void>[] = [];
+
+		if (personIdA) {
+			loadPromises.push(
+				api.getPerson(personIdA)
+					.then((person) => {
+						initialPersonA = person;
+					})
+					.catch(() => {
+						// Person not found, ignore
+					})
+			);
+		}
+
+		if (personIdB) {
+			loadPromises.push(
+				api.getPerson(personIdB)
+					.then((person) => {
+						initialPersonB = person;
+					})
+					.catch(() => {
+						// Person not found, ignore
+					})
+			);
+		}
+
+		await Promise.all(loadPromises);
+		loading = false;
+	});
+</script>
+
+<svelte:head>
+	<title>Relationship Calculator | My Family</title>
+	<meta name="description" content="Calculate the relationship between two people in your family tree" />
+</svelte:head>
+
+<div class="relationship-page">
+	<header class="page-header">
+		<a href="/" class="back-link">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<path d="M19 12H5m0 0l7 7m-7-7l7-7" />
+			</svg>
+			Back
+		</a>
+	</header>
+
+	<main class="page-content">
+		{#if loading}
+			<div class="loading-container">
+				<div class="loading-spinner"></div>
+				<span>Loading...</span>
+			</div>
+		{:else}
+			<RelationshipCalculator {initialPersonA} {initialPersonB} />
+		{/if}
+	</main>
+</div>
+
+<style>
+	.relationship-page {
+		min-height: 100vh;
+		background: #f8fafc;
+	}
+
+	.page-header {
+		padding: 1rem 1.5rem;
+		background: white;
+		border-bottom: 1px solid #e2e8f0;
+	}
+
+	.back-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		color: #64748b;
+		text-decoration: none;
+		font-size: 0.875rem;
+		font-weight: 500;
+		transition: color 0.15s;
+	}
+
+	.back-link:hover {
+		color: #3b82f6;
+	}
+
+	.back-link svg {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	.page-content {
+		padding: 2rem 1rem;
+	}
+
+	@media (max-width: 640px) {
+		.page-content {
+			padding: 1rem;
+		}
+	}
+
+	.loading-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 1rem;
+		padding: 4rem 2rem;
+		color: #64748b;
+	}
+
+	.loading-spinner {
+		width: 2rem;
+		height: 2rem;
+		border: 3px solid #e2e8f0;
+		border-top-color: #3b82f6;
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- Implement relationship calculation between two people in the family tree
- Add frontend UI for selecting people and displaying relationship results

## Changes

### Backend
- **RelationshipService** (`internal/query/relationship_queries.go`)
  - LCA (Lowest Common Ancestor) algorithm for finding common ancestors
  - Terminology mapper for standard genealogical terms (parent, grandparent, cousin, uncle/aunt, etc.)
  - Multiple relationship path detection when related through different ancestors
  - 87.9% test coverage with 29 test cases

### API
- `GET /api/v1/relationship/{personId1}/{personId2}` endpoint
- OpenAPI schema with `RelationshipPath` and `RelationshipResult` types

### Frontend
- **PersonSelector** component with search/autocomplete and keyboard navigation
- **RelationshipCalculator** component with:
  - Two-person selector interface
  - Visual path from Person A → Common Ancestor → Person B
  - "Also related as" section for multiple paths
  - Responsive design for mobile/tablet
- Route at `/relationship` with query param support (`?personA=id&personB=id`)

## Test plan
- [x] Backend unit tests for all relationship types (29 test cases)
- [x] Coverage threshold met (87.9% for relationship_queries.go)
- [x] All existing tests pass
- [x] TypeScript compiles without errors
- [x] Frontend builds successfully

Closes #46
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)