### PR TITLE
Use pull_request_target for dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,6 +1,6 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Switch dependabot automerge workflow from `pull_request` to `pull_request_target` event
- Fixes all Dependabot PRs failing with "commit signature is not verified" because `pull_request` doesn't grant sufficient permissions for `dependabot/fetch-metadata` to verify signatures

## Test plan
- [ ] Verify this PR's own CI passes
- [ ] Confirm one of the open Dependabot PRs gets auto-merged after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)