### PR TITLE
Add quick capture mode for fast person data entry

### DIFF
--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -275,13 +275,13 @@ func TestContractPersons(t *testing.T) {
 			wantStatus:  http.StatusCreated,
 		},
 		{
-			name:           "CreatePerson_BadRequest_MissingSurname",
-			method:         http.MethodPost,
-			path:           "/api/v1/persons",
-			body:           `{"given_name":"John"}`,
-			contentType:    "application/json",
-			wantStatus:     http.StatusBadRequest,
-			skipRequestVal: true, // intentionally invalid request
+			name:            "CreatePerson_Success_WithoutSurname",
+			method:          http.MethodPost,
+			path:            "/api/v1/persons",
+			body:            `{"given_name":"Madonna"}`,
+			contentType:     "application/json",
+			wantStatus:      http.StatusCreated,
+			skipResponseVal: true,
 		},
 		{
 			name:   "GetPerson_Success",

--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -1544,7 +1544,7 @@ type PersonCreate struct {
 
 	// ResearchStatus Confidence level of genealogical data per GPS standards
 	ResearchStatus *ResearchStatus `json:"research_status,omitempty"`
-	Surname        string          `json:"surname"`
+	Surname        *string         `json:"surname,omitempty"`
 }
 
 // PersonCreateGender defines model for PersonCreate.Gender.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -73,8 +73,8 @@ func TestCreatePerson(t *testing.T) {
 
 func TestCreatePerson_ValidationError(t *testing.T) {
 	server := setupTestServer()
-	// Missing required surname
-	body := `{"given_name":"John"}`
+	// Missing required given_name
+	body := `{"surname":"Doe"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -83,6 +83,18 @@ func TestCreatePerson_ValidationError(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCreatePerson_WithoutSurname(t *testing.T) {
+	server := setupTestServer()
+	body := `{"given_name":"Madonna"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/persons", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusCreated)
 	}
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2794,7 +2794,7 @@ components:
 
     PersonCreate:
       type: object
-      required: [given_name, surname]
+      required: [given_name]
       properties:
         given_name:
           type: string
@@ -2802,7 +2802,6 @@ components:
           maxLength: 100
         surname:
           type: string
-          minLength: 1
           maxLength: 100
         gender:
           type: string

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -1486,9 +1486,13 @@ func (ss *StrictServer) ListPersons(ctx context.Context, request ListPersonsRequ
 
 // CreatePerson implements StrictServerInterface.
 func (ss *StrictServer) CreatePerson(ctx context.Context, request CreatePersonRequestObject) (CreatePersonResponseObject, error) {
+	var surname string
+	if request.Body.Surname != nil {
+		surname = *request.Body.Surname
+	}
 	input := command.CreatePersonInput{
 		GivenName: request.Body.GivenName,
-		Surname:   request.Body.Surname,
+		Surname:   surname,
 	}
 	if request.Body.Gender != nil {
 		input.Gender = string(*request.Body.Gender)
@@ -1521,7 +1525,7 @@ func (ss *StrictServer) CreatePerson(ctx context.Context, request CreatePersonRe
 	_, _ = ss.server.commandHandler.AddName(ctx, command.AddNameInput{
 		PersonID:  result.ID,
 		GivenName: request.Body.GivenName,
-		Surname:   request.Body.Surname,
+		Surname:   surname,
 		IsPrimary: true,
 	})
 

--- a/internal/command/person_commands.go
+++ b/internal/command/person_commands.go
@@ -41,8 +41,8 @@ type CreatePersonResult struct {
 // CreatePerson creates a new person record.
 func (h *Handler) CreatePerson(ctx context.Context, input CreatePersonInput) (*CreatePersonResult, error) {
 	// Validate required fields
-	if input.GivenName == "" || input.Surname == "" {
-		return nil, fmt.Errorf("%w: given_name and surname are required", ErrInvalidInput)
+	if input.GivenName == "" {
+		return nil, fmt.Errorf("%w: given_name is required", ErrInvalidInput)
 	}
 
 	// Create person entity

--- a/internal/command/person_commands_test.go
+++ b/internal/command/person_commands_test.go
@@ -60,14 +60,35 @@ func TestCreatePerson_Validation(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for empty given name")
 	}
+}
 
-	// Missing surname
-	_, err = handler.CreatePerson(ctx, command.CreatePersonInput{
-		GivenName: "John",
-		Surname:   "",
+func TestCreatePerson_EmptySurname(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	result, err := handler.CreatePerson(ctx, command.CreatePersonInput{
+		GivenName:      "Madonna",
+		Surname:        "",
+		Gender:         "female",
+		ResearchStatus: "possible",
 	})
-	if err == nil {
-		t.Error("Expected error for empty surname")
+	if err != nil {
+		t.Fatalf("CreatePerson with empty surname failed: %v", err)
+	}
+	if result.ID == uuid.Nil {
+		t.Error("Expected non-nil ID")
+	}
+	person, _ := readStore.GetPerson(ctx, result.ID)
+	if person == nil {
+		t.Fatal("Person not found in read model")
+	}
+	if person.GivenName != "Madonna" {
+		t.Errorf("GivenName = %s, want Madonna", person.GivenName)
+	}
+	if person.Surname != "" {
+		t.Errorf("Surname = %s, want empty", person.Surname)
 	}
 }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -43,7 +43,7 @@ export interface Person {
 
 export interface PersonCreate {
 	given_name: string;
-	surname: string;
+	surname?: string;
 	gender?: 'male' | 'female' | 'unknown';
 	birth_date?: string;
 	birth_place?: string;

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -1674,7 +1674,7 @@ export interface components {
         };
         PersonCreate: {
             given_name: string;
-            surname: string;
+            surname?: string;
             /** @enum {string} */
             gender?: "male" | "female" | "unknown";
             /**

--- a/web/src/lib/components/QuickCapture.svelte
+++ b/web/src/lib/components/QuickCapture.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+	import { api, type PersonCreate } from '$lib/api/client';
+	import { goto } from '$app/navigation';
+	import { parseName } from '$lib/utils/nameParse';
+
+	let nameInput = $state('');
+	let gender = $state<'male' | 'female' | 'unknown'>('unknown');
+	let birthYear = $state('');
+	let notes = $state('');
+	let showNotes = $state(false);
+	let sessionCount = $state(0);
+	let error = $state<string | null>(null);
+	let saving = $state(false);
+
+	let parsed = $derived(parseName(nameInput));
+
+	async function submit(mode: 'next' | 'view') {
+		if (!parsed.givenName) {
+			error = 'Please enter at least a given name.';
+			return;
+		}
+
+		saving = true;
+		error = null;
+
+		try {
+			const payload: PersonCreate = {
+				given_name: parsed.givenName,
+				surname: parsed.surname,
+				gender: gender,
+				research_status: 'possible'
+			};
+
+			if (notes) {
+				payload.notes = `[Quick capture] ${notes}`;
+			} else {
+				payload.notes = '[Quick capture]';
+			}
+
+			if (birthYear) {
+				payload.birth_date = birthYear;
+			}
+
+			const person = await api.createPerson(payload);
+			sessionCount++;
+
+			if (mode === 'view') {
+				goto(`/persons/${person.id}`);
+			} else {
+				// Reset form for next entry
+				nameInput = '';
+				gender = 'unknown';
+				birthYear = '';
+				notes = '';
+				showNotes = false;
+			}
+		} catch (e) {
+			error = (e as { message?: string }).message || 'Failed to create person';
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<div class="quick-capture">
+	{#if sessionCount > 0}
+		<div class="session-counter">
+			{sessionCount} {sessionCount === 1 ? 'person' : 'people'} added this session
+		</div>
+	{/if}
+
+	{#if error}
+		<div class="error">{error}</div>
+	{/if}
+
+	<form onsubmit={(e) => { e.preventDefault(); submit('next'); }}>
+		<label class="field">
+			Full Name
+			<input
+				type="text"
+				bind:value={nameInput}
+				placeholder="e.g., John Smith or Madonna"
+				autocomplete="off"
+				required
+			/>
+		</label>
+
+		{#if nameInput.trim()}
+			<div class="name-preview">
+				<span class="preview-label">Given:</span> {parsed.givenName}
+				{#if parsed.surname}
+					<span class="preview-sep">|</span>
+					<span class="preview-label">Surname:</span> {parsed.surname}
+				{/if}
+			</div>
+		{/if}
+
+		<fieldset class="gender-group">
+			<legend>Gender</legend>
+			<div class="gender-buttons">
+				<button
+					type="button"
+					class="gender-btn"
+					class:active={gender === 'male'}
+					onclick={() => (gender = 'male')}
+				>
+					Male
+				</button>
+				<button
+					type="button"
+					class="gender-btn"
+					class:active={gender === 'female'}
+					onclick={() => (gender = 'female')}
+				>
+					Female
+				</button>
+				<button
+					type="button"
+					class="gender-btn"
+					class:active={gender === 'unknown'}
+					onclick={() => (gender = 'unknown')}
+				>
+					Unknown
+				</button>
+			</div>
+		</fieldset>
+
+		<label class="field">
+			Birth Year <span class="optional">(optional)</span>
+			<input
+				type="text"
+				bind:value={birthYear}
+				placeholder="e.g., 1850"
+				inputmode="numeric"
+			/>
+		</label>
+
+		{#if showNotes}
+			<label class="field">
+				Notes <span class="optional">(optional)</span>
+				<textarea bind:value={notes} rows="2" placeholder="Any quick notes..."></textarea>
+			</label>
+		{:else}
+			<button type="button" class="toggle-notes" onclick={() => (showNotes = true)}>
+				+ Add notes
+			</button>
+		{/if}
+
+		<div class="form-actions">
+			<button type="submit" class="btn btn-primary" disabled={saving}>
+				{saving ? 'Adding...' : 'Add & Next'}
+			</button>
+			<button type="button" class="btn btn-secondary" disabled={saving} onclick={() => submit('view')}>
+				Add & View
+			</button>
+		</div>
+	</form>
+</div>
+
+<style>
+	.quick-capture {
+		max-width: 480px;
+		margin: 0 auto;
+	}
+
+	.session-counter {
+		background: #f0fdf4;
+		border: 1px solid #bbf7d0;
+		color: #166534;
+		padding: 0.5rem 1rem;
+		border-radius: 6px;
+		font-size: 0.875rem;
+		text-align: center;
+		margin-bottom: 1rem;
+	}
+
+	.error {
+		background: #fef2f2;
+		border: 1px solid #fecaca;
+		color: #dc2626;
+		padding: 0.75rem 1rem;
+		border-radius: 6px;
+		margin-bottom: 1rem;
+		font-size: 0.875rem;
+	}
+
+	form {
+		background: white;
+		border-radius: 12px;
+		border: 1px solid #e2e8f0;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	.optional {
+		color: #94a3b8;
+		font-weight: normal;
+	}
+
+	input,
+	textarea {
+		padding: 0.75rem;
+		border: 1px solid #e2e8f0;
+		border-radius: 6px;
+		font-size: 1rem;
+		min-height: 48px;
+		box-sizing: border-box;
+	}
+
+	input:focus,
+	textarea:focus {
+		outline: none;
+		border-color: #3b82f6;
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+	}
+
+	textarea {
+		resize: vertical;
+	}
+
+	.name-preview {
+		font-size: 0.8125rem;
+		color: #64748b;
+		padding: 0.375rem 0.75rem;
+		background: #f8fafc;
+		border-radius: 4px;
+		margin-top: -0.5rem;
+	}
+
+	.preview-label {
+		font-weight: 600;
+		color: #475569;
+	}
+
+	.preview-sep {
+		margin: 0 0.5rem;
+		color: #cbd5e1;
+	}
+
+	.gender-group {
+		border: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.gender-group legend {
+		font-size: 0.875rem;
+		color: #475569;
+		margin-bottom: 0.375rem;
+	}
+
+	.gender-buttons {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.5rem;
+	}
+
+	.gender-btn {
+		padding: 0.75rem;
+		min-height: 48px;
+		border: 1px solid #e2e8f0;
+		border-radius: 6px;
+		background: white;
+		font-size: 0.875rem;
+		cursor: pointer;
+		transition: all 0.15s;
+		color: #475569;
+	}
+
+	.gender-btn:hover {
+		background: #f1f5f9;
+	}
+
+	.gender-btn.active {
+		background: #eff6ff;
+		border-color: #3b82f6;
+		color: #1d4ed8;
+		font-weight: 600;
+	}
+
+	.toggle-notes {
+		background: none;
+		border: none;
+		color: #64748b;
+		font-size: 0.8125rem;
+		cursor: pointer;
+		padding: 0.25rem 0;
+		text-align: left;
+	}
+
+	.toggle-notes:hover {
+		color: #3b82f6;
+	}
+
+	.form-actions {
+		display: flex;
+		gap: 0.75rem;
+		padding-top: 0.5rem;
+	}
+
+	.btn {
+		padding: 0.75rem 1.25rem;
+		min-height: 48px;
+		border-radius: 6px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.btn-primary {
+		flex: 1;
+		background: #3b82f6;
+		border: 1px solid #3b82f6;
+		color: white;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: #2563eb;
+	}
+
+	.btn-secondary {
+		background: white;
+		border: 1px solid #cbd5e1;
+		color: #475569;
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: #f1f5f9;
+	}
+</style>

--- a/web/src/lib/utils/nameParse.test.ts
+++ b/web/src/lib/utils/nameParse.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { parseName } from './nameParse';
+
+describe('parseName', () => {
+	it('splits first and last name', () => {
+		expect(parseName('John Smith')).toEqual({ givenName: 'John', surname: 'Smith' });
+	});
+
+	it('handles multiple given names', () => {
+		expect(parseName('Mary Jane Watson')).toEqual({ givenName: 'Mary Jane', surname: 'Watson' });
+	});
+
+	it('handles single name', () => {
+		expect(parseName('Madonna')).toEqual({ givenName: 'Madonna', surname: '' });
+	});
+
+	it('trims whitespace', () => {
+		expect(parseName('  John  Smith  ')).toEqual({ givenName: 'John', surname: 'Smith' });
+	});
+
+	it('handles empty string', () => {
+		expect(parseName('')).toEqual({ givenName: '', surname: '' });
+	});
+});

--- a/web/src/lib/utils/nameParse.ts
+++ b/web/src/lib/utils/nameParse.ts
@@ -1,0 +1,14 @@
+export function parseName(fullName: string): { givenName: string; surname: string } {
+	const trimmed = fullName.trim().replace(/\s+/g, ' ');
+	if (!trimmed) {
+		return { givenName: '', surname: '' };
+	}
+	const lastSpace = trimmed.lastIndexOf(' ');
+	if (lastSpace === -1) {
+		return { givenName: trimmed, surname: '' };
+	}
+	return {
+		givenName: trimmed.substring(0, lastSpace),
+		surname: trimmed.substring(lastSpace + 1)
+	};
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -128,6 +128,12 @@
 					</svg>
 					Add Family
 				</a>
+				<a href="/persons/quick" class="action-btn accent">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+					</svg>
+					Quick Capture
+				</a>
 			</div>
 		</section>
 	{/if}
@@ -308,5 +314,16 @@
 	.action-btn svg {
 		width: 1.25rem;
 		height: 1.25rem;
+	}
+
+	.action-btn.accent {
+		background: #f0f9ff;
+		border-color: #7dd3fc;
+		color: #0369a1;
+	}
+
+	.action-btn.accent:hover {
+		background: #e0f2fe;
+		border-color: #38bdf8;
 	}
 </style>

--- a/web/src/routes/persons/+page.svelte
+++ b/web/src/routes/persons/+page.svelte
@@ -77,6 +77,24 @@
 <div class="persons-page">
 	<header class="page-header">
 		<h1>People</h1>
+		<div class="header-actions">
+			<a href="/persons/add" class="btn">Add Person</a>
+			<a href="/persons/quick" class="btn btn-accent">Quick Capture</a>
+		</div>
+	</header>
+
+	<div class="toolbar">
+		<button
+			class="chip"
+			class:chip-active={researchStatusFilter === 'possible'}
+			onclick={() => {
+				researchStatusFilter = researchStatusFilter === 'possible' ? '' : 'possible';
+				currentPage = 1;
+				loadPersons();
+			}}
+		>
+			Quick Captures
+		</button>
 		<div class="controls">
 			<label>
 				Confidence:
@@ -110,7 +128,7 @@
 				{/if}
 			</button>
 		</div>
-	</header>
+	</div>
 
 	{#if loading}
 		<div class="loading">Loading...</div>
@@ -262,5 +280,65 @@
 	.pagination span {
 		font-size: 0.875rem;
 		color: #64748b;
+	}
+
+	.header-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.btn {
+		padding: 0.5rem 1rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 6px;
+		background: white;
+		font-size: 0.875rem;
+		cursor: pointer;
+		text-decoration: none;
+		color: #475569;
+	}
+
+	.btn:hover {
+		background: #f1f5f9;
+	}
+
+	.btn-accent {
+		background: #f0f9ff;
+		border-color: #7dd3fc;
+		color: #0369a1;
+	}
+
+	.btn-accent:hover {
+		background: #e0f2fe;
+	}
+
+	.toolbar {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+		flex-wrap: wrap;
+	}
+
+	.chip {
+		padding: 0.375rem 0.75rem;
+		border: 1px solid #e2e8f0;
+		border-radius: 9999px;
+		background: white;
+		font-size: 0.8125rem;
+		cursor: pointer;
+		color: #64748b;
+		transition: all 0.15s;
+	}
+
+	.chip:hover {
+		border-color: #cbd5e1;
+		background: #f8fafc;
+	}
+
+	.chip-active {
+		background: #fef3c7;
+		border-color: #fbbf24;
+		color: #92400e;
 	}
 </style>

--- a/web/src/routes/persons/add/+page.svelte
+++ b/web/src/routes/persons/add/+page.svelte
@@ -70,6 +70,10 @@
 		<h1>Add Person</h1>
 	</header>
 
+	<div class="quick-capture-hint">
+		Need to add many people quickly? Try <a href="/persons/quick">Quick Capture mode</a>
+	</div>
+
 	{#if error}
 		<div class="error">{error}</div>
 	{/if}
@@ -259,5 +263,23 @@
 		margin-top: 1.5rem;
 		padding-top: 1rem;
 		border-top: 1px solid #e2e8f0;
+	}
+
+	.quick-capture-hint {
+		font-size: 0.8125rem;
+		color: #64748b;
+		margin-bottom: 1rem;
+		padding: 0.5rem 0.75rem;
+		background: #f8fafc;
+		border-radius: 6px;
+	}
+
+	.quick-capture-hint a {
+		color: #3b82f6;
+		text-decoration: none;
+	}
+
+	.quick-capture-hint a:hover {
+		text-decoration: underline;
 	}
 </style>

--- a/web/src/routes/persons/quick/+page.svelte
+++ b/web/src/routes/persons/quick/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import QuickCapture from '$lib/components/QuickCapture.svelte';
+</script>
+
+<svelte:head>
+	<title>Quick Capture | My Family</title>
+</svelte:head>
+
+<div class="quick-capture-page">
+	<header class="page-header">
+		<a href="/persons" class="back-link">&larr; People</a>
+		<h1>Quick Capture</h1>
+	</header>
+	<p class="subtitle">Add people quickly with minimal info. Enrich details later.</p>
+	<QuickCapture />
+</div>
+
+<style>
+	.quick-capture-page {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+
+	.page-header {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.page-header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+		color: #1e293b;
+	}
+
+	.back-link {
+		color: #64748b;
+		text-decoration: none;
+		font-size: 0.875rem;
+	}
+
+	.back-link:hover {
+		color: #3b82f6;
+	}
+
+	.subtitle {
+		color: #64748b;
+		font-size: 0.875rem;
+		margin: 0 0 1.5rem;
+	}
+</style>


### PR DESCRIPTION
## Summary
- Streamlined data entry for quickly adding people with minimal info
- Smart name parsing: "John Smith" -> given_name="John", surname="Smith"
- Entries marked with `research_status=possible` for easy filtering
- Mobile-first design with large touch targets (48px min-height inputs)
- Session counter tracks additions; "Add & Next" for batch entry
- Backend: relax surname requirement (domain already allowed empty surnames)

New: QuickCapture component, `/persons/quick` route, name parsing utility, "Quick Captures" filter chip on persons list, dashboard button.

## Test plan
- [ ] Create person with just a given name (no surname) succeeds
- [ ] Smart name parsing splits correctly for 1, 2, and 3+ word names
- [ ] Quick capture form creates person with research_status=possible
- [ ] "Add & Next" clears form and increments counter
- [ ] "Add & View" navigates to the created person's detail page
- [ ] "Quick Captures" filter on persons list shows only possible-status entries
- [ ] Birth year field shows numeric keyboard on mobile
- [ ] Go tests pass with relaxed surname validation

Closes #43

Generated with [Claude Code](https://claude.com/claude-code)
