### PR TITLE
Split ETHOS.md into philosophy and roadmap

### DIFF
--- a/.claude/skills/check-phase/SKILL.md
+++ b/.claude/skills/check-phase/SKILL.md
@@ -5,11 +5,11 @@ context: fork
 agent: Explore
 ---
 
-Assess whether recent work aligns with Phase 1 priorities from docs/ETHOS.md. Phase 1 focus is: "Core data, import/export, basic UI, self-hosting." This is READ-ONLY, do not modify files.
+Assess whether recent work aligns with Phase 1 priorities from docs/ROADMAP.md. Phase 1 focus is: "Core data, import/export, basic UI, self-hosting." This is READ-ONLY, do not modify files.
 
 ## Checks
 
-1. Read the last 20 git commit messages (use `git log --oneline -20`). Categorize each as Phase 1/2/3 work based on the phase markers in ETHOS.md.
+1. Read the last 20 git commit messages (use `git log --oneline -20`). Categorize each as Phase 1/2/3 work based on the phase markers in ROADMAP.md.
 2. Check open GitHub issues (if accessible) or the Integration Matrix for what's being prioritized.
 3. Review the entity status matrix in INTEGRATION-MATRIX.md - are partially-complete Phase 1 entities being finished before Phase 2/3 work begins?
 4. Are there any Phase 3 features (plugins, AI/LLM, themes) being built prematurely?

--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -21,7 +21,7 @@ Use the Task tool to launch each of these as separate subagents. Each skill runs
 
 3. **Test Quality** - Invoke the `check-tests` skill: Edge case coverage, assertion quality, table-driven patterns, dual database coverage, missing test files, GEDCOM round-trip tests. Report PASS/WARN/FAIL.
 
-4. **Phase Alignment** - Invoke the `check-phase` skill: Last 20 commits vs ETHOS.md phases, Integration Matrix priorities, partial entity completion order, premature Phase 3 work. Brief alignment assessment.
+4. **Phase Alignment** - Invoke the `check-phase` skill: Last 20 commits vs ROADMAP.md phases, Integration Matrix priorities, partial entity completion order, premature Phase 3 work. Brief alignment assessment.
 
 5. **Technical Debt** - Invoke the `check-debt` skill: TODO comments by package, partial entities from matrix, HACK/FIXME/XXX comments, long functions, packages with no tests. Debt summary.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ Self-hosted genealogy software written in Go. A premier self-hosted genealogy pl
 
 ## Strategic Context
 
-- [Project Ethos](./docs/ETHOS.md) - Vision, principles, success factors (note phase markers: Phase 1 = now)
+- [Project Ethos](./docs/ETHOS.md) - Vision, principles, and differentiators
+- [Roadmap](./docs/ROADMAP.md) - Phased feature plan (Phase 1 = now)
 - [GitHub Issues](https://github.com/cacack/my-family/issues) - Planned features and work
 - [Conventions](./docs/CONVENTIONS.md) - **Canonical source** for code patterns, commit types, and standards
 - [Architecture Decisions](./docs/adr/) - Key technical decisions with rationale

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ go vet ./...
 
 ## Documentation
 
-- [ETHOS.md](./docs/ETHOS.md) - Project vision, principles, and success factors
+- [ETHOS.md](./docs/ETHOS.md) - Project vision and guiding principles
+- [ROADMAP.md](./docs/ROADMAP.md) - Phased feature plan and success factors
 - [CONVENTIONS.md](./docs/CONVENTIONS.md) - Code patterns and standards
 - [Architecture Decisions](./docs/adr/) - Key technical decisions with rationale
 - [FEATURES.md](./FEATURES.md) - Complete feature list

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -1,6 +1,6 @@
 # Project Ethos
 
-The guiding philosophy, success factors, and strategic vision for my-family.
+The guiding philosophy and strategic vision for my-family. For the phased feature plan and success factors, see [ROADMAP.md](./ROADMAP.md).
 
 ---
 
@@ -10,147 +10,22 @@ A premier self-hosted genealogy platform that combines **research rigor** with *
 
 ---
 
-## Phase Guide
-
-Features and capabilities are organized into phases to focus effort. **Phase 1 is the current priority** - resist the temptation to jump ahead.
-
-| Phase | Focus | Principle |
-|-------|-------|-----------|
-| **Phase 1 (Now)** | Core data, import/export, basic UI, self-hosting | Nail the Basics First |
-| **Phase 2 (Near-term)** | Research workflows, collaboration, richer visualizations | Dogfood Relentlessly |
-| **Phase 3 (Future)** | AI features, plugins, community ecosystem | Start Small, Ship Often |
-
----
-
 ## Core Differentiators
 
 ### 1. Research Rigor (GPS-Compliant)
-Align with the [Genealogical Proof Standard](https://bcgcertification.org/ethics-standards/) from the Board for Certification of Genealogists:
-- **Complete citations** - Every fact tied to a source, Evidence Explained style `Phase 1`
-- **Uncertain data markers** - Distinguish facts from speculation `Phase 1`
-- **Reasonably exhaustive search** - Track what you've searched, including negative results `Phase 2`
-- **Analysis & correlation** - Separate evidence (what sources say) from conclusions (what you believe) `Phase 2`
-- **Conflict resolution** - Surface contradictions, require resolution `Phase 2`
-- **Written conclusions** - Proof summaries for non-obvious conclusions `Phase 3`
+Align with the [Genealogical Proof Standard](https://bcgcertification.org/ethics-standards/) from the Board for Certification of Genealogists. Every fact should be tied to a source with proper citations, uncertain data clearly distinguished from established facts, and conflicting evidence surfaced and resolved through reasoned analysis.
 
 ### 2. Git-Inspired Workflow
-Treat genealogy research like code - versioned, branched, collaborative:
-- **Full audit trail** - Who changed what, when, and why `Phase 1`
-- **Tags/snapshots** - Mark milestones ("Pre-DNA results", "After courthouse trip") `Phase 1`
-- **Rollback capability** - Mistakes are recoverable `Phase 1`
-- **Research branches** - Explore hypotheses without polluting main tree `Phase 2`
-- **Merge with review** - Bring proven research into main tree with diff view `Phase 2`
-- **Collaborative forks** - Others can propose changes via pull request workflow `Phase 3`
+Treat genealogy research like code — versioned, branched, collaborative. A full audit trail tracks who changed what, when, and why. Research hypotheses can be explored in branches without polluting the main tree, and proven findings merged back with review.
 
 ### 3. Bringing History to Life
-Make ancestors feel like real people, not just names and dates:
-- **Interactive timelines** - Zoomable, with historical events interwoven `Phase 2`
-- **Migration maps** - Animated paths showing family movements `Phase 2`
-- **Memory capture** - Oral histories, family stories attached to people `Phase 2`
-- **Auto-generated narratives** - Prose stories from structured data `Phase 3`
-- **Historical context** - What was happening in the world during their lives `Phase 3`
-- **"A Day in Their Life"** - What was daily life like for their occupation/era? `Phase 3`
+Make ancestors feel like real people, not just names and dates. Interactive timelines, migration maps, oral history capture, and auto-generated narratives turn structured data into engaging stories with historical context.
 
 ### 4. Personalization & Extensibility
-Your genealogy tool, your way:
-- **Report templates** - Output in your preferred format `Phase 2`
-- **Custom fields** - Add your own data types `Phase 2`
-- **Theming engine** - Colors, fonts, layouts `Phase 3`
-- **Plugin architecture** - Community extensions `Phase 3`
-- **Customizable dashboards** - See what matters to you `Phase 3`
+Your genealogy tool, your way. Customizable reports, fields, themes, dashboards, and a plugin architecture that enables community extensions.
 
 ### 5. Fun & Engaging
-Research should be enjoyable, not a chore:
-- **Completeness scores** - Gamify filling in gaps `Phase 1`
-- **Brick wall tracker** - Track and celebrate breakthroughs `Phase 2`
-- **Discovery feed** - Suggestions to explore `Phase 3`
-- **Achievements & badges** - Celebrate milestones `Phase 3`
-- **Shareable spotlights** - Social media cards for sharing discoveries `Phase 3`
-
----
-
-## Success Factors
-
-### Technical Foundation
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **Data integrity** | ACID transactions, referential integrity | 1 |
-| **Easy self-hosting** | Docker one-liner, not a 20-step guide | 1 |
-| **API-first architecture** | Everything accessible programmatically | 1 |
-| **Performance at scale** | Trees with 50,000+ people must stay fast | 2 |
-| **Mobile experience** | Quick lookups at cemeteries, courthouses, reunions | 2 |
-| **Automatic backups** | Data loss is catastrophic for genealogists | 2 |
-| **Offline-first / PWA** | Researchers work in archives without internet | 3 |
-
-### User Experience & Adoption
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **Keyboard shortcuts** | Power users need speed | 1 |
-| **Accessibility (a11y)** | Older users, screen readers, motor impairments | 1 |
-| **Import from everywhere** | Not just GEDCOM - Ancestry, FamilySearch, Gramps | 1-2 |
-| **Exceptional onboarding** | First 5 minutes determine retention | 2 |
-| **Demo/sandbox mode** | Try before committing (no install required) | 2 |
-| **Guided workflows** | Wizards for common tasks, not empty forms | 2 |
-| **"Quick capture" mode** | Fast entry at courthouse, enrich later | 3 |
-
-### Data & Interoperability
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **No vendor lock-in** | Your data is always yours | 1 |
-| **Export flexibility** | JSON, CSV, GEDCOM, custom formats | 1 |
-| **Data validation tools** | Find inconsistencies, duplicates, errors | 1 |
-| **Lossless GEDCOM 7.0** | Modern standard with proper extensions | 2 |
-| **Bulk operations** | Mass edit, find/replace across tree | 2 |
-| **Import from proprietary formats** | Ancestry exports lose DNA, photo tags, hints | 3 |
-
-### Research Integrity
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **Flexible dates** | "about 1842", "between 1840-1845", "before 1850" | 1 |
-| **Multiple name handling** | Maiden names, aliases, spelling variants | 1 |
-| **Relationship qualifiers** | Biological, adopted, step, foster | 1 |
-| **Inclusive relationships** | Same-sex couples, modern family structures | 1 |
-| **Uncertain data markers** | Distinguish facts from speculation | 1 |
-| **Historical place context** | "Prussia" maps to modern Germany | 2 |
-
-### AI/LLM Integration (Modern Differentiator) `Phase 3`
-
-| Capability | Description |
-|------------|-------------|
-| **Handwriting transcription** | OCR old documents, letters, records |
-| **Record extraction** | Parse census images into structured data |
-| **Translation assistance** | German church records, Swedish parish books |
-| **Research suggestions** | "Based on this data, you might search for..." |
-| **Story generation** | LLM-assisted narrative writing |
-| **Conflict analysis** | Explain why sources might disagree |
-| **Natural language search** | "Who lived in Ohio in 1850?" |
-
-### Community & Ecosystem `Phase 2-3`
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **Clear contribution guide** | How to help, what's needed | 1 |
-| **Public roadmap** | Transparency builds trust | 1 |
-| **Regular releases** | Activity signals project health | 1 |
-| **Discussion forum/Discord** | Community needs a home | 2 |
-| **Plugin SDK + documentation** | Enable community extensions | 3 |
-| **Theme SDK + documentation** | Let designers contribute | 3 |
-| **Showcase/testimonials** | Social proof matters | 3 |
-
-### Adoption & Go-to-Market `Phase 2-3`
-
-| Factor | Why It Matters | Phase |
-|--------|----------------|-------|
-| **Hosted demo instance** | Try without installing anything | 2 |
-| **Migration guides** | Step-by-step from Ancestry, FamilySearch | 2 |
-| **Comparison page** | "my-family vs Gramps vs TNG vs..." | 2 |
-| **Video tutorials** | YouTube is how people learn | 2 |
-| **Genealogy society outreach** | Built-in audience of serious researchers | 3 |
-| **Browser extension** | Capture from Ancestry/FamilySearch | 3 |
+Research should be enjoyable, not a chore. Completeness scores, brick wall tracking, discovery feeds, achievements, and shareable spotlights keep researchers motivated.
 
 ---
 
@@ -215,5 +90,6 @@ Genealogy is a scholarly discipline. Build tools worthy of serious researchers.
 
 ## Related
 
+- [Roadmap](./ROADMAP.md) - Phased feature plan and success factors
 - [Architecture Decision Records](./adr/) - Decisions guided by this ethos
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - How to contribute

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,161 @@
+# Roadmap
+
+The phased feature plan for my-family. For the project vision, guiding principles, and differentiators, see [ETHOS.md](./ETHOS.md).
+
+---
+
+## Phase Guide
+
+Features and capabilities are organized into phases to focus effort. **Phase 1 is the current priority** - resist the temptation to jump ahead.
+
+| Phase | Focus | Principle |
+|-------|-------|-----------|
+| **Phase 1 (Now)** | Core data, import/export, basic UI, self-hosting | Nail the Basics First |
+| **Phase 2 (Near-term)** | Research workflows, collaboration, richer visualizations | Dogfood Relentlessly |
+| **Phase 3 (Future)** | AI features, plugins, community ecosystem | Start Small, Ship Often |
+
+---
+
+## Feature Catalog
+
+### Research Rigor (GPS-Compliant)
+
+- **Complete citations** - Every fact tied to a source, Evidence Explained style `Phase 1`
+- **Uncertain data markers** - Distinguish facts from speculation `Phase 1`
+- **Reasonably exhaustive search** - Track what you've searched, including negative results `Phase 2`
+- **Analysis & correlation** - Separate evidence (what sources say) from conclusions (what you believe) `Phase 2`
+- **Conflict resolution** - Surface contradictions, require resolution `Phase 2`
+- **Written conclusions** - Proof summaries for non-obvious conclusions `Phase 3`
+
+### Git-Inspired Workflow
+
+- **Full audit trail** - Who changed what, when, and why `Phase 1`
+- **Tags/snapshots** - Mark milestones ("Pre-DNA results", "After courthouse trip") `Phase 1`
+- **Rollback capability** - Mistakes are recoverable `Phase 1`
+- **Research branches** - Explore hypotheses without polluting main tree `Phase 2`
+- **Merge with review** - Bring proven research into main tree with diff view `Phase 2`
+- **Collaborative forks** - Others can propose changes via pull request workflow `Phase 3`
+
+### Bringing History to Life
+
+- **Interactive timelines** - Zoomable, with historical events interwoven `Phase 2`
+- **Migration maps** - Animated paths showing family movements `Phase 2`
+- **Memory capture** - Oral histories, family stories attached to people `Phase 2`
+- **Auto-generated narratives** - Prose stories from structured data `Phase 3`
+- **Historical context** - What was happening in the world during their lives `Phase 3`
+- **"A Day in Their Life"** - What was daily life like for their occupation/era? `Phase 3`
+
+### Personalization & Extensibility
+
+- **Report templates** - Output in your preferred format `Phase 2`
+- **Custom fields** - Add your own data types `Phase 2`
+- **Theming engine** - Colors, fonts, layouts `Phase 3`
+- **Plugin architecture** - Community extensions `Phase 3`
+- **Customizable dashboards** - See what matters to you `Phase 3`
+
+### Fun & Engaging
+
+- **Completeness scores** - Gamify filling in gaps `Phase 1`
+- **Brick wall tracker** - Track and celebrate breakthroughs `Phase 2`
+- **Discovery feed** - Suggestions to explore `Phase 3`
+- **Achievements & badges** - Celebrate milestones `Phase 3`
+- **Shareable spotlights** - Social media cards for sharing discoveries `Phase 3`
+
+---
+
+## Success Factors
+
+### Technical Foundation
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **Data integrity** | ACID transactions, referential integrity | 1 |
+| **Easy self-hosting** | Docker one-liner, not a 20-step guide | 1 |
+| **API-first architecture** | Everything accessible programmatically | 1 |
+| **Performance at scale** | Trees with 50,000+ people must stay fast | 2 |
+| **Mobile experience** | Quick lookups at cemeteries, courthouses, reunions | 2 |
+| **Automatic backups** | Data loss is catastrophic for genealogists | 2 |
+| **Offline-first / PWA** | Researchers work in archives without internet | 3 |
+
+### User Experience & Adoption
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **Keyboard shortcuts** | Power users need speed | 1 |
+| **Accessibility (a11y)** | Older users, screen readers, motor impairments | 1 |
+| **Import from everywhere** | Not just GEDCOM - Ancestry, FamilySearch, Gramps | 1-2 |
+| **Exceptional onboarding** | First 5 minutes determine retention | 2 |
+| **Demo/sandbox mode** | Try before committing (no install required) | 2 |
+| **Guided workflows** | Wizards for common tasks, not empty forms | 2 |
+| **"Quick capture" mode** | Fast entry at courthouse, enrich later | 3 |
+
+### Data & Interoperability
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **No vendor lock-in** | Your data is always yours | 1 |
+| **Export flexibility** | JSON, CSV, GEDCOM, custom formats | 1 |
+| **Data validation tools** | Find inconsistencies, duplicates, errors | 1 |
+| **Lossless GEDCOM 7.0** | Modern standard with proper extensions | 2 |
+| **Bulk operations** | Mass edit, find/replace across tree | 2 |
+| **Import from proprietary formats** | Ancestry exports lose DNA, photo tags, hints | 3 |
+
+### Research Integrity
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **Flexible dates** | "about 1842", "between 1840-1845", "before 1850" | 1 |
+| **Multiple name handling** | Maiden names, aliases, spelling variants | 1 |
+| **Relationship qualifiers** | Biological, adopted, step, foster | 1 |
+| **Inclusive relationships** | Same-sex couples, modern family structures | 1 |
+| **Uncertain data markers** | Distinguish facts from speculation | 1 |
+| **Historical place context** | "Prussia" maps to modern Germany | 2 |
+
+---
+
+## AI/LLM Integration (Modern Differentiator) `Phase 3`
+
+| Capability | Description |
+|------------|-------------|
+| **Handwriting transcription** | OCR old documents, letters, records |
+| **Record extraction** | Parse census images into structured data |
+| **Translation assistance** | German church records, Swedish parish books |
+| **Research suggestions** | "Based on this data, you might search for..." |
+| **Story generation** | LLM-assisted narrative writing |
+| **Conflict analysis** | Explain why sources might disagree |
+| **Natural language search** | "Who lived in Ohio in 1850?" |
+
+---
+
+## Community & Ecosystem `Phase 2-3`
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **Clear contribution guide** | How to help, what's needed | 1 |
+| **Public roadmap** | Transparency builds trust | 1 |
+| **Regular releases** | Activity signals project health | 1 |
+| **Discussion forum/Discord** | Community needs a home | 2 |
+| **Plugin SDK + documentation** | Enable community extensions | 3 |
+| **Theme SDK + documentation** | Let designers contribute | 3 |
+| **Showcase/testimonials** | Social proof matters | 3 |
+
+---
+
+## Adoption & Go-to-Market `Phase 2-3`
+
+| Factor | Why It Matters | Phase |
+|--------|----------------|-------|
+| **Hosted demo instance** | Try without installing anything | 2 |
+| **Migration guides** | Step-by-step from Ancestry, FamilySearch | 2 |
+| **Comparison page** | "my-family vs Gramps vs TNG vs..." | 2 |
+| **Video tutorials** | YouTube is how people learn | 2 |
+| **Genealogy society outreach** | Built-in audience of serious researchers | 3 |
+| **Browser extension** | Capture from Ancestry/FamilySearch | 3 |
+
+---
+
+## Related
+
+- [Project Ethos](./ETHOS.md) - Vision, principles, and differentiators
+- [GitHub Milestones](https://github.com/cacack/my-family/milestones) - Active milestone tracking
+- [CONTRIBUTING.md](../CONTRIBUTING.md) - How to contribute


### PR DESCRIPTION
## Summary

- **Split `docs/ETHOS.md`** into two focused documents: philosophy (`ETHOS.md`) and phased feature plan (`ROADMAP.md`)
- **`ETHOS.md`** now contains only vision, core differentiators (as narrative), strategic principles, anti-patterns, inspirations, and references
- **`ROADMAP.md`** contains the phase guide, itemized feature catalog with phase markers, success factor tables, AI/LLM integration, community & ecosystem, and adoption sections
- Updated cross-references in `CLAUDE.md`, `README.md`, `check-phase` skill, and `health-check` skill

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (Go + frontend)
- [x] No `Phase N` markers remain in ETHOS.md
- [x] All phase content preserved in ROADMAP.md
- [x] Remaining ETHOS.md references across docs point to principles (still valid)
- [x] Skill files reference ROADMAP.md for phase content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized project documentation structure with improved clarity and navigation
  * Added a comprehensive Roadmap document detailing phased feature development and Phase 1 priorities
  * Updated project vision, principles, and core differentiators in foundational documentation
  * Enhanced cross-references across documentation for better discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->