### PR TITLE
Bump Go to 1.25.7 to fix security check failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache: true
 
       - name: Install dependencies
@@ -220,7 +220,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache: true
 
       - name: Set up Node.js
@@ -320,7 +320,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
 
       - name: Create placeholder for embedded files
         if: matrix.language == 'go'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache: true
 
       - name: Set up Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY web/ ./
 RUN npm run build
 
 # Build stage: Backend
-FROM golang:1.25-alpine AS backend-builder
+FROM golang:1.25.7-alpine AS backend-builder
 
 # Install build dependencies for CGO (required for SQLite)
 RUN apk add --no-cache gcc musl-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cacack/my-family
 
-go 1.25
+go 1.25.7
 
 require (
 	github.com/cacack/gedcom-go v1.1.0


### PR DESCRIPTION
## Summary
- Pin Go version to 1.25.7 across all CI workflows, Dockerfile, and go.mod
- Resolves security check failures caused by a known vulnerability in Go 1.25.6

## Changes
- `.github/workflows/ci.yml` - 3 occurrences
- `.github/workflows/release.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/release-please.yml`
- `Dockerfile`
- `go.mod`

## Test plan
- [ ] CI security job passes without Go vulnerability findings
- [ ] All existing PR checks pass with the updated Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)