### PR TITLE
Migrate custom CSS to shadcn-svelte components (Phase 1)

### DIFF
--- a/web/src/lib/components/ChangeHistory.svelte
+++ b/web/src/lib/components/ChangeHistory.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api, type ChangeEntry, type ChangeHistoryResponse } from '$lib/api/client';
+	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import DiffView from './DiffView.svelte';
 
@@ -32,14 +33,16 @@
 		});
 	}
 
+	function getActionBadgeVariant(action: string): 'destructive' | undefined {
+		return action === 'deleted' ? 'destructive' : undefined;
+	}
+
 	function getActionBadgeClass(action: string): string {
 		switch (action) {
 			case 'created':
-				return 'badge-created';
+				return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
 			case 'updated':
-				return 'badge-updated';
-			case 'deleted':
-				return 'badge-deleted';
+				return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400';
 			default:
 				return '';
 		}
@@ -176,7 +179,7 @@
 				<div class="timeline-entry">
 					<div class="entry-header">
 						<span class="timestamp">{formatTimestamp(entry.timestamp)}</span>
-						<span class="action-badge {getActionBadgeClass(entry.action)}">{entry.action}</span>
+						<Badge variant={getActionBadgeVariant(entry.action)} class="capitalize {getActionBadgeClass(entry.action)}">{entry.action}</Badge>
 					</div>
 					<div class="entry-body">
 						<span class="entity-type">{entry.entity_type}</span>
@@ -288,30 +291,6 @@
 	.timestamp {
 		font-size: 0.8125rem;
 		color: #64748b;
-	}
-
-	.action-badge {
-		display: inline-block;
-		padding: 0.125rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.75rem;
-		font-weight: 500;
-		text-transform: capitalize;
-	}
-
-	.badge-created {
-		background: #22c55e;
-		color: white;
-	}
-
-	.badge-updated {
-		background: #3b82f6;
-		color: white;
-	}
-
-	.badge-deleted {
-		background: #ef4444;
-		color: white;
 	}
 
 	.entry-body {

--- a/web/src/lib/components/ConflictError.svelte
+++ b/web/src/lib/components/ConflictError.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+
 	interface Props {
 		message?: string;
 		onRetry: () => void;
@@ -20,9 +22,9 @@
 		<p class="conflict-message">
 			{message || 'This record was updated by another operation. Your changes were not lost.'}
 		</p>
-		<button class="btn-retry" onclick={onRetry} disabled={retrying}>
+		<Button variant="destructive" onclick={onRetry} disabled={retrying}>
 			{retrying ? 'Retrying...' : 'Try Again'}
-		</button>
+		</Button>
 	</div>
 </div>
 
@@ -52,26 +54,7 @@
 		color: #92400e;
 	}
 
-	.btn-retry {
-		padding: 0.375rem 0.75rem;
-		font-size: 0.8125rem;
-		border: 1px solid #fbbf24;
-		border-radius: 6px;
-		background: white;
-		color: #92400e;
-		cursor: pointer;
-	}
-
-	.btn-retry:hover {
-		background: #fffbeb;
-	}
-
-	.btn-retry:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	:global(body.high-contrast) .conflict-error {
+:global(body.high-contrast) .conflict-error {
 		border-color: #d97706;
 		background: #fef3c7;
 	}

--- a/web/src/lib/components/DiscoveryFeed.svelte
+++ b/web/src/lib/components/DiscoveryFeed.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api, type DiscoverySuggestion } from '$lib/api/client';
+	import { Card, CardContent } from '$lib/components/ui/card';
 
 	type SuggestionType = DiscoverySuggestion['type'];
 
@@ -85,39 +86,43 @@
 
 		<div class="feed-grid">
 			{#each displayedSuggestions as suggestion}
-				<a href={suggestion.action_url} class="feed-card" data-type={suggestion.type}>
-					<div class="card-icon">
-						{#if suggestion.type === 'missing_data'}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<circle cx="11" cy="11" r="8" />
-								<line x1="21" y1="21" x2="16.65" y2="16.65" />
-							</svg>
-						{:else if suggestion.type === 'orphan'}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-								<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-							</svg>
-						{:else if suggestion.type === 'unassessed'}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M9 11l3 3L22 4" />
-								<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-							</svg>
-						{:else if suggestion.type === 'brick_wall_resolved'}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-							</svg>
-						{:else}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<line x1="18" y1="20" x2="18" y2="10" />
-								<line x1="12" y1="20" x2="12" y2="4" />
-								<line x1="6" y1="20" x2="6" y2="14" />
-							</svg>
-						{/if}
-					</div>
-					<div class="card-content">
-						<h4 class="card-title">{suggestion.title}</h4>
-						<p class="card-desc">{suggestion.description}</p>
-					</div>
+				<a href={suggestion.action_url} class="feed-card-link" data-type={suggestion.type}>
+					<Card size="sm" class="h-full p-0 hover:ring-primary/30 hover:shadow-sm transition-all">
+						<CardContent class="flex gap-3 p-4">
+							<div class="feed-icon">
+								{#if suggestion.type === 'missing_data'}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<circle cx="11" cy="11" r="8" />
+										<line x1="21" y1="21" x2="16.65" y2="16.65" />
+									</svg>
+								{:else if suggestion.type === 'orphan'}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+										<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+									</svg>
+								{:else if suggestion.type === 'unassessed'}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M9 11l3 3L22 4" />
+										<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+									</svg>
+								{:else if suggestion.type === 'brick_wall_resolved'}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+									</svg>
+								{:else}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<line x1="18" y1="20" x2="18" y2="10" />
+										<line x1="12" y1="20" x2="12" y2="4" />
+										<line x1="6" y1="20" x2="6" y2="14" />
+									</svg>
+								{/if}
+							</div>
+							<div class="min-w-0">
+								<h4 class="mb-1 text-[0.8125rem] font-semibold text-foreground">{suggestion.title}</h4>
+								<p class="m-0 text-xs leading-snug text-muted-foreground line-clamp-2">{suggestion.description}</p>
+							</div>
+						</CardContent>
+					</Card>
 				</a>
 			{/each}
 		</div>
@@ -188,30 +193,18 @@
 		gap: 0.75rem;
 	}
 
-	.feed-card {
-		display: flex;
-		gap: 0.75rem;
-		padding: 1rem;
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
+	.feed-card-link {
 		text-decoration: none;
 		color: inherit;
-		transition: all 0.15s ease;
 	}
 
-	.feed-card:hover {
-		border-color: #3b82f6;
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-		transform: translateY(-1px);
-	}
-
-	.feed-card:focus {
-		outline: 2px solid #3b82f6;
+	.feed-card-link:focus-visible {
+		outline: 2px solid hsl(var(--primary));
 		outline-offset: 2px;
+		border-radius: 0.75rem;
 	}
 
-	.card-icon {
+	.feed-icon {
 		flex-shrink: 0;
 		width: 2rem;
 		height: 2rem;
@@ -222,57 +215,34 @@
 		padding: 0.375rem;
 	}
 
-	.card-icon svg {
+	.feed-icon :global(svg) {
 		width: 100%;
 		height: 100%;
 	}
 
-	[data-type="missing_data"] .card-icon {
+	[data-type="missing_data"] .feed-icon {
 		background: #fef3c7;
 		color: #b45309;
 	}
 
-	[data-type="orphan"] .card-icon {
+	[data-type="orphan"] .feed-icon {
 		background: #fce7f3;
 		color: #be185d;
 	}
 
-	[data-type="unassessed"] .card-icon {
+	[data-type="unassessed"] .feed-icon {
 		background: #e0e7ff;
 		color: #4338ca;
 	}
 
-	[data-type="brick_wall_resolved"] .card-icon {
+	[data-type="brick_wall_resolved"] .feed-icon {
 		background: #dcfce7;
 		color: #15803d;
 	}
 
-	[data-type="quality_gap"] .card-icon {
+	[data-type="quality_gap"] .feed-icon {
 		background: #f0f9ff;
 		color: #0369a1;
-	}
-
-	.card-content {
-		min-width: 0;
-	}
-
-	.card-title {
-		margin: 0 0 0.25rem;
-		font-size: 0.8125rem;
-		font-weight: 600;
-		color: #1e293b;
-	}
-
-	.card-desc {
-		margin: 0;
-		font-size: 0.75rem;
-		color: #64748b;
-		line-height: 1.4;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
 	}
 
 	.view-more {

--- a/web/src/lib/components/MediaLightbox.svelte
+++ b/web/src/lib/components/MediaLightbox.svelte
@@ -74,28 +74,28 @@
 		</div>
 
 		<!-- Close button -->
-		<button class="close-btn" onclick={onClose} aria-label="Close lightbox">
-			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+		<Button variant="ghost" size="icon" class="absolute top-4 right-4 z-10 rounded-full text-white hover:bg-white/20" onclick={onClose} aria-label="Close lightbox">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-6">
 				<line x1="18" y1="6" x2="6" y2="18" />
 				<line x1="6" y1="6" x2="18" y2="18" />
 			</svg>
-		</button>
+		</Button>
 
 		<!-- Navigation buttons -->
 		{#if allMedia.length > 1 && currentIndex > 0}
-			<button class="nav-btn nav-prev" onclick={goToPrevious} aria-label="Previous media">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+			<Button variant="ghost" size="icon" class="nav-prev absolute top-1/2 left-4 z-10 -translate-y-1/2 rounded-full text-white hover:bg-white/20 h-12 w-12" onclick={goToPrevious} aria-label="Previous media">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-6">
 					<polyline points="15 18 9 12 15 6" />
 				</svg>
-			</button>
+			</Button>
 		{/if}
 
 		{#if allMedia.length > 1 && currentIndex < allMedia.length - 1}
-			<button class="nav-btn nav-next" onclick={goToNext} aria-label="Next media">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+			<Button variant="ghost" size="icon" class="nav-next absolute top-1/2 right-4 z-10 -translate-y-1/2 rounded-full text-white hover:bg-white/20 h-12 w-12" onclick={goToNext} aria-label="Next media">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-6">
 					<polyline points="9 18 15 12 9 6" />
 				</svg>
-			</button>
+			</Button>
 		{/if}
 
 		<div class="lightbox-content">
@@ -185,69 +185,7 @@
 </Dialog.Root>
 
 <style>
-	.close-btn {
-		position: absolute;
-		top: 1rem;
-		right: 1rem;
-		width: 2.5rem;
-		height: 2.5rem;
-		border: none;
-		background: rgba(255, 255, 255, 0.1);
-		border-radius: 50%;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: background 0.2s;
-		z-index: 10;
-	}
-
-	.close-btn svg {
-		width: 1.5rem;
-		height: 1.5rem;
-		color: white;
-	}
-
-	.close-btn:hover {
-		background: rgba(255, 255, 255, 0.2);
-	}
-
-	.nav-btn {
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-		width: 3rem;
-		height: 3rem;
-		border: none;
-		background: rgba(255, 255, 255, 0.1);
-		border-radius: 50%;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: background 0.2s;
-		z-index: 10;
-	}
-
-	.nav-btn svg {
-		width: 1.5rem;
-		height: 1.5rem;
-		color: white;
-	}
-
-	.nav-btn:hover {
-		background: rgba(255, 255, 255, 0.2);
-	}
-
-	.nav-prev {
-		left: 1rem;
-	}
-
-	.nav-next {
-		right: 1rem;
-	}
-
-	.lightbox-content {
+.lightbox-content {
 		display: flex;
 		gap: 2rem;
 		width: 100%;
@@ -359,19 +297,6 @@
 		.metadata-panel {
 			width: 100%;
 			max-height: 200px;
-		}
-
-		.nav-btn {
-			width: 2.5rem;
-			height: 2.5rem;
-		}
-
-		.nav-prev {
-			left: 0.5rem;
-		}
-
-		.nav-next {
-			right: 0.5rem;
 		}
 	}
 </style>

--- a/web/src/lib/components/MediaUpload.svelte
+++ b/web/src/lib/components/MediaUpload.svelte
@@ -188,12 +188,12 @@
 					<span class="file-name">{file.name}</span>
 					<span class="file-size">{formatFileSize(file.size)}</span>
 				</div>
-				<button class="remove-btn" onclick={removeFile} type="button" aria-label="Remove file">
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<Button variant="destructive" size="icon-xs" onclick={removeFile} type="button" aria-label="Remove file">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-4">
 						<line x1="18" y1="6" x2="6" y2="18" />
 						<line x1="6" y1="6" x2="18" y2="18" />
 					</svg>
-				</button>
+				</Button>
 			</div>
 		{:else}
 			<svg class="upload-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -371,35 +371,7 @@
 		font-size: 0.75rem;
 	}
 
-	.remove-btn {
-		width: 1.75rem;
-		height: 1.75rem;
-		border: none;
-		background: #f1f5f9;
-		border-radius: 50%;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-shrink: 0;
-		transition: all 0.15s;
-	}
-
-	.remove-btn svg {
-		width: 1rem;
-		height: 1rem;
-		color: #64748b;
-	}
-
-	.remove-btn:hover {
-		background: #fee2e2;
-	}
-
-	.remove-btn:hover svg {
-		color: #dc2626;
-	}
-
-	.upload-form {
+.upload-form {
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;

--- a/web/src/lib/components/QuickCapture.svelte
+++ b/web/src/lib/components/QuickCapture.svelte
@@ -99,30 +99,33 @@
 		<fieldset class="gender-group">
 			<legend>Gender</legend>
 			<div class="gender-buttons">
-				<button
+				<Button
 					type="button"
-					class="gender-btn"
-					class:active={gender === 'male'}
+					variant={gender === 'male' ? 'default' : 'outline'}
+					size="sm"
+					class="min-h-12"
 					onclick={() => (gender = 'male')}
 				>
 					Male
-				</button>
-				<button
+				</Button>
+				<Button
 					type="button"
-					class="gender-btn"
-					class:active={gender === 'female'}
+					variant={gender === 'female' ? 'default' : 'outline'}
+					size="sm"
+					class="min-h-12"
 					onclick={() => (gender = 'female')}
 				>
 					Female
-				</button>
-				<button
+				</Button>
+				<Button
 					type="button"
-					class="gender-btn"
-					class:active={gender === 'unknown'}
+					variant={gender === 'unknown' ? 'default' : 'outline'}
+					size="sm"
+					class="min-h-12"
 					onclick={() => (gender = 'unknown')}
 				>
 					Unknown
-				</button>
+				</Button>
 			</div>
 		</fieldset>
 
@@ -266,30 +269,7 @@
 		gap: 0.5rem;
 	}
 
-	.gender-btn {
-		padding: 0.75rem;
-		min-height: 48px;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		background: white;
-		font-size: 0.875rem;
-		cursor: pointer;
-		transition: all 0.15s;
-		color: #475569;
-	}
-
-	.gender-btn:hover {
-		background: #f1f5f9;
-	}
-
-	.gender-btn.active {
-		background: #eff6ff;
-		border-color: #3b82f6;
-		color: #1d4ed8;
-		font-weight: 600;
-	}
-
-	.toggle-notes {
+.toggle-notes {
 		background: none;
 		border: none;
 		color: #64748b;

--- a/web/src/lib/components/RestorePointBrowser.svelte
+++ b/web/src/lib/components/RestorePointBrowser.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api, type RestorePointsResponse } from '$lib/api/client';
+	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 
 	interface Props {
@@ -29,17 +30,19 @@
 		});
 	}
 
+	function getActionBadgeVariant(action: string): 'destructive' | undefined {
+		return action === 'deleted' ? 'destructive' : undefined;
+	}
+
 	function getActionBadgeClass(action: string): string {
 		switch (action) {
 			case 'created':
-				return 'badge-created';
+				return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
 			case 'updated':
-				return 'badge-updated';
-			case 'deleted':
-				return 'badge-deleted';
+				return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400';
 			case 'linked':
 			case 'unlinked':
-				return 'badge-linked';
+				return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400';
 			default:
 				return '';
 		}
@@ -122,19 +125,21 @@
 					<div class="entry-content">
 						<div class="entry-header">
 							<span class="timestamp">{formatTimestamp(point.timestamp)}</span>
-							<span class="action-badge {getActionBadgeClass(point.action)}">{point.action}</span>
+							<Badge variant={getActionBadgeVariant(point.action)} class="capitalize {getActionBadgeClass(point.action)}">{point.action}</Badge>
 							{#if isCurrent}
-								<span class="current-badge">Current</span>
+								<Badge variant="secondary">Current</Badge>
 							{/if}
 						</div>
 						<div class="entry-summary">{point.summary}</div>
 						{#if !isCurrent}
-							<button
-								class="restore-btn"
+							<Button
+								variant="warning"
+								size="sm"
+								class="mt-2"
 								onclick={() => onSelectVersion(point.version, point.summary)}
 							>
 								Restore to this version
-							</button>
+							</Button>
 						{/if}
 					</div>
 				</div>
@@ -258,70 +263,12 @@
 		color: #64748b;
 	}
 
-	.action-badge {
-		display: inline-block;
-		padding: 0.0625rem 0.375rem;
-		border-radius: 4px;
-		font-size: 0.6875rem;
-		font-weight: 500;
-		text-transform: capitalize;
-	}
-
-	.badge-created {
-		background: #22c55e;
-		color: white;
-	}
-
-	.badge-updated {
-		background: #3b82f6;
-		color: white;
-	}
-
-	.badge-deleted {
-		background: #ef4444;
-		color: white;
-	}
-
-	.badge-linked {
-		background: #8b5cf6;
-		color: white;
-	}
-
-	.current-badge {
-		display: inline-block;
-		padding: 0.0625rem 0.375rem;
-		border-radius: 4px;
-		font-size: 0.6875rem;
-		font-weight: 600;
-		background: #dbeafe;
-		color: #1d4ed8;
-	}
-
 	.entry-summary {
 		font-size: 0.8125rem;
 		color: #475569;
 	}
 
-	.restore-btn {
-		display: inline-block;
-		margin-top: 0.5rem;
-		padding: 0.25rem 0.625rem;
-		border: 1px solid #f59e0b;
-		border-radius: 4px;
-		background: #fffbeb;
-		color: #b45309;
-		font-size: 0.75rem;
-		font-weight: 500;
-		cursor: pointer;
-		transition: background 0.15s, border-color 0.15s;
-	}
-
-	.restore-btn:hover {
-		background: #fef3c7;
-		border-color: #d97706;
-	}
-
-	.load-more {
+.load-more {
 		display: flex;
 		justify-content: center;
 		margin-top: 1rem;

--- a/web/src/lib/components/SurnameBrowser.svelte
+++ b/web/src/lib/components/SurnameBrowser.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api, type SurnameEntry, type LetterCount } from '$lib/api/client';
+	import { Button } from '$lib/components/ui/button';
 
 	let letterCounts: LetterCount[] = $state([]);
 	let surnames: SurnameEntry[] = $state([]);
@@ -60,19 +61,19 @@
 		<div class="letter-nav">
 			{#each ALPHABET as letter}
 				{@const count = getLetterCount(letter)}
-				<button
-					class="letter-btn"
-					class:active={selectedLetter === letter}
-					class:disabled={count === 0}
+				<Button
+					variant={selectedLetter === letter ? 'default' : 'outline'}
+					size="sm"
+					class="letter-btn relative"
 					disabled={count === 0}
 					onclick={() => selectLetter(letter)}
 					title={count > 0 ? `${count} surname${count === 1 ? '' : 's'}` : 'No surnames'}
 				>
 					{letter}
 					{#if count > 0}
-						<span class="count-badge">{count}</span>
+						<span class="count-badge" class:count-badge-active={selectedLetter === letter}>{count}</span>
 					{/if}
-				</button>
+				</Button>
 			{/each}
 		</div>
 
@@ -118,41 +119,7 @@
 		border-radius: 8px;
 	}
 
-	.letter-btn {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 2.5rem;
-		height: 2.5rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		background: white;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #1e293b;
-		cursor: pointer;
-		transition: all 0.15s ease;
-	}
-
-	.letter-btn:hover:not(:disabled) {
-		background: #f1f5f9;
-		border-color: #3b82f6;
-	}
-
-	.letter-btn.active {
-		background: #3b82f6;
-		border-color: #3b82f6;
-		color: white;
-	}
-
-	.letter-btn.disabled {
-		color: #94a3b8;
-		background: #f1f5f9;
-		cursor: not-allowed;
-	}
-
-	.count-badge {
+.count-badge {
 		position: absolute;
 		top: -4px;
 		right: -4px;
@@ -169,7 +136,7 @@
 		justify-content: center;
 	}
 
-	.letter-btn.active .count-badge {
+	.count-badge-active {
 		background: white;
 		color: #3b82f6;
 	}
@@ -224,12 +191,6 @@
 		.letter-nav {
 			gap: 0.25rem;
 			padding: 0.75rem;
-		}
-
-		.letter-btn {
-			width: 2rem;
-			height: 2rem;
-			font-size: 0.75rem;
 		}
 
 		.count-badge {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import DiscoveryFeed from '$lib/components/DiscoveryFeed.svelte';
 	import { onboardingState } from '$lib/stores/onboardingSettings.svelte';
 	import OnboardingWizard from '$lib/components/onboarding/OnboardingWizard.svelte';
+	import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
 
 	let recentPersons: Person[] = $state([]);
 	let recentFamilies: FamilyDetail[] = $state([]);
@@ -67,60 +68,71 @@
 		<div class="loading">Loading...</div>
 	{:else}
 		<section class="stats">
-			<div class="stat-card">
-				<span class="stat-value">{stats.persons}</span>
-				<span class="stat-label">People</span>
-			</div>
-			<div class="stat-card">
-				<span class="stat-value">{stats.families}</span>
-				<span class="stat-label">Families</span>
-			</div>
+			<Card class="flex flex-col items-center px-12 py-6">
+				<span class="text-3xl font-bold text-foreground">{stats.persons}</span>
+				<span class="mt-1 text-sm text-muted-foreground">People</span>
+			</Card>
+			<Card class="flex flex-col items-center px-12 py-6">
+				<span class="text-3xl font-bold text-foreground">{stats.families}</span>
+				<span class="mt-1 text-sm text-muted-foreground">Families</span>
+			</Card>
 		</section>
 
 		{#if hasSuggestions}
-			<section class="suggestions-section">
-				<h2>Research Suggestions</h2>
-				<DiscoveryFeed />
-			</section>
+			<Card class="mb-8">
+				<CardHeader>
+					<h2 class="m-0 text-base font-semibold text-foreground">Research Suggestions</h2>
+				</CardHeader>
+				<CardContent>
+					<DiscoveryFeed />
+				</CardContent>
+			</Card>
 		{/if}
 
 		<div class="content-grid">
-			<section class="panel">
-				<div class="panel-header">
-					<h2>Recent People</h2>
-					<a href="/persons">View all</a>
-				</div>
-				{#if recentPersons.length === 0}
-					<p class="empty">No people yet. <a href="/import">Import a GEDCOM file</a> to get started.</p>
-				{:else}
-					<div class="card-list">
-						{#each recentPersons as person}
-							<PersonCard {person} href="/persons/{person.id}" variant="compact" />
-						{/each}
-					</div>
-				{/if}
-			</section>
+			<Card>
+				<CardHeader class="flex-row items-center justify-between">
+					<h2 class="m-0 text-base font-semibold text-foreground">Recent People</h2>
+					<a href="/persons" class="text-sm text-primary no-underline hover:underline">View all</a>
+				</CardHeader>
+				<CardContent>
+					{#if recentPersons.length === 0}
+						<p class="empty">No people yet. <a href="/import">Import a GEDCOM file</a> to get started.</p>
+					{:else}
+						<div class="card-list">
+							{#each recentPersons as person}
+								<PersonCard {person} href="/persons/{person.id}" variant="compact" />
+							{/each}
+						</div>
+					{/if}
+				</CardContent>
+			</Card>
 
-			<section class="panel">
-				<div class="panel-header">
-					<h2>Recent Families</h2>
-					<a href="/families">View all</a>
-				</div>
-				{#if recentFamilies.length === 0}
-					<p class="empty">No families yet.</p>
-				{:else}
-					<div class="card-list">
-						{#each recentFamilies as family}
-							<FamilyCard {family} href="/families/{family.id}" />
-						{/each}
-					</div>
-				{/if}
-			</section>
+			<Card>
+				<CardHeader class="flex-row items-center justify-between">
+					<h2 class="m-0 text-base font-semibold text-foreground">Recent Families</h2>
+					<a href="/families" class="text-sm text-primary no-underline hover:underline">View all</a>
+				</CardHeader>
+				<CardContent>
+					{#if recentFamilies.length === 0}
+						<p class="empty">No families yet.</p>
+					{:else}
+						<div class="card-list">
+							{#each recentFamilies as family}
+								<FamilyCard {family} href="/families/{family.id}" />
+							{/each}
+						</div>
+					{/if}
+				</CardContent>
+			</Card>
 		</div>
 
-		<section class="quick-actions">
-			<h2>Quick Actions</h2>
-			<div class="action-buttons">
+		<Card>
+			<CardHeader>
+				<h2 class="m-0 text-base font-semibold text-foreground">Quick Actions</h2>
+			</CardHeader>
+			<CardContent>
+				<div class="action-buttons">
 				<a href="/import" class="action-btn primary">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -154,7 +166,8 @@
 					Quick Capture
 				</a>
 			</div>
-		</section>
+			</CardContent>
+		</Card>
 	{/if}
 </div>
 {/if}
@@ -196,28 +209,6 @@
 		margin-bottom: 2rem;
 	}
 
-	.stat-card {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		padding: 1.5rem 3rem;
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-	}
-
-	.stat-value {
-		font-size: 2rem;
-		font-weight: 700;
-		color: #1e293b;
-	}
-
-	.stat-label {
-		font-size: 0.875rem;
-		color: #64748b;
-		margin-top: 0.25rem;
-	}
-
 	.content-grid {
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
@@ -229,37 +220,6 @@
 		.content-grid {
 			grid-template-columns: 1fr;
 		}
-	}
-
-	.panel {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.25rem;
-	}
-
-	.panel-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1rem;
-	}
-
-	.panel-header h2 {
-		margin: 0;
-		font-size: 1rem;
-		font-weight: 600;
-		color: #1e293b;
-	}
-
-	.panel-header a {
-		font-size: 0.8125rem;
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.panel-header a:hover {
-		text-decoration: underline;
 	}
 
 	.card-list {
@@ -277,20 +237,6 @@
 
 	.empty a {
 		color: #3b82f6;
-	}
-
-	.quick-actions {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.25rem;
-	}
-
-	.quick-actions h2 {
-		margin: 0 0 1rem;
-		font-size: 1rem;
-		font-weight: 600;
-		color: #1e293b;
 	}
 
 	.action-buttons {
@@ -333,21 +279,6 @@
 	.action-btn svg {
 		width: 1.25rem;
 		height: 1.25rem;
-	}
-
-	.suggestions-section {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.25rem;
-		margin-bottom: 2rem;
-	}
-
-	.suggestions-section h2 {
-		margin: 0 0 1rem;
-		font-size: 1rem;
-		font-weight: 600;
-		color: #1e293b;
 	}
 
 	.action-btn.accent {

--- a/web/src/routes/ahnentafel/[id]/+page.svelte
+++ b/web/src/routes/ahnentafel/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import { api, type AhnentafelResponse, type AhnentafelEntry, formatGenDate } from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button';
+	import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
 
 	let report: AhnentafelResponse | null = $state(null);
 	let error: string | null = $state(null);
@@ -227,43 +228,45 @@
 							</h3>
 							<div class="card-list">
 								{#each entries as entry}
-									<div class="ancestor-card" class:unknown={!entry.id} class:male={entry.gender === 'male'} class:female={entry.gender === 'female'}>
-										<div class="card-header">
-											<span class="card-number">{entry.number}</span>
-											<span class="card-relationship">{entry.relationship}</span>
-										</div>
-										<div class="card-name">
-											{#if entry.id}
-												<a href="/persons/{entry.id}" class="person-link">
-													{entry.given_name || '?'} {entry.surname || '?'}
-												</a>
-											{:else}
-												<span class="unknown-person">Unknown</span>
-											{/if}
-										</div>
-										{#if entry.id && (entry.birth_date || entry.birth_place || entry.death_date || entry.death_place)}
-											<div class="card-details">
-												{#if entry.birth_date || entry.birth_place}
-													<div class="card-event">
-														<span class="event-label">b.</span>
-														<span class="event-value">
-															{entry.birth_date ? formatGenDate(entry.birth_date) : ''}
-															{entry.birth_place || ''}
-														</span>
-													</div>
-												{/if}
-												{#if entry.death_date || entry.death_place}
-													<div class="card-event">
-														<span class="event-label">d.</span>
-														<span class="event-value">
-															{entry.death_date ? formatGenDate(entry.death_date) : ''}
-															{entry.death_place || ''}
-														</span>
-													</div>
+									<Card size="sm" class="p-0 {!entry.id ? 'opacity-70 bg-muted' : ''} {entry.gender === 'male' ? 'border-l-[3px] border-l-blue-500' : ''} {entry.gender === 'female' ? 'border-l-[3px] border-l-pink-500' : ''}">
+										<CardHeader class="flex-row items-center justify-between gap-2 px-3 pt-3 pb-0">
+											<span class="text-[0.9375rem] font-bold text-muted-foreground">{entry.number}</span>
+											<span class="text-xs text-muted-foreground/70">{entry.relationship}</span>
+										</CardHeader>
+										<CardContent class="px-3 pb-3 pt-1">
+											<div class="mb-1 text-base font-medium">
+												{#if entry.id}
+													<a href="/persons/{entry.id}" class="person-link">
+														{entry.given_name || '?'} {entry.surname || '?'}
+													</a>
+												{:else}
+													<span class="unknown-person">Unknown</span>
 												{/if}
 											</div>
-										{/if}
-									</div>
+											{#if entry.id && (entry.birth_date || entry.birth_place || entry.death_date || entry.death_place)}
+												<div class="text-[0.8125rem] text-muted-foreground">
+													{#if entry.birth_date || entry.birth_place}
+														<div class="card-event">
+															<span class="event-label">b.</span>
+															<span class="event-value">
+																{entry.birth_date ? formatGenDate(entry.birth_date) : ''}
+																{entry.birth_place || ''}
+															</span>
+														</div>
+													{/if}
+													{#if entry.death_date || entry.death_place}
+														<div class="card-event">
+															<span class="event-label">d.</span>
+															<span class="event-value">
+																{entry.death_date ? formatGenDate(entry.death_date) : ''}
+																{entry.death_place || ''}
+															</span>
+														</div>
+													{/if}
+												</div>
+											{/if}
+										</CardContent>
+									</Card>
 								{/each}
 							</div>
 						</div>
@@ -520,56 +523,6 @@
 		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 		gap: 0.75rem;
 		padding: 0.75rem;
-	}
-
-	.ancestor-card {
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
-		padding: 0.75rem;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-	}
-
-	.ancestor-card.unknown {
-		opacity: 0.7;
-		background: #f8fafc;
-	}
-
-	.ancestor-card.male {
-		border-left: 3px solid #3b82f6;
-	}
-
-	.ancestor-card.female {
-		border-left: 3px solid #ec4899;
-	}
-
-	.card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.375rem;
-	}
-
-	.card-number {
-		font-weight: 700;
-		font-size: 0.9375rem;
-		color: #64748b;
-	}
-
-	.card-relationship {
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	.card-name {
-		font-size: 1rem;
-		font-weight: 500;
-		margin-bottom: 0.5rem;
-	}
-
-	.card-details {
-		font-size: 0.8125rem;
-		color: #64748b;
 	}
 
 	.card-event {

--- a/web/src/routes/browse/brick-walls/+page.svelte
+++ b/web/src/routes/browse/brick-walls/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api, type BrickWallEntry } from '$lib/api/client';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Card, CardHeader, CardContent, CardFooter } from '$lib/components/ui/card';
 
 	let entries: BrickWallEntry[] = $state([]);
 	let activeCount = $state(0);
@@ -76,14 +77,14 @@
 		<div class="empty">No brick walls yet. Mark a person as a brick wall from their profile.</div>
 	{:else}
 		<div class="summary-stats">
-			<div class="stat">
-				<span class="stat-value">{activeCount}</span>
-				<span class="stat-label">Active</span>
-			</div>
-			<div class="stat">
-				<span class="stat-value">{resolvedCount}</span>
-				<span class="stat-label">Resolved</span>
-			</div>
+			<Card class="flex flex-col items-center px-8 py-4">
+				<span class="text-2xl font-bold text-foreground">{activeCount}</span>
+				<span class="mt-1 text-sm text-muted-foreground">Active</span>
+			</Card>
+			<Card class="flex flex-col items-center px-8 py-4">
+				<span class="text-2xl font-bold text-foreground">{resolvedCount}</span>
+				<span class="mt-1 text-sm text-muted-foreground">Resolved</span>
+			</Card>
 		</div>
 
 		<div class="controls">
@@ -104,8 +105,8 @@
 		{:else}
 			<div class="brick-wall-grid" aria-label="Brick wall list">
 				{#each entries as entry}
-					<div class="brick-wall-card" class:resolved={entry.resolved_at}>
-						<div class="card-header">
+					<Card class="p-0 {entry.resolved_at ? 'border-l-4 border-l-green-500' : 'border-l-4 border-l-amber-400'} hover:shadow-sm transition-all">
+						<CardHeader class="flex-row items-center justify-between gap-2 px-5 pt-5 pb-0">
 							<a href="/persons/{entry.person_id}" class="person-link">
 								{entry.person_name}
 							</a>
@@ -124,18 +125,20 @@
 									Active
 								</Badge>
 							{/if}
-						</div>
+						</CardHeader>
 						{#if entry.note}
-							<p class="note">{entry.note}</p>
+							<CardContent class="px-5 py-0">
+								<p class="note">{entry.note}</p>
+							</CardContent>
 						{/if}
-						<div class="card-footer">
+						<CardFooter class="px-5 pb-4 pt-2">
 							{#if entry.resolved_at}
 								<span class="meta">Resolved {formatDate(entry.resolved_at)}</span>
 							{:else}
 								<span class="meta">Marked {formatRelativeTime(entry.since)}</span>
 							{/if}
-						</div>
-					</div>
+						</CardFooter>
+					</Card>
 				{/each}
 			</div>
 		{/if}
@@ -198,28 +201,6 @@
 		margin-bottom: 1.5rem;
 	}
 
-	.stat {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		padding: 1rem 2rem;
-		background: white;
-		border-radius: 8px;
-		border: 1px solid #e2e8f0;
-	}
-
-	.stat-value {
-		font-size: 1.5rem;
-		font-weight: 700;
-		color: #1e293b;
-	}
-
-	.stat-label {
-		font-size: 0.8125rem;
-		color: #64748b;
-		margin-top: 0.25rem;
-	}
-
 	.controls {
 		margin-bottom: 1.5rem;
 	}
@@ -243,30 +224,6 @@
 		gap: 0.75rem;
 	}
 
-	.brick-wall-card {
-		padding: 1.25rem;
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-left: 4px solid #f59e0b;
-		border-radius: 8px;
-		transition: all 0.15s ease;
-	}
-
-	.brick-wall-card:hover {
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-	}
-
-	.brick-wall-card.resolved {
-		border-left-color: #22c55e;
-	}
-
-	.card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.5rem;
-	}
-
 	.person-link {
 		font-weight: 600;
 		color: #1e293b;
@@ -283,11 +240,6 @@
 		font-size: 0.8125rem;
 		color: #475569;
 		line-height: 1.5;
-	}
-
-	.card-footer {
-		display: flex;
-		align-items: center;
 	}
 
 	.meta {

--- a/web/src/routes/search/+page.svelte
+++ b/web/src/routes/search/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
 	import {
 		api,
 		type SearchResult,
@@ -81,7 +82,9 @@
 			const childPromises = result.items
 				.filter((place) => place.has_children)
 				.map((place) =>
-					api.getPlaceHierarchy(place.full_name || place.name).catch(() => ({ items: [] as PlaceEntry[] }))
+					api
+						.getPlaceHierarchy(place.full_name || place.name)
+						.catch(() => ({ items: [] as PlaceEntry[] }))
 				);
 			const childResults = await Promise.all(childPromises);
 			allPlaces = [...allPlaces, ...childResults.flatMap((r) => r.items)];
@@ -257,7 +260,7 @@
 	}
 
 	function scoreLabel(score: number | undefined): string {
-		if (score === undefined) return '—';
+		if (score === undefined) return '\u2014';
 		return `${Math.round(score * 100)}%`;
 	}
 </script>
@@ -272,309 +275,361 @@
 		<p class="description">Search people by name, dates, and places</p>
 	</header>
 
-	<form class="search-form" onsubmit={handleFormSubmit}>
-		<!-- Name query -->
-		<div class="form-section">
-			<label class="field-label" for="search-query">Name</label>
-			<input
-				id="search-query"
-				type="text"
-				bind:value={query}
-				onkeydown={handleNameKeydown}
-				placeholder="Name (e.g., Smith, John Smith)"
-				class="name-input"
-			/>
-		</div>
-
-		<!-- Toggle buttons -->
-		<div class="toggle-row">
-			<button
-				type="button"
-				class="pill-toggle"
-				class:active={fuzzy}
-				onclick={() => (fuzzy = !fuzzy)}
-				aria-pressed={fuzzy}
-				title={fuzzy ? 'Fuzzy matching enabled' : 'Enable fuzzy matching'}
-			>
-				<span class="toggle-icon">~</span>
-				Fuzzy
-			</button>
-			<button
-				type="button"
-				class="pill-toggle"
-				class:active={soundex}
-				onclick={() => (soundex = !soundex)}
-				aria-pressed={soundex}
-				title={soundex ? 'Phonetic matching enabled' : 'Enable phonetic matching'}
-			>
-				Phonetic
-			</button>
-		</div>
-
-		<!-- Date ranges -->
-		<div class="form-section">
-			<div class="date-grid">
-				<div class="date-group">
-					<span class="field-label">Birth date</span>
-					<div class="date-range">
-						<label class="date-label">
-							From
-							<input
-								type="text"
-								bind:value={birthYearFrom}
-								inputmode="numeric"
-								pattern="[0-9]*"
-								placeholder="YYYY"
-								class="year-input"
-								maxlength={4}
-							/>
-						</label>
-						<label class="date-label">
-							To
-							<input
-								type="text"
-								bind:value={birthYearTo}
-								inputmode="numeric"
-								pattern="[0-9]*"
-								placeholder="YYYY"
-								class="year-input"
-								maxlength={4}
-							/>
-						</label>
-					</div>
+	<Card class="mb-8">
+		<CardContent>
+			<form onsubmit={handleFormSubmit}>
+				<!-- Name query -->
+				<div class="form-section">
+					<label class="field-label" for="search-query">Name</label>
+					<input
+						id="search-query"
+						type="text"
+						bind:value={query}
+						onkeydown={handleNameKeydown}
+						placeholder="Name (e.g., Smith, John Smith)"
+						class="name-input"
+					/>
 				</div>
-				<div class="date-group">
-					<span class="field-label">Death date</span>
-					<div class="date-range">
-						<label class="date-label">
-							From
-							<input
-								type="text"
-								bind:value={deathYearFrom}
-								inputmode="numeric"
-								pattern="[0-9]*"
-								placeholder="YYYY"
-								class="year-input"
-								maxlength={4}
-							/>
-						</label>
-						<label class="date-label">
-							To
-							<input
-								type="text"
-								bind:value={deathYearTo}
-								inputmode="numeric"
-								pattern="[0-9]*"
-								placeholder="YYYY"
-								class="year-input"
-								maxlength={4}
-							/>
-						</label>
-					</div>
-				</div>
-			</div>
-		</div>
 
-		<!-- Place filters -->
-		<div class="form-section">
-			<div class="place-grid">
-				<div class="place-field">
-					<label class="field-label" for="birth-place-input">Birth place</label>
-					<div class="place-wrapper">
-						<input
-							id="birth-place-input"
-							type="text"
-							bind:value={birthPlace}
-							onfocus={() => {
-								if (birthPlaceSuggestions.length > 0) showBirthPlaceDropdown = true;
-							}}
-							onblur={() => { showBirthPlaceDropdown = false; birthPlaceHighlight = -1; }}
-							onkeydown={handleBirthPlaceKeydown}
-							placeholder="e.g., Springfield, IL"
-							role="combobox"
-							aria-expanded={showBirthPlaceDropdown}
-							aria-haspopup="listbox"
-							aria-controls="birth-place-listbox"
-							aria-autocomplete="list"
-							aria-activedescendant={birthPlaceHighlight >= 0 ? `bp-option-${birthPlaceHighlight}` : undefined}
-							autocomplete="off"
-						/>
-						{#if showBirthPlaceDropdown && birthPlaceSuggestions.length > 0}
-							<!-- svelte-ignore a11y_interactive_supports_focus -->
-						<div class="place-dropdown" role="listbox" id="birth-place-listbox" aria-label="Birth place suggestions" onmousedown={(e) => e.preventDefault()}>
-								{#each birthPlaceSuggestions as place, i}
-									<button
-										type="button"
-										id="bp-option-{i}"
-										class="place-option"
-										class:highlighted={i === birthPlaceHighlight}
-										onclick={() => selectBirthPlace(place)}
-										role="option"
-										aria-selected={i === birthPlaceHighlight}
-									>
-										<span class="place-name">{place.full_name}</span>
-										<span class="place-count">({place.count})</span>
-									</button>
-								{/each}
+				<!-- Toggle buttons -->
+				<div class="toggle-row">
+					<button
+						type="button"
+						class="pill-toggle"
+						class:active={fuzzy}
+						onclick={() => (fuzzy = !fuzzy)}
+						aria-pressed={fuzzy}
+						title={fuzzy ? 'Fuzzy matching enabled' : 'Enable fuzzy matching'}
+					>
+						<span class="toggle-icon">~</span>
+						Fuzzy
+					</button>
+					<button
+						type="button"
+						class="pill-toggle"
+						class:active={soundex}
+						onclick={() => (soundex = !soundex)}
+						aria-pressed={soundex}
+						title={soundex ? 'Phonetic matching enabled' : 'Enable phonetic matching'}
+					>
+						Phonetic
+					</button>
+				</div>
+
+				<!-- Date ranges -->
+				<div class="form-section">
+					<div class="date-grid">
+						<div class="date-group">
+							<span class="field-label">Birth date</span>
+							<div class="date-range">
+								<label class="date-label">
+									From
+									<input
+										type="text"
+										bind:value={birthYearFrom}
+										inputmode="numeric"
+										pattern="[0-9]*"
+										placeholder="YYYY"
+										class="year-input"
+										maxlength={4}
+									/>
+								</label>
+								<label class="date-label">
+									To
+									<input
+										type="text"
+										bind:value={birthYearTo}
+										inputmode="numeric"
+										pattern="[0-9]*"
+										placeholder="YYYY"
+										class="year-input"
+										maxlength={4}
+									/>
+								</label>
 							</div>
-						{/if}
-					</div>
-				</div>
-				<div class="place-field">
-					<label class="field-label" for="death-place-input">Death place</label>
-					<div class="place-wrapper">
-						<input
-							id="death-place-input"
-							type="text"
-							bind:value={deathPlace}
-							onfocus={() => {
-								if (deathPlaceSuggestions.length > 0) showDeathPlaceDropdown = true;
-							}}
-							onblur={() => { showDeathPlaceDropdown = false; deathPlaceHighlight = -1; }}
-							onkeydown={handleDeathPlaceKeydown}
-							placeholder="e.g., Springfield, IL"
-							role="combobox"
-							aria-expanded={showDeathPlaceDropdown}
-							aria-haspopup="listbox"
-							aria-controls="death-place-listbox"
-							aria-autocomplete="list"
-							aria-activedescendant={deathPlaceHighlight >= 0 ? `dp-option-${deathPlaceHighlight}` : undefined}
-							autocomplete="off"
-						/>
-						{#if showDeathPlaceDropdown && deathPlaceSuggestions.length > 0}
-							<!-- svelte-ignore a11y_interactive_supports_focus -->
-						<div class="place-dropdown" role="listbox" id="death-place-listbox" aria-label="Death place suggestions" onmousedown={(e) => e.preventDefault()}>
-								{#each deathPlaceSuggestions as place, i}
-									<button
-										type="button"
-										id="dp-option-{i}"
-										class="place-option"
-										class:highlighted={i === deathPlaceHighlight}
-										onclick={() => selectDeathPlace(place)}
-										role="option"
-										aria-selected={i === deathPlaceHighlight}
-									>
-										<span class="place-name">{place.full_name}</span>
-										<span class="place-count">({place.count})</span>
-									</button>
-								{/each}
+						</div>
+						<div class="date-group">
+							<span class="field-label">Death date</span>
+							<div class="date-range">
+								<label class="date-label">
+									From
+									<input
+										type="text"
+										bind:value={deathYearFrom}
+										inputmode="numeric"
+										pattern="[0-9]*"
+										placeholder="YYYY"
+										class="year-input"
+										maxlength={4}
+									/>
+								</label>
+								<label class="date-label">
+									To
+									<input
+										type="text"
+										bind:value={deathYearTo}
+										inputmode="numeric"
+										pattern="[0-9]*"
+										placeholder="YYYY"
+										class="year-input"
+										maxlength={4}
+									/>
+								</label>
 							</div>
-						{/if}
+						</div>
 					</div>
 				</div>
-			</div>
-		</div>
 
-		<!-- Action buttons -->
-		<div class="form-actions">
-			<Button type="submit" disabled={!hasAnyCriteria || loading}>
-				{loading ? 'Searching...' : 'Search'}
-			</Button>
-			<Button variant="secondary" onclick={clearAll}>Clear All</Button>
-		</div>
-	</form>
+				<!-- Place filters -->
+				<div class="form-section">
+					<div class="place-grid">
+						<div class="place-field">
+							<label class="field-label" for="birth-place-input">Birth place</label>
+							<div class="place-wrapper">
+								<input
+									id="birth-place-input"
+									type="text"
+									bind:value={birthPlace}
+									onfocus={() => {
+										if (birthPlaceSuggestions.length > 0)
+											showBirthPlaceDropdown = true;
+									}}
+									onblur={() => {
+										showBirthPlaceDropdown = false;
+										birthPlaceHighlight = -1;
+									}}
+									onkeydown={handleBirthPlaceKeydown}
+									placeholder="e.g., Springfield, IL"
+									role="combobox"
+									aria-expanded={showBirthPlaceDropdown}
+									aria-haspopup="listbox"
+									aria-controls="birth-place-listbox"
+									aria-autocomplete="list"
+									aria-activedescendant={birthPlaceHighlight >= 0
+										? `bp-option-${birthPlaceHighlight}`
+										: undefined}
+									autocomplete="off"
+								/>
+								{#if showBirthPlaceDropdown && birthPlaceSuggestions.length > 0}
+									<!-- svelte-ignore a11y_interactive_supports_focus -->
+									<div
+										class="place-dropdown"
+										role="listbox"
+										id="birth-place-listbox"
+										aria-label="Birth place suggestions"
+										onmousedown={(e) => e.preventDefault()}
+									>
+										{#each birthPlaceSuggestions as place, i}
+											<button
+												type="button"
+												id="bp-option-{i}"
+												class="place-option"
+												class:highlighted={i === birthPlaceHighlight}
+												onclick={() => selectBirthPlace(place)}
+												role="option"
+												aria-selected={i === birthPlaceHighlight}
+											>
+												<span class="place-name">{place.full_name}</span>
+												<span class="place-count">({place.count})</span>
+											</button>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						</div>
+						<div class="place-field">
+							<label class="field-label" for="death-place-input">Death place</label>
+							<div class="place-wrapper">
+								<input
+									id="death-place-input"
+									type="text"
+									bind:value={deathPlace}
+									onfocus={() => {
+										if (deathPlaceSuggestions.length > 0)
+											showDeathPlaceDropdown = true;
+									}}
+									onblur={() => {
+										showDeathPlaceDropdown = false;
+										deathPlaceHighlight = -1;
+									}}
+									onkeydown={handleDeathPlaceKeydown}
+									placeholder="e.g., Springfield, IL"
+									role="combobox"
+									aria-expanded={showDeathPlaceDropdown}
+									aria-haspopup="listbox"
+									aria-controls="death-place-listbox"
+									aria-autocomplete="list"
+									aria-activedescendant={deathPlaceHighlight >= 0
+										? `dp-option-${deathPlaceHighlight}`
+										: undefined}
+									autocomplete="off"
+								/>
+								{#if showDeathPlaceDropdown && deathPlaceSuggestions.length > 0}
+									<!-- svelte-ignore a11y_interactive_supports_focus -->
+									<div
+										class="place-dropdown"
+										role="listbox"
+										id="death-place-listbox"
+										aria-label="Death place suggestions"
+										onmousedown={(e) => e.preventDefault()}
+									>
+										{#each deathPlaceSuggestions as place, i}
+											<button
+												type="button"
+												id="dp-option-{i}"
+												class="place-option"
+												class:highlighted={i === deathPlaceHighlight}
+												onclick={() => selectDeathPlace(place)}
+												role="option"
+												aria-selected={i === deathPlaceHighlight}
+											>
+												<span class="place-name">{place.full_name}</span>
+												<span class="place-count">({place.count})</span>
+											</button>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Action buttons -->
+				<div class="form-actions">
+					<Button type="submit" disabled={!hasAnyCriteria || loading}>
+						{loading ? 'Searching...' : 'Search'}
+					</Button>
+					<Button variant="secondary" onclick={clearAll}>Clear All</Button>
+				</div>
+			</form>
+		</CardContent>
+	</Card>
 
 	<!-- Results section -->
 	{#if searched}
-		<div class="results-section">
-			<!-- Sort controls and result count -->
-			<div class="results-header">
-				<div class="results-info">
-					{#if loading}
-						<span class="results-count" aria-live="polite">Searching...</span>
-					{:else}
-						<span class="results-count" aria-live="polite">Showing {results.length} of {total} results</span>
-					{/if}
-					{#if soundex}
-						<span class="mode-badge">Phonetic</span>
-					{/if}
-				</div>
-				<div class="sort-controls">
-					<label class="sort-label">
-						Sort by:
-						<select value={sort} onchange={handleSortChange}>
-							<option value="relevance">Relevance</option>
-							<option value="name">Name</option>
-							<option value="birth_date">Birth Date</option>
-							<option value="death_date">Death Date</option>
-						</select>
-					</label>
-					<button
-						class="order-btn"
-						onclick={handleOrderToggle}
-						title="Toggle sort order ({order === 'asc' ? 'ascending' : 'descending'})"
-					>
-						{#if order === 'asc'}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M12 5v14M5 12l7-7 7 7" />
-							</svg>
+		<Card>
+			<CardContent>
+				<!-- Sort controls and result count -->
+				<div class="results-header">
+					<div class="results-info">
+						{#if loading}
+							<span class="results-count" aria-live="polite">Searching...</span>
 						{:else}
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M12 19V5M5 12l7 7 7-7" />
-							</svg>
+							<span class="results-count" aria-live="polite"
+								>Showing {results.length} of {total} results</span
+							>
 						{/if}
-					</button>
-				</div>
-			</div>
-
-			{#if error}
-				<div class="error-message" role="alert">{error}</div>
-			{:else if !loading && results.length === 0}
-				<div class="empty-state">No results found. Try adjusting your search criteria.</div>
-			{:else if !loading}
-				<!-- Desktop table -->
-				<div class="results-table-wrapper">
-					<table class="results-table">
-						<thead>
-							<tr>
-								<th>Name</th>
-								<th>Birth</th>
-								<th>Death</th>
-								<th>Score</th>
-							</tr>
-						</thead>
-						<tbody>
-							{#each results as person}
-								<tr>
-									<td>
-										<a href="/persons/{person.id}" class="person-link">
-											{formatPersonName(person)}
-										</a>
-									</td>
-									<td class="date-cell">{formatGenDate(person.birth_date)}</td>
-									<td class="date-cell">{formatGenDate(person.death_date)}</td>
-									<td class="score-cell">
-										<span class="score-badge {scoreColor(person.score)}">{scoreLabel(person.score)}</span>
-									</td>
-								</tr>
-							{/each}
-						</tbody>
-					</table>
-				</div>
-
-				<!-- Mobile cards -->
-				<div class="results-cards">
-					{#each results as person}
-						<a href="/persons/{person.id}" class="result-card">
-							<div class="card-top">
-								<span class="card-name">{formatPersonName(person)}</span>
-								<span class="score-badge {scoreColor(person.score)}">{scoreLabel(person.score)}</span>
-							</div>
-							<span class="card-lifespan">{formatLifespan(person)}</span>
-						</a>
-					{/each}
-				</div>
-
-				<!-- Load more -->
-				{#if results.length < total}
-					<div class="load-more">
-						<Button variant="secondary" onclick={loadMore} disabled={loading}>
-							Load more
-						</Button>
+						{#if soundex}
+							<span class="mode-badge">Phonetic</span>
+						{/if}
 					</div>
+					<div class="sort-controls">
+						<label class="sort-label">
+							Sort by:
+							<select value={sort} onchange={handleSortChange}>
+								<option value="relevance">Relevance</option>
+								<option value="name">Name</option>
+								<option value="birth_date">Birth Date</option>
+								<option value="death_date">Death Date</option>
+							</select>
+						</label>
+						<button
+							class="order-btn"
+							onclick={handleOrderToggle}
+							title="Toggle sort order ({order === 'asc' ? 'ascending' : 'descending'})"
+						>
+							{#if order === 'asc'}
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+								>
+									<path d="M12 5v14M5 12l7-7 7 7" />
+								</svg>
+							{:else}
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+								>
+									<path d="M12 19V5M5 12l7 7 7-7" />
+								</svg>
+							{/if}
+						</button>
+					</div>
+				</div>
+
+				{#if error}
+					<div class="error-message" role="alert">{error}</div>
+				{:else if !loading && results.length === 0}
+					<div class="empty-state">
+						No results found. Try adjusting your search criteria.
+					</div>
+				{:else if !loading}
+					<!-- Desktop table -->
+					<div class="results-table-wrapper">
+						<table class="results-table">
+							<thead>
+								<tr>
+									<th>Name</th>
+									<th>Birth</th>
+									<th>Death</th>
+									<th>Score</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each results as person}
+									<tr>
+										<td>
+											<a href="/persons/{person.id}" class="person-link">
+												{formatPersonName(person)}
+											</a>
+										</td>
+										<td class="date-cell">{formatGenDate(person.birth_date)}</td>
+										<td class="date-cell">{formatGenDate(person.death_date)}</td>
+										<td class="score-cell">
+											<span class="score-badge {scoreColor(person.score)}"
+												>{scoreLabel(person.score)}</span
+											>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+
+					<!-- Mobile cards -->
+					<div class="results-cards">
+						{#each results as person}
+							<a href="/persons/{person.id}" class="result-card">
+								<div class="result-card-top">
+									<span class="result-card-name"
+										>{formatPersonName(person)}</span
+									>
+									<span class="score-badge {scoreColor(person.score)}"
+										>{scoreLabel(person.score)}</span
+									>
+								</div>
+								<span class="result-card-lifespan"
+									>{formatLifespan(person)}</span
+								>
+							</a>
+						{/each}
+					</div>
+
+					<!-- Load more -->
+					{#if results.length < total}
+						<div class="load-more">
+							<Button variant="secondary" onclick={loadMore} disabled={loading}>
+								Load more
+							</Button>
+						</div>
+					{/if}
 				{/if}
-			{/if}
-		</div>
+			</CardContent>
+		</Card>
 	{/if}
 </div>
 
@@ -599,15 +654,6 @@
 		margin: 0;
 		color: #64748b;
 		font-size: 0.9375rem;
-	}
-
-	/* Search form */
-	.search-form {
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-radius: 12px;
-		padding: 1.5rem;
-		margin-bottom: 2rem;
 	}
 
 	.form-section {
@@ -813,14 +859,7 @@
 		border-top: 1px solid #e2e8f0;
 	}
 
-	/* Results section */
-	.results-section {
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-radius: 12px;
-		padding: 1.5rem;
-	}
-
+	/* Results */
 	.results-header {
 		display: flex;
 		justify-content: space-between;
@@ -1008,20 +1047,20 @@
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 	}
 
-	.card-top {
+	.result-card-top {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		margin-bottom: 0.25rem;
 	}
 
-	.card-name {
+	.result-card-name {
 		font-weight: 500;
 		color: #1e293b;
 		font-size: 0.875rem;
 	}
 
-	.card-lifespan {
+	.result-card-lifespan {
 		font-size: 0.8125rem;
 		color: #64748b;
 	}


### PR DESCRIPTION
## Summary

Completes Phase 1 of #366 by replacing hand-rolled button, badge, and card CSS with shadcn-svelte primitives across 12 components, eliminating ~400 lines of custom CSS.

- **Buttons** (6 components): ConflictError, QuickCapture, MediaLightbox, SurnameBrowser, MediaUpload, RestorePointBrowser — now use `Button` with variant/size props
- **Badges** (2 components): ChangeHistory, RestorePointBrowser — action badges now use `Badge` with Tailwind color classes
- **Cards** (5 files): DiscoveryFeed, home, search, brick-walls, ahnentafel — now use Card/CardHeader/CardContent/CardFooter

## Test plan

- [x] `make lint` — 0 issues
- [x] `svelte-check --threshold error` — 0 errors
- [x] Go tests — all passed
- [x] Frontend tests — 137/137 passed
- [x] Playwright visual verification of all migrated pages (home, search, history, surnames, quick capture, brick walls, ahnentafel)
- [x] Gender button toggle (QuickCapture) — active/inactive states work
- [x] Letter button toggle (SurnameBrowser) — active/selected state works
- [x] Badge colors preserved (green=created, blue=updated, red=deleted)
- [x] Full binary build (`make binary`) succeeded

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated button components across the application with unified styling, variants (default, destructive, warning, ghost, outline), and sizing options
  * Standardized badge implementations using a shared component for action indicators and markers
  * Updated card-based layouts (dashboard, browse pages, search results) to use consistent Card/CardHeader/CardContent structures
  * Replaced custom CSS rules with utility-based styling for improved visual consistency throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->