### PR TITLE
Add citations export endpoint and UI

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1781,6 +1781,27 @@ paths:
                   total:
                     type: integer
 
+  /export/citations:
+    get:
+      operationId: exportCitations
+      summary: Export citations data
+      description: Export all citations data in a structured format
+      tags: [export]
+      responses:
+        '200':
+          description: Citations data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  citations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Citation'
+                  total:
+                    type: integer
+
   /export/events:
     get:
       operationId: exportEvents

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -813,6 +813,25 @@ func (ss *StrictServer) ExportSources(ctx context.Context, _ ExportSourcesReques
 	}, nil
 }
 
+// ExportCitations implements StrictServerInterface.
+func (ss *StrictServer) ExportCitations(ctx context.Context, _ ExportCitationsRequestObject) (ExportCitationsResponseObject, error) {
+	readModels, err := repository.ListAll(ctx, 1000, ss.server.readStore.ListCitations)
+	if err != nil {
+		return nil, err
+	}
+
+	citations := make([]Citation, len(readModels))
+	for i, rm := range readModels {
+		citations[i] = convertReadModelCitationToGenerated(rm)
+	}
+
+	total := len(citations)
+	return ExportCitations200JSONResponse{
+		Citations: &citations,
+		Total:     &total,
+	}, nil
+}
+
 // ExportEvents implements StrictServerInterface.
 func (ss *StrictServer) ExportEvents(ctx context.Context, _ ExportEventsRequestObject) (ExportEventsResponseObject, error) {
 	events, err := repository.ListAll(ctx, 1000, ss.server.readStore.ListEvents)
@@ -4888,6 +4907,45 @@ func convertReadModelSourceToGenerated(rm repository.SourceReadModel) Source {
 	}
 	if rm.Notes != "" {
 		resp.Notes = &rm.Notes
+	}
+	return resp
+}
+
+func convertReadModelCitationToGenerated(rm repository.CitationReadModel) Citation {
+	resp := Citation{
+		Id:          rm.ID,
+		SourceId:    rm.SourceID,
+		SourceTitle: rm.SourceTitle,
+		FactType:    string(rm.FactType),
+		FactOwnerId: rm.FactOwnerID,
+		Version:     rm.Version,
+	}
+	if rm.Page != "" {
+		resp.Page = &rm.Page
+	}
+	if rm.Volume != "" {
+		resp.Volume = &rm.Volume
+	}
+	if string(rm.SourceQuality) != "" {
+		sq := string(rm.SourceQuality)
+		resp.SourceQuality = &sq
+	}
+	if string(rm.InformantType) != "" {
+		it := string(rm.InformantType)
+		resp.InformantType = &it
+	}
+	if string(rm.EvidenceType) != "" {
+		et := string(rm.EvidenceType)
+		resp.EvidenceType = &et
+	}
+	if rm.QuotedText != "" {
+		resp.QuotedText = &rm.QuotedText
+	}
+	if rm.Analysis != "" {
+		resp.Analysis = &rm.Analysis
+	}
+	if rm.TemplateID != "" {
+		resp.TemplateId = &rm.TemplateID
 	}
 	return resp
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -952,6 +952,24 @@ class ApiClient {
 		return response.text();
 	}
 
+	async exportCitations(format: 'json' | 'csv', fields?: string[]): Promise<string> {
+		const params = new URLSearchParams({ format });
+		if (fields?.length) params.set('fields', fields.join(','));
+
+		const response = await fetch(`${API_BASE}/export/citations?${params}`);
+
+		if (!response.ok) {
+			const error: ApiError = await response.json().catch(() => ({
+				code: 'UNKNOWN_ERROR',
+				message: response.statusText
+			}));
+			error.status = response.status;
+			throw error;
+		}
+
+		return response.text();
+	}
+
 	async exportEvents(format: 'json' | 'csv', fields?: string[]): Promise<string> {
 		const params = new URLSearchParams({ format });
 		if (fields?.length) params.set('fields', fields.join(','));

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -1040,6 +1040,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/export/citations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export citations data
+         * @description Export all citations data in a structured format
+         */
+        get: operations["exportCitations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/export/events": {
         parameters: {
             query?: never;
@@ -5269,6 +5289,29 @@ export interface operations {
                 content: {
                     "application/json": {
                         sources?: components["schemas"]["Source"][];
+                        total?: number;
+                    };
+                };
+            };
+        };
+    };
+    exportCitations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Citations data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        citations?: components["schemas"]["Citation"][];
                         total?: number;
                     };
                 };

--- a/web/src/routes/import/+page.svelte
+++ b/web/src/routes/import/+page.svelte
@@ -10,7 +10,7 @@
 	let dragOver = $state(false);
 
 	// Export state
-	type EntityType = 'tree' | 'persons' | 'families' | 'sources' | 'events' | 'attributes';
+	type EntityType = 'tree' | 'persons' | 'families' | 'sources' | 'citations' | 'events' | 'attributes';
 	type ExportFormat = 'json' | 'csv';
 
 	let exportEntityType: EntityType = $state('tree');
@@ -57,6 +57,21 @@
 		{ id: 'notes', label: 'Notes' }
 	];
 
+	const citationFields = [
+		{ id: 'id', label: 'ID' },
+		{ id: 'source_id', label: 'Source ID' },
+		{ id: 'source_title', label: 'Source Title' },
+		{ id: 'fact_type', label: 'Fact Type' },
+		{ id: 'fact_owner_id', label: 'Fact Owner' },
+		{ id: 'page', label: 'Page' },
+		{ id: 'volume', label: 'Volume' },
+		{ id: 'source_quality', label: 'Source Quality' },
+		{ id: 'informant_type', label: 'Informant Type' },
+		{ id: 'evidence_type', label: 'Evidence Type' },
+		{ id: 'quoted_text', label: 'Quoted Text' },
+		{ id: 'analysis', label: 'Analysis' }
+	];
+
 	const eventFields = [
 		{ id: 'id', label: 'ID' },
 		{ id: 'owner_type', label: 'Owner Type' },
@@ -83,6 +98,7 @@
 	let selectedPersonFields: Set<string> = $state(new Set(personFields.map((f) => f.id)));
 	let selectedFamilyFields: Set<string> = $state(new Set(familyFields.map((f) => f.id)));
 	let selectedSourceFields: Set<string> = $state(new Set(sourceFields.map((f) => f.id)));
+	let selectedCitationFields: Set<string> = $state(new Set(citationFields.map((f) => f.id)));
 	let selectedEventFields: Set<string> = $state(new Set(eventFields.map((f) => f.id)));
 	let selectedAttributeFields: Set<string> = $state(new Set(attributeFields.map((f) => f.id)));
 
@@ -102,6 +118,11 @@
 			if (newSet.has(fieldId)) newSet.delete(fieldId);
 			else newSet.add(fieldId);
 			selectedSourceFields = newSet;
+		} else if (entityType === 'citations') {
+			const newSet = new Set(selectedCitationFields);
+			if (newSet.has(fieldId)) newSet.delete(fieldId);
+			else newSet.add(fieldId);
+			selectedCitationFields = newSet;
 		} else if (entityType === 'events') {
 			const newSet = new Set(selectedEventFields);
 			if (newSet.has(fieldId)) newSet.delete(fieldId);
@@ -122,6 +143,8 @@
 			selectedFamilyFields = new Set(familyFields.map((f) => f.id));
 		} else if (entityType === 'sources') {
 			selectedSourceFields = new Set(sourceFields.map((f) => f.id));
+		} else if (entityType === 'citations') {
+			selectedCitationFields = new Set(citationFields.map((f) => f.id));
 		} else if (entityType === 'events') {
 			selectedEventFields = new Set(eventFields.map((f) => f.id));
 		} else if (entityType === 'attributes') {
@@ -136,6 +159,8 @@
 			selectedFamilyFields = new Set();
 		} else if (entityType === 'sources') {
 			selectedSourceFields = new Set();
+		} else if (entityType === 'citations') {
+			selectedCitationFields = new Set();
 		} else if (entityType === 'events') {
 			selectedEventFields = new Set();
 		} else if (entityType === 'attributes') {
@@ -148,6 +173,7 @@
 			case 'persons': return personFields;
 			case 'families': return familyFields;
 			case 'sources': return sourceFields;
+			case 'citations': return citationFields;
 			case 'events': return eventFields;
 			case 'attributes': return attributeFields;
 			default: return [];
@@ -159,6 +185,7 @@
 			case 'persons': return selectedPersonFields;
 			case 'families': return selectedFamilyFields;
 			case 'sources': return selectedSourceFields;
+			case 'citations': return selectedCitationFields;
 			case 'events': return selectedEventFields;
 			case 'attributes': return selectedAttributeFields;
 			default: return new Set();
@@ -171,6 +198,7 @@
 			case 'persons': return 'People';
 			case 'families': return 'Families';
 			case 'sources': return 'Sources';
+			case 'citations': return 'Citations';
 			case 'events': return 'Events';
 			case 'attributes': return 'Attributes';
 			default: return '';
@@ -261,6 +289,12 @@
 					exportFormat === 'csv' ? Array.from(selectedSourceFields) : undefined;
 				data = await api.exportSources(exportFormat, fields);
 				filename = `sources.${exportFormat}`;
+				contentType = exportFormat === 'csv' ? 'text/csv' : 'application/json';
+			} else if (exportEntityType === 'citations') {
+				const fields =
+					exportFormat === 'csv' ? Array.from(selectedCitationFields) : undefined;
+				data = await api.exportCitations(exportFormat, fields);
+				filename = `citations.${exportFormat}`;
 				contentType = exportFormat === 'csv' ? 'text/csv' : 'application/json';
 			} else if (exportEntityType === 'events') {
 				const fields =
@@ -474,6 +508,15 @@
 								bind:group={exportEntityType}
 							/>
 							<span>Sources</span>
+						</label>
+						<label class="radio-label">
+							<input
+								type="radio"
+								name="entityType"
+								value="citations"
+								bind:group={exportEntityType}
+							/>
+							<span>Citations</span>
 						</label>
 						<label class="radio-label">
 							<input


### PR DESCRIPTION
## Summary

- Add `/export/citations` GET endpoint to OpenAPI spec using the existing `Citation` schema (consistent with other export endpoints)
- Implement `ExportCitations` handler in `server_strict.go` with `convertReadModelCitationToGenerated` conversion function
- Add `exportCitations` method to the TypeScript API client
- Add `citations` to the `EntityType` union and add `citationFields` definition in the export UI
- Regenerate `generated.go` and `types.generated.ts` from the updated OpenAPI spec

This completes the export layer for citations - the exporter package already had full JSON/CSV support (`EntityTypeCitations`) but the API and UI were missing.

## Test plan

- [ ] Verify `/export/citations` returns JSON with `citations` array and `total` count
- [ ] Verify the export UI shows "Citations" as a radio option in the entity type selector
- [ ] Verify field selection and select-all/deselect-all work for citations in the UI
- [ ] Verify CSV export with selected citation fields works end-to-end
- [ ] All Go tests pass: `make test`
- [ ] Coverage thresholds met: `make check-coverage`

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added citations export capability supporting JSON and CSV formats
  * Added citations as a selectable entity type in the export interface with customizable field selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->