### PR TITLE
Fix history page showing unknown event types for child link/unlink entries

### DIFF
--- a/internal/query/history_queries.go
+++ b/internal/query/history_queries.go
@@ -31,10 +31,10 @@ func NewHistoryService(eventStore repository.EventStore, readStore repository.Re
 type ChangeEntry struct {
 	ID         uuid.UUID              `json:"id"`
 	Timestamp  time.Time              `json:"timestamp"`
-	EntityType string                 `json:"entity_type"` // "person", "family", "source", "citation", "import"
+	EntityType string                 `json:"entity_type"` // "person", "family", "source", "citation"
 	EntityID   uuid.UUID              `json:"entity_id"`
 	EntityName string                 `json:"entity_name"` // e.g., "John Smith"
-	Action     string                 `json:"action"`      // "created", "updated", "deleted", "linked", "unlinked"
+	Action     string                 `json:"action"`      // "created", "updated", "deleted"
 	Changes    map[string]FieldChange `json:"changes,omitempty"`
 	UserID     *string                `json:"user_id,omitempty"`
 }
@@ -136,20 +136,26 @@ func (s *HistoryService) transformStoredEvents(ctx context.Context, events []rep
 	entries := make([]ChangeEntry, 0, len(events))
 
 	for _, evt := range events {
+		// Map event type to entity type and action
+		entityType, action := s.mapEventTypeToEntityAndAction(evt.EventType)
+
+		// Skip events that don't map to valid OpenAPI entity types (e.g., GedcomImported)
+		if entityType == "skip" {
+			continue
+		}
+
 		entry := ChangeEntry{
 			ID:        evt.ID,
 			Timestamp: evt.Timestamp,
 			EntityID:  evt.StreamID,
 		}
 
-		// Map event type to entity type and action
-		entityType, action := s.mapEventTypeToEntityAndAction(evt.EventType)
 		entry.EntityType = entityType
 		entry.Action = action
 
 		// Extract changes for update events
 		if action == "updated" {
-			changes, err := s.extractChanges(evt)
+			changes, err := s.extractChanges(ctx, evt)
 			if err == nil && len(changes) > 0 {
 				entry.Changes = changes
 			}
@@ -189,9 +195,9 @@ func (s *HistoryService) mapEventTypeToEntityAndAction(eventType string) (entity
 	case "FamilyDeleted":
 		return "family", "deleted"
 	case "ChildLinkedToFamily":
-		return "family", "linked"
+		return "family", "updated"
 	case "ChildUnlinkedFromFamily":
-		return "family", "unlinked"
+		return "family", "updated"
 	case "SourceCreated":
 		return "source", "created"
 	case "SourceUpdated":
@@ -205,14 +211,14 @@ func (s *HistoryService) mapEventTypeToEntityAndAction(eventType string) (entity
 	case "CitationDeleted":
 		return "citation", "deleted"
 	case "GedcomImported":
-		return "import", "created"
+		return "skip", ""
 	default:
 		return "unknown", "unknown"
 	}
 }
 
 // extractChanges extracts field-level changes from update events.
-func (s *HistoryService) extractChanges(evt repository.StoredEvent) (map[string]FieldChange, error) {
+func (s *HistoryService) extractChanges(ctx context.Context, evt repository.StoredEvent) (map[string]FieldChange, error) {
 	// Decode the event to access its Changes field
 	domainEvent, err := evt.DecodeEvent()
 	if err != nil {
@@ -229,6 +235,16 @@ func (s *HistoryService) extractChanges(evt repository.StoredEvent) (map[string]
 		return s.convertChangesMap(e.Changes), nil
 	case domain.CitationUpdated:
 		return s.convertChangesMap(e.Changes), nil
+	case domain.ChildLinkedToFamily:
+		childName := s.getPersonName(ctx, e.PersonID, nil)
+		return map[string]FieldChange{
+			"children": {NewValue: fmt.Sprintf("Child linked: %s", childName)},
+		}, nil
+	case domain.ChildUnlinkedFromFamily:
+		childName := s.getPersonName(ctx, e.PersonID, nil)
+		return map[string]FieldChange{
+			"children": {NewValue: fmt.Sprintf("Child unlinked: %s", childName)},
+		}, nil
 	default:
 		return nil, nil
 	}
@@ -259,8 +275,6 @@ func (s *HistoryService) getEntityName(ctx context.Context, entityType string, e
 		return s.getSourceName(ctx, entityID, evt)
 	case "citation":
 		return s.getCitationName(ctx, entityID, evt)
-	case "import":
-		return s.getImportName(evt)
 	default:
 		return entityID.String()
 	}
@@ -275,7 +289,7 @@ func (s *HistoryService) getPersonName(ctx context.Context, personID uuid.UUID, 
 	}
 
 	// Fallback: extract name from creation event
-	if evt.EventType == "PersonCreated" {
+	if evt != nil && evt.EventType == "PersonCreated" {
 		var created domain.PersonCreated
 		if err := json.Unmarshal(evt.Data, &created); err == nil {
 			if created.GivenName != "" || created.Surname != "" {
@@ -289,8 +303,7 @@ func (s *HistoryService) getPersonName(ctx context.Context, personID uuid.UUID, 
 }
 
 // getFamilyName retrieves or constructs a family's name.
-// TODO: evt parameter reserved for extracting name from event data when read model unavailable
-func (s *HistoryService) getFamilyName(ctx context.Context, familyID uuid.UUID, _ *repository.StoredEvent) string {
+func (s *HistoryService) getFamilyName(ctx context.Context, familyID uuid.UUID, evt *repository.StoredEvent) string {
 	// Try to get from read model first
 	family, err := s.readStore.GetFamily(ctx, familyID)
 	if err == nil && family != nil {
@@ -305,7 +318,27 @@ func (s *HistoryService) getFamilyName(ctx context.Context, familyID uuid.UUID, 
 		}
 	}
 
-	// Fallback: use ID
+	// Fallback: extract partner names from creation event
+	if evt != nil && evt.EventType == "FamilyCreated" {
+		var created domain.FamilyCreated
+		if err := json.Unmarshal(evt.Data, &created); err == nil {
+			names := make([]string, 0, 2)
+			if created.Partner1ID != nil {
+				names = append(names, s.getPersonName(ctx, *created.Partner1ID, nil))
+			}
+			if created.Partner2ID != nil {
+				names = append(names, s.getPersonName(ctx, *created.Partner2ID, nil))
+			}
+			if len(names) == 2 {
+				return fmt.Sprintf("%s & %s", names[0], names[1])
+			}
+			if len(names) == 1 {
+				return names[0]
+			}
+		}
+	}
+
+	// Last resort: use ID
 	return familyID.String()
 }
 
@@ -342,15 +375,4 @@ func (s *HistoryService) getCitationName(ctx context.Context, citationID uuid.UU
 
 	// Fallback: use ID
 	return citationID.String()
-}
-
-// getImportName constructs a name for an import event.
-func (s *HistoryService) getImportName(evt *repository.StoredEvent) string {
-	if evt.EventType == "GedcomImported" {
-		var imported domain.GedcomImported
-		if err := json.Unmarshal(evt.Data, &imported); err == nil {
-			return fmt.Sprintf("GEDCOM Import: %s", imported.Filename)
-		}
-	}
-	return "Import"
 }

--- a/internal/query/history_queries_test.go
+++ b/internal/query/history_queries_test.go
@@ -678,15 +678,15 @@ func TestMapEventTypeToEntityAndAction(t *testing.T) {
 		{"FamilyCreated", "family", "created"},
 		{"FamilyUpdated", "family", "updated"},
 		{"FamilyDeleted", "family", "deleted"},
-		{"ChildLinkedToFamily", "family", "linked"},
-		{"ChildUnlinkedFromFamily", "family", "unlinked"},
+		{"ChildLinkedToFamily", "family", "updated"},
+		{"ChildUnlinkedFromFamily", "family", "updated"},
 		{"SourceCreated", "source", "created"},
 		{"SourceUpdated", "source", "updated"},
 		{"SourceDeleted", "source", "deleted"},
 		{"CitationCreated", "citation", "created"},
 		{"CitationUpdated", "citation", "updated"},
 		{"CitationDeleted", "citation", "deleted"},
-		{"GedcomImported", "import", "created"},
+		{"GedcomImported", "skip", ""},
 		{"UnknownEvent", "unknown", "unknown"},
 	}
 
@@ -700,7 +700,7 @@ func TestMapEventTypeToEntityAndAction(t *testing.T) {
 }
 
 func TestExtractChanges(t *testing.T) {
-	service := &HistoryService{}
+	service := NewHistoryService(&mockEventStore{}, &mockReadModelStore{})
 
 	tests := []struct {
 		name        string
@@ -753,7 +753,7 @@ func TestExtractChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			changes, err := service.extractChanges(tt.event)
+			changes, err := service.extractChanges(context.Background(), tt.event)
 			require.NoError(t, err)
 
 			if tt.wantChanges {
@@ -774,7 +774,6 @@ func TestGetEntityName(t *testing.T) {
 	familyID := uuid.New()
 	sourceID := uuid.New()
 	citationID := uuid.New()
-	importID := uuid.New()
 
 	readStore := &mockReadModelStore{
 		getPersonFunc: func(ctx context.Context, id uuid.UUID) (*repository.PersonReadModel, error) {
@@ -853,16 +852,6 @@ func TestGetEntityName(t *testing.T) {
 			entityID:   citationID,
 			event:      &repository.StoredEvent{EventType: "CitationCreated"},
 			wantName:   "1900 Census (person_birth)",
-		},
-		{
-			name:       "import event",
-			entityType: "import",
-			entityID:   importID,
-			event: &repository.StoredEvent{
-				EventType: "GedcomImported",
-				Data:      mustMarshal(domain.NewGedcomImported("family.ged", 1024, 10, 5, nil, nil)),
-			},
-			wantName: "GEDCOM Import: family.ged",
 		},
 		{
 			name:       "unknown entity type",
@@ -1129,6 +1118,217 @@ func TestTransformStoredEvents(t *testing.T) {
 	assert.Equal(t, "John Smith", entries[1].EntityName)
 	assert.NotNil(t, entries[1].Changes)
 	assert.Contains(t, entries[1].Changes, "given_name")
+}
+
+func TestChildLinkedToFamilyProducesUpdatedAction(t *testing.T) {
+	familyID := uuid.New()
+	childID := uuid.New()
+	now := time.Now().UTC()
+
+	linkedEvent := domain.NewChildLinkedToFamily(&domain.FamilyChild{
+		FamilyID:         familyID,
+		PersonID:         childID,
+		RelationshipType: domain.ChildBiological,
+	})
+	linkedData, _ := json.Marshal(linkedEvent)
+
+	readStore := &mockReadModelStore{
+		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
+			if id == familyID {
+				return &repository.FamilyReadModel{
+					ID:           familyID,
+					Partner1Name: "John Smith",
+					Partner2Name: "Jane Smith",
+				}, nil
+			}
+			return nil, repository.ErrStreamNotFound
+		},
+		getPersonFunc: func(ctx context.Context, id uuid.UUID) (*repository.PersonReadModel, error) {
+			if id == childID {
+				return &repository.PersonReadModel{
+					ID:       childID,
+					FullName: "Bobby Smith",
+				}, nil
+			}
+			return nil, repository.ErrStreamNotFound
+		},
+	}
+
+	service := NewHistoryService(&mockEventStore{}, readStore)
+
+	events := []repository.StoredEvent{
+		{
+			ID:         uuid.New(),
+			StreamID:   familyID,
+			StreamType: "family",
+			EventType:  "ChildLinkedToFamily",
+			Data:       linkedData,
+			Version:    2,
+			Position:   2,
+			Timestamp:  now,
+		},
+	}
+
+	entries, err := service.transformStoredEvents(context.Background(), events)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, "family", entry.EntityType)
+	assert.Equal(t, "updated", entry.Action)
+	assert.Equal(t, "John Smith & Jane Smith", entry.EntityName)
+	require.Contains(t, entry.Changes, "children")
+	assert.Equal(t, "Child linked: Bobby Smith", entry.Changes["children"].NewValue)
+}
+
+func TestChildUnlinkedFromFamilyProducesUpdatedAction(t *testing.T) {
+	familyID := uuid.New()
+	childID := uuid.New()
+	now := time.Now().UTC()
+
+	unlinkedEvent := domain.NewChildUnlinkedFromFamily(familyID, childID)
+	unlinkedData, _ := json.Marshal(unlinkedEvent)
+
+	readStore := &mockReadModelStore{
+		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
+			if id == familyID {
+				return &repository.FamilyReadModel{
+					ID:           familyID,
+					Partner1Name: "John Smith",
+					Partner2Name: "Jane Smith",
+				}, nil
+			}
+			return nil, repository.ErrStreamNotFound
+		},
+		getPersonFunc: func(ctx context.Context, id uuid.UUID) (*repository.PersonReadModel, error) {
+			if id == childID {
+				return &repository.PersonReadModel{
+					ID:       childID,
+					FullName: "Bobby Smith",
+				}, nil
+			}
+			return nil, repository.ErrStreamNotFound
+		},
+	}
+
+	service := NewHistoryService(&mockEventStore{}, readStore)
+
+	events := []repository.StoredEvent{
+		{
+			ID:         uuid.New(),
+			StreamID:   familyID,
+			StreamType: "family",
+			EventType:  "ChildUnlinkedFromFamily",
+			Data:       unlinkedData,
+			Version:    3,
+			Position:   3,
+			Timestamp:  now,
+		},
+	}
+
+	entries, err := service.transformStoredEvents(context.Background(), events)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, "family", entry.EntityType)
+	assert.Equal(t, "updated", entry.Action)
+	assert.Equal(t, "John Smith & Jane Smith", entry.EntityName)
+	require.Contains(t, entry.Changes, "children")
+	assert.Equal(t, "Child unlinked: Bobby Smith", entry.Changes["children"].NewValue)
+}
+
+func TestGedcomImportedEventsAreSkipped(t *testing.T) {
+	importID := uuid.New()
+	now := time.Now().UTC()
+
+	importEvent := domain.NewGedcomImported("family.ged", 1024, 10, 5, nil, nil)
+	importData, _ := json.Marshal(importEvent)
+
+	service := NewHistoryService(&mockEventStore{}, &mockReadModelStore{})
+
+	events := []repository.StoredEvent{
+		{
+			ID:         uuid.New(),
+			StreamID:   importID,
+			StreamType: "import",
+			EventType:  "GedcomImported",
+			Data:       importData,
+			Version:    1,
+			Position:   1,
+			Timestamp:  now,
+		},
+	}
+
+	entries, err := service.transformStoredEvents(context.Background(), events)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "GedcomImported events should be filtered out")
+}
+
+func TestUnknownEventTypeStillReturnsUnknown(t *testing.T) {
+	service := &HistoryService{}
+	entityType, action := service.mapEventTypeToEntityAndAction("CompletelyUnknownEvent")
+	assert.Equal(t, "unknown", entityType)
+	assert.Equal(t, "unknown", action)
+}
+
+func TestGetFamilyNameFallbackFromCreationEvent(t *testing.T) {
+	familyID := uuid.New()
+	partner1ID := uuid.New()
+	partner2ID := uuid.New()
+
+	readStore := &mockReadModelStore{
+		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
+			return nil, repository.ErrStreamNotFound
+		},
+		getPersonFunc: func(ctx context.Context, id uuid.UUID) (*repository.PersonReadModel, error) {
+			if id == partner1ID {
+				return &repository.PersonReadModel{ID: partner1ID, FullName: "John Smith"}, nil
+			}
+			if id == partner2ID {
+				return &repository.PersonReadModel{ID: partner2ID, FullName: "Jane Doe"}, nil
+			}
+			return nil, repository.ErrStreamNotFound
+		},
+	}
+
+	service := NewHistoryService(&mockEventStore{}, readStore)
+
+	t.Run("both partners from creation event", func(t *testing.T) {
+		evt := &repository.StoredEvent{
+			EventType: "FamilyCreated",
+			Data: mustMarshal(domain.FamilyCreated{
+				FamilyID:   familyID,
+				Partner1ID: &partner1ID,
+				Partner2ID: &partner2ID,
+			}),
+		}
+		name := service.getFamilyName(context.Background(), familyID, evt)
+		assert.Equal(t, "John Smith & Jane Doe", name)
+	})
+
+	t.Run("one partner from creation event", func(t *testing.T) {
+		evt := &repository.StoredEvent{
+			EventType: "FamilyCreated",
+			Data: mustMarshal(domain.FamilyCreated{
+				FamilyID:   familyID,
+				Partner1ID: &partner1ID,
+			}),
+		}
+		name := service.getFamilyName(context.Background(), familyID, evt)
+		assert.Equal(t, "John Smith", name)
+	})
+
+	t.Run("no partners falls back to ID", func(t *testing.T) {
+		evt := &repository.StoredEvent{
+			EventType: "FamilyCreated",
+			Data: mustMarshal(domain.FamilyCreated{
+				FamilyID: familyID,
+			}),
+		}
+		name := service.getFamilyName(context.Background(), familyID, evt)
+		assert.Equal(t, familyID.String(), name)
+	})
 }
 
 // Helper function to marshal data for tests


### PR DESCRIPTION
## Summary
- Map `ChildLinkedToFamily` and `ChildUnlinkedFromFamily` events to `("family", "updated")` instead of invalid `"linked"`/`"unlinked"` actions not in the OpenAPI enum
- Add synthetic change entries showing child name (e.g., "Child linked: Bobby Smith") so updated entries are informative
- Skip `GedcomImported` events that used invalid `"import"` entity_type
- Improve `getFamilyName()` fallback to extract partner names from `FamilyCreated` event data

## Test plan
- [x] Unit tests for all event type mappings including linked/unlinked → updated
- [x] Unit tests for GedcomImported event skipping
- [x] Unit test for family name fallback from creation event
- [x] `make lint` passes
- [x] `make test` passes (all Go + frontend)
- [x] `make check-coverage` passes (query package at 86.8%)
- [ ] Manual: verify `/history` page shows proper labels for all entries

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)