### PR TITLE
Unblock pre-push by scoping coverage test to contributing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
         # keeps CI in sync with `make check-coverage` and scripts/pre-push (#408).
         run: |
           COVERAGE_PKGS=$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$')
+          if [ -z "$COVERAGE_PKGS" ]; then
+            echo "Error: failed to resolve coverage package list"
+            exit 1
+          fi
           go test -race -coverprofile=coverage.out $COVERAGE_PKGS
 
       - name: Check coverage threshold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,12 @@ jobs:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: myfamily_test
-        run: go test -race -coverprofile=coverage.out ./...
+        # Scope the build to packages that contribute to coverage. cmd/myfamily
+        # and internal/web are excluded in .testcoverage.yml; skipping them here
+        # keeps CI in sync with `make check-coverage` and scripts/pre-push (#408).
+        run: |
+          COVERAGE_PKGS=$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$')
+          go test -race -coverprofile=coverage.out $COVERAGE_PKGS
 
       - name: Check coverage threshold
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         # and internal/web are excluded in .testcoverage.yml; skipping them here
         # keeps CI in sync with `make check-coverage` and scripts/pre-push (#408).
         run: |
+          set -euo pipefail
           COVERAGE_PKGS=$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$')
           if [ -z "$COVERAGE_PKGS" ]; then
             echo "Error: failed to resolve coverage package list"

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,12 @@ check-coverage: ## Check coverage thresholds (same as CI)
 	# and `internal/web` are excluded in .testcoverage.yml; skipping them here
 	# avoids a Go toolchain rebuild of internal cover helpers that trips
 	# version mismatches in mixed-toolchain environments (see #408).
-	go test -coverprofile=coverage.out $$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$$')
+	@COVERAGE_PKGS=$$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$$'); \
+	if [ -z "$$COVERAGE_PKGS" ]; then \
+		echo "ERROR: check-coverage: failed to resolve coverage package list"; \
+		exit 1; \
+	fi; \
+	go test -coverprofile=coverage.out $$COVERAGE_PKGS
 	@GO_TEST_COVERAGE=$$(command -v go-test-coverage || echo "$$HOME/go/bin/go-test-coverage"); \
 	if [ ! -x "$$GO_TEST_COVERAGE" ]; then \
 		GO_TEST_COVERAGE="$$(go env GOPATH)/bin/go-test-coverage"; \

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,11 @@ check-full: fmt vet lint test ## Full CI check including lint
 	cd web && npm run check
 
 check-coverage: ## Check coverage thresholds (same as CI)
-	go test -coverprofile=coverage.out ./...
+	# Scope the build to packages that contribute to coverage. `cmd/myfamily`
+	# and `internal/web` are excluded in .testcoverage.yml; skipping them here
+	# avoids a Go toolchain rebuild of internal cover helpers that trips
+	# version mismatches in mixed-toolchain environments (see #408).
+	go test -coverprofile=coverage.out $$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$$')
 	@GO_TEST_COVERAGE=$$(command -v go-test-coverage || echo "$$HOME/go/bin/go-test-coverage"); \
 	if [ ! -x "$$GO_TEST_COVERAGE" ]; then \
 		GO_TEST_COVERAGE="$$(go env GOPATH)/bin/go-test-coverage"; \

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -33,6 +33,10 @@ echo "→ Running tests with coverage..."
 # a Go toolchain rebuild of internal cover helpers that trips version
 # mismatches in mixed-toolchain environments (see #408).
 COVERAGE_PKGS=$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$')
+if [ -z "$COVERAGE_PKGS" ]; then
+  echo "Error: failed to resolve coverage package list"
+  exit 1
+fi
 go test -coverprofile=coverage.out $COVERAGE_PKGS
 
 echo "→ Checking coverage thresholds (85% per-package, 75% total)..."

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -9,6 +9,7 @@
 #   # Or run: make setup
 
 set -e
+set -o pipefail
 
 echo "Running pre-push checks..."
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -28,7 +28,12 @@ fi
 
 # --- Coverage Threshold Check ---
 echo "→ Running tests with coverage..."
-go test -coverprofile=coverage.out ./...
+# Scope the build to packages that contribute to coverage. `cmd/myfamily` and
+# `internal/web` are excluded in .testcoverage.yml; skipping them here avoids
+# a Go toolchain rebuild of internal cover helpers that trips version
+# mismatches in mixed-toolchain environments (see #408).
+COVERAGE_PKGS=$(go list ./... | grep -vE '(cmd/myfamily|internal/web)$')
+go test -coverprofile=coverage.out $COVERAGE_PKGS
 
 echo "→ Checking coverage thresholds (85% per-package, 75% total)..."
 if ! "$GO_TEST_COVERAGE" --config=.testcoverage.yml --profile=coverage.out; then


### PR DESCRIPTION
## Summary

Fixes `make check-coverage` / `scripts/pre-push` / CI test step all failing with a Go toolchain version mismatch (`go1.26.2` vs `go1.26.1`) on developer machines with a mixed-toolchain state. The coverage gate itself was green, but `go test -coverprofile=coverage.out ./...` was pulling in `cmd/myfamily` and `internal/web` — both already excluded from coverage in `.testcoverage.yml` — and those packages triggered a stdlib cover-helper rebuild that tripped the version check.

Scopes all three invocations via `go list ./... | grep -vE '(cmd/myfamily|internal/web)$'` so the test build skips the already-excluded packages entirely. CI is kept in sync for consistency, even though CI wasn't broken.

## Changes

- `Makefile` — `check-coverage` target scopes the `go test -coverprofile` package list
- `scripts/pre-push` — same scoping for the pre-push hook
- `.github/workflows/ci.yml` — same scoping for CI parity

All three files cross-reference `#408` in comments pointing back to `.testcoverage.yml`.

## Verification

- [x] `make check-coverage` exits 0 (package 85% PASS, total 75% PASS at 76.3%)
- [x] `make lint` clean
- [x] `make test` — all Go packages + 225 frontend tests pass
- [x] Pre-push hook passed (this very PR push proves it)
- [x] Coverage surface unchanged — only packages already in `.testcoverage.yml`'s `exclude.paths` were dropped from the test build

## Notes

- The root cause is a local Go toolchain mismatch on developer machines, not a project issue. Option 2 from the issue body (scope the invocation) was chosen as the pragmatic fix — it unblocks pushes regardless of local toolchain state, and keeps `make check-coverage` honest about what it's actually testing (the coverage gate's own surface).
- CI's separate per-package check (ci.yml:137) is unaffected — it only inspects `api command config domain gedcom query repository repository/memory`, none of which were dropped.

Closes #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated test coverage collection to exclude specific internal modules, validate the selected package set before running, and generate coverage reports only for the filtered packages—improving accuracy and reliability of coverage checks in CI and pre-push workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->