### PR TITLE
Add gedcom_xref field to Citation API schema

### DIFF
--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -1483,8 +1483,11 @@ type Citation struct {
 	FactOwnerId openapi_types.UUID `json:"fact_owner_id"`
 
 	// FactType Type of fact being cited (e.g., birth, death, marriage)
-	FactType string             `json:"fact_type"`
-	Id       openapi_types.UUID `json:"id"`
+	FactType string `json:"fact_type"`
+
+	// GedcomXref GEDCOM cross-reference ID (e.g., "@C1@") for round-trip support
+	GedcomXref *string            `json:"gedcom_xref,omitempty"`
+	Id         openapi_types.UUID `json:"id"`
 
 	// InformantType Type of informant (e.g., primary, secondary)
 	InformantType *string `json:"informant_type,omitempty"`
@@ -1517,7 +1520,10 @@ type CitationCreate struct {
 	FactOwnerId openapi_types.UUID `json:"fact_owner_id"`
 
 	// FactType Type of fact being cited (e.g., birth, death, marriage)
-	FactType      string             `json:"fact_type"`
+	FactType string `json:"fact_type"`
+
+	// GedcomXref Optional GEDCOM cross-reference ID for import
+	GedcomXref    *string            `json:"gedcom_xref,omitempty"`
 	InformantType *string            `json:"informant_type,omitempty"`
 	Page          *string            `json:"page,omitempty"`
 	QuotedText    *string            `json:"quoted_text,omitempty"`

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -4333,6 +4333,9 @@ components:
         template_id:
           type: string
           description: Citation template ID
+        gedcom_xref:
+          type: string
+          description: GEDCOM cross-reference ID (e.g., "@C1@") for round-trip support
         version:
           type: integer
           format: int64
@@ -4368,6 +4371,9 @@ components:
           type: string
         template_id:
           type: string
+        gedcom_xref:
+          type: string
+          description: Optional GEDCOM cross-reference ID for import
 
     CitationUpdate:
       type: object

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -512,6 +512,9 @@ func (ss *StrictServer) CreateCitation(ctx context.Context, request CreateCitati
 	if request.Body.TemplateId != nil {
 		input.TemplateID = *request.Body.TemplateId
 	}
+	if request.Body.GedcomXref != nil {
+		input.GedcomXref = *request.Body.GedcomXref
+	}
 
 	result, err := ss.server.commandHandler.CreateCitation(ctx, input)
 	if err != nil {
@@ -3629,6 +3632,7 @@ func convertQueryCitationToGenerated(c query.Citation) Citation {
 		QuotedText:    c.QuotedText,
 		Analysis:      c.Analysis,
 		TemplateId:    c.TemplateID,
+		GedcomXref:    c.GedcomXref,
 		Version:       c.Version,
 	}
 }
@@ -4949,6 +4953,9 @@ func convertReadModelCitationToGenerated(rm repository.CitationReadModel) Citati
 	}
 	if rm.TemplateID != "" {
 		resp.TemplateId = &rm.TemplateID
+	}
+	if rm.GedcomXref != "" {
+		resp.GedcomXref = &rm.GedcomXref
 	}
 	return resp
 }

--- a/internal/api/source_handlers_test.go
+++ b/internal/api/source_handlers_test.go
@@ -290,8 +290,11 @@ func TestCreateCitation(t *testing.T) {
 	json.Unmarshal(personRec.Body.Bytes(), &personResp)
 	personID := personResp["id"].(string)
 
-	// Create citation
-	citationBody := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `","page":"123"}`
+	// Create citation with all optional fields including gedcom_xref
+	citationBody := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `",` +
+		`"page":"123","volume":"Vol 1","source_quality":"original","informant_type":"primary",` +
+		`"evidence_type":"direct","quoted_text":"Born Jan 1","analysis":"Good evidence","template_id":"tmpl1",` +
+		`"gedcom_xref":"@C1@"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(citationBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -310,6 +313,9 @@ func TestCreateCitation(t *testing.T) {
 	}
 	if resp["fact_type"] != "person_birth" {
 		t.Errorf("fact_type = %v, want person_birth", resp["fact_type"])
+	}
+	if resp["gedcom_xref"] != "@C1@" {
+		t.Errorf("gedcom_xref = %v, want @C1@", resp["gedcom_xref"])
 	}
 }
 
@@ -337,8 +343,8 @@ func TestGetCitation(t *testing.T) {
 	json.Unmarshal(personRec.Body.Bytes(), &personResp)
 	personID := personResp["id"].(string)
 
-	// Create citation
-	citationBody := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `"}`
+	// Create citation with gedcom_xref
+	citationBody := `{"source_id":"` + sourceID + `","fact_type":"person_birth","fact_owner_id":"` + personID + `","gedcom_xref":"@C2@"}`
 	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/citations", strings.NewReader(citationBody))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
@@ -363,6 +369,9 @@ func TestGetCitation(t *testing.T) {
 	}
 	if resp["fact_type"] != "person_birth" {
 		t.Errorf("fact_type = %v, want person_birth", resp["fact_type"])
+	}
+	if resp["gedcom_xref"] != "@C2@" {
+		t.Errorf("gedcom_xref = %v, want @C2@", resp["gedcom_xref"])
 	}
 }
 

--- a/internal/command/source_commands.go
+++ b/internal/command/source_commands.go
@@ -263,6 +263,7 @@ type CreateCitationInput struct {
 	QuotedText    string
 	Analysis      string
 	TemplateID    string
+	GedcomXref    string
 }
 
 // CreateCitationResult contains the result of creating a citation.
@@ -320,6 +321,9 @@ func (h *Handler) CreateCitation(ctx context.Context, input CreateCitationInput)
 	}
 	if input.TemplateID != "" {
 		citation.TemplateID = input.TemplateID
+	}
+	if input.GedcomXref != "" {
+		citation.GedcomXref = input.GedcomXref
 	}
 
 	// Validate citation

--- a/internal/query/source_queries.go
+++ b/internal/query/source_queries.go
@@ -53,6 +53,7 @@ type Citation struct {
 	QuotedText    *string   `json:"quoted_text,omitempty"`
 	Analysis      *string   `json:"analysis,omitempty"`
 	TemplateID    *string   `json:"template_id,omitempty"`
+	GedcomXref    *string   `json:"gedcom_xref,omitempty"`
 	Version       int64     `json:"version"`
 	CreatedAt     time.Time `json:"created_at"`
 }
@@ -292,6 +293,9 @@ func convertReadModelToCitation(rm repository.CitationReadModel) Citation {
 	}
 	if rm.TemplateID != "" {
 		c.TemplateID = &rm.TemplateID
+	}
+	if rm.GedcomXref != "" {
+		c.GedcomXref = &rm.GedcomXref
 	}
 
 	return c

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -2582,6 +2582,8 @@ export interface components {
             analysis?: string;
             /** @description Citation template ID */
             template_id?: string;
+            /** @description GEDCOM cross-reference ID (e.g., "@C1@") for round-trip support */
+            gedcom_xref?: string;
             /**
              * Format: int64
              * @description Optimistic locking version
@@ -2606,6 +2608,8 @@ export interface components {
             quoted_text?: string;
             analysis?: string;
             template_id?: string;
+            /** @description Optional GEDCOM cross-reference ID for import */
+            gedcom_xref?: string;
         };
         CitationUpdate: {
             page?: string;


### PR DESCRIPTION
## Summary
- Add `gedcom_xref` to `Citation` response and `CitationCreate` request schemas in OpenAPI spec
- Wire field through command input, query model, and API converter functions
- Matches existing pattern from Note and Submitter entities for GEDCOM round-trip support

Closes #284

## Test plan
- [x] Existing tests pass
- [x] New test coverage for gedcom_xref in create and get citation endpoints
- [x] `make check-coverage` passes (76.1%)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Citations now include an optional GEDCOM cross-reference identifier field for enhanced data compatibility and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->