### PR TITLE
Fix family page partner links and children display

### DIFF
--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -2958,14 +2958,18 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 	}
 
 	// Add partner details if available
-	if fd.Partner1Name != nil {
+	if fd.Partner1ID != nil && fd.Partner1Name != nil {
 		resp.Partner1 = &PersonSummary{
+			Id:        *fd.Partner1ID,
 			GivenName: *fd.Partner1Name,
+			Surname:   "",
 		}
 	}
-	if fd.Partner2Name != nil {
+	if fd.Partner2ID != nil && fd.Partner2Name != nil {
 		resp.Partner2 = &PersonSummary{
+			Id:        *fd.Partner2ID,
 			GivenName: *fd.Partner2Name,
+			Surname:   "",
 		}
 	}
 
@@ -2975,6 +2979,11 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 			children[i] = FamilyChild{
 				PersonId:         c.ID,
 				RelationshipType: FamilyChildRelationshipType(c.RelationshipType),
+				Person: &PersonSummary{
+					Id:        c.ID,
+					GivenName: c.Name,
+					Surname:   "",
+				},
 			}
 		}
 		resp.Children = &children

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -125,9 +125,10 @@ export interface FamilyUpdate {
 }
 
 export interface FamilyChild {
-	id: string;
-	name: string;
+	person_id: string;
 	relationship_type: 'biological' | 'adopted' | 'foster';
+	person?: PersonSummary;
+	sequence?: number;
 }
 
 export interface FamilyDetail extends Family {

--- a/web/src/routes/analytics/+page.svelte
+++ b/web/src/routes/analytics/+page.svelte
@@ -80,7 +80,7 @@
 			if (family.partner1_id === person.id || family.partner2_id === person.id) {
 				return false;
 			}
-			if (family.children?.some((c) => c.id === person.id)) {
+			if (family.children?.some((c) => c.person_id === person.id)) {
 				return false;
 			}
 		}

--- a/web/src/routes/families/[id]/+page.svelte
+++ b/web/src/routes/families/[id]/+page.svelte
@@ -242,8 +242,8 @@
 						<ul class="children-list">
 							{#each family.children as child}
 								<li>
-									<a href="/persons/{child.id}">
-										{child.name}
+									<a href="/persons/{child.person?.id || child.person_id}">
+										{child.person ? formatPersonName(child.person) : 'Unknown'}
 									</a>
 									{#if child.relationship_type && child.relationship_type !== 'biological'}
 										<span class="child-type">({child.relationship_type})</span>

--- a/web/src/routes/families/[id]/page.test.ts
+++ b/web/src/routes/families/[id]/page.test.ts
@@ -53,14 +53,22 @@ const mockFamilyWithChildren: apiModule.FamilyDetail = {
 	},
 	children: [
 		{
-			id: 'child1-id',
-			name: 'Alice Smith',
-			relationship_type: 'biological'
+			person_id: 'child1-id',
+			relationship_type: 'biological',
+			person: {
+				id: 'child1-id',
+				given_name: 'Alice',
+				surname: 'Smith'
+			}
 		},
 		{
-			id: 'child2-id',
-			name: 'Bob Smith',
-			relationship_type: 'adopted'
+			person_id: 'child2-id',
+			relationship_type: 'adopted',
+			person: {
+				id: 'child2-id',
+				given_name: 'Bob',
+				surname: 'Smith'
+			}
 		}
 	]
 };


### PR DESCRIPTION
## Summary

Fixes two related display bugs on the family page:

- **Partner links broken**: Clicking partner links resulted in "Person not found" because `PersonSummary` objects were missing the `Id` field needed for navigation
- **Children not listed**: Children were counted correctly but not displayed because `FamilyChild` objects were missing the `Person` field containing name data

## Changes

### Backend (`internal/api/server_strict.go`)
- `convertQueryFamilyDetailToGenerated()` now populates Partner1/Partner2 `PersonSummary` with `Id` from `PartnerXID`
- `FamilyChild` now includes `Person` field with `Id` and `GivenName`

### Frontend
- Updated `FamilyChild` TypeScript interface to match OpenAPI spec (`person_id`, `person`)
- Updated Svelte component to access `child.person?.id` and `child.person?.given_name`
- Fixed analytics page `isOrphaned()` function to use `person_id`

## Test plan

- [x] All Go tests pass
- [x] All frontend tests pass (86 tests)
- [x] Coverage thresholds maintained (85.9%)
- [x] Lint checks pass
- [ ] Manual: Navigate to family page, verify partner links work
- [ ] Manual: Verify children are listed with working links

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)