### PR TITLE
Repair security job and dependabot PR title failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
     commit-message:
-      prefix: "ci"
+      prefix: "deps"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,26 +260,29 @@ jobs:
         run: cd web && npm audit --audit-level=moderate
 
       # SAST: Go security issues
+      # Pinned to v2.22.11 — v2.23.0 produces invalid SARIF (securego/gosec#877)
       - name: Go security scan (gosec)
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11
           gosec -exclude=G104 -exclude-generated -fmt sarif -out gosec-results.sarif ./...
 
       - name: Upload gosec results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: success() || failure()
+        if: (success() || failure()) && hashFiles('gosec-results.sarif') != ''
         with:
           sarif_file: gosec-results.sarif
           category: gosec
 
       # Secret detection
       - name: Detect secrets (gitleaks)
+        if: success() || failure()
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Trivy: Filesystem vulnerability and misconfiguration scanning
       - name: Trivy filesystem scan
+        if: success() || failure()
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'
@@ -290,21 +293,21 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: success() || failure()
+        if: (success() || failure()) && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: trivy-results.sarif
           category: trivy
 
       # Semgrep: Rule-based static analysis
       - name: Semgrep scan
+        if: success() || failure()
         uses: docker://semgrep/semgrep:latest
         with:
           args: semgrep scan --config p/security-audit --config p/secrets --config p/golang --config p/typescript --sarif --output semgrep.sarif .
-        continue-on-error: true
 
       - name: Upload Semgrep results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: (success() || failure()) && hashFiles('semgrep.sarif') != ''
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
## Summary
- **Pin gosec to v2.22.11** — v2.23.0 (released Feb 11) produces invalid SARIF output (securego/gosec#877), breaking the upload-sarif step on every PR
- **Make all security scanners run independently** — previously, a gosec failure silently skipped trivy, semgrep, and gitleaks, resulting in fewer security scans running
- **Guard SARIF upload steps with hashFiles() checks** — prevents confusing file not found errors; the actual scan step failure remains visible
- **Change dependabot github-actions prefix from ci to deps** — ci: triggers the PR title check that rejects conventional commit format; these are dependency updates, consistent with the other ecosystems

## Test plan
- [ ] Verify security job passes on this PRs CI run
- [ ] Confirm all 4 scanners (gosec, gitleaks, trivy, semgrep) execute independently
- [ ] Re-run existing dependabot PRs to confirm title check passes

Generated with [Claude Code](https://claude.com/claude-code)