### PR TITLE
Fix Dockerfile Go version to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY web/ ./
 RUN npm run build
 
 # Build stage: Backend
-FROM golang:1.25.7-alpine AS backend-builder
+FROM golang:1.25.8-alpine AS backend-builder
 
 # Install build dependencies for CGO (required for SQLite)
 RUN apk add --no-cache gcc musl-dev


### PR DESCRIPTION
## Summary
- Bumps Dockerfile Go version from 1.25.7 to 1.25.8 to match `go.mod` requirement
- Fixes `docker-smoke-test` CI failure blocking all open PRs (#343, #344, #286)

## Test plan
- [ ] Verify `docker-smoke-test` CI job passes on this PR
- [ ] Verify dependabot PRs can be retried/rebased and pass CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment infrastructure. Build processes and application functionality remain unchanged. This maintenance release does not impact user-facing features, system behavior, or any existing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->