### PR TITLE
Fix dependabot automerge actor check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary
- Checks `github.event.pull_request.user.login` (PR author) instead of `github.actor` (event trigger)
- When dependabot rebases PRs after a merge, the triggering actor is the user who merged, not dependabot, causing the job to be skipped

## Test plan
- [ ] Verify automerge workflow runs on existing dependabot PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve the automated dependency management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->