### PR TITLE
Fix Dependabot commit-message prefix to match conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
+      include: "scope"
     labels:
       - "dependencies"
       - "go"
@@ -23,7 +24,8 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
+      include: "scope"
     labels:
       - "dependencies"
       - "ci"
@@ -37,7 +39,8 @@ updates:
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
+      include: "scope"
     labels:
       - "dependencies"
       - "frontend"


### PR DESCRIPTION
## Summary
- Changes Dependabot `commit-message` config from `prefix: "deps"` to `prefix: "chore"` with `include: "scope"`
- Future Dependabot PRs will use `chore(deps): bump ...` format, matching both CONVENTIONS.md and the CI PR title check exemption pattern
- Previous `deps:` prefix passed the title check by accident (not a conventional commit type), not by matching the exemption

## Test plan
- [ ] Verify next Dependabot PR uses `chore(deps): bump ...` title format
- [ ] Verify CI PR Title Check passes for new Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to improve commit message formatting and PR organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->