### PR TITLE
Adopt lenient parsing mode for robust GEDCOM import

### DIFF
--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -1139,12 +1139,25 @@ func (ss *StrictServer) ImportGedcom(ctx context.Context, request ImportGedcomRe
 		}
 	}
 
-	return ImportGedcom200JSONResponse{
+	importErrors := make([]ImportError, len(result.Errors))
+	for i, e := range result.Errors {
+		importErrors[i] = ImportError{
+			Line:    0,
+			Message: e,
+		}
+	}
+
+	response := ImportGedcom200JSONResponse{
 		FamiliesImported: result.FamiliesImported,
 		PersonsImported:  result.PersonsImported,
 		Success:          true,
 		Warnings:         &warnings,
-	}, nil
+	}
+	if len(importErrors) > 0 {
+		response.Errors = &importErrors
+	}
+
+	return response, nil
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Switch from DecodeWithOptions to DecodeWithDiagnostics (gedcom-go v1.1.0)
- Parse errors collected as diagnostics instead of aborting import
- Diagnostics mapped to warnings/errors by severity and surfaced in API response
- Frontend already renders warnings and errors - no UI changes needed

## Changes
- `internal/gedcom/importer.go` - Switch decoder call, map diagnostics
- `internal/api/server_strict.go` - Surface errors array in API response
- Tests for lenient mode with malformed input and API-level diagnostics

## Test plan
- [x] Malformed GEDCOM imports successfully with warnings (not hard failure)
- [x] Completely invalid input still returns error
- [x] API returns diagnostics in warnings/errors fields
- [x] All existing import tests pass
- [x] Coverage thresholds satisfied

Closes #221

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Lenient import mode now allows GEDCOM files with errors to import partially, with diagnostics reported for problematic lines.

**Improvements**
* Export operations now reliably handle large datasets without truncation.

**Tests**
* Added comprehensive tests validating partial import success with diagnostic feedback and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->