### PR TITLE
Migrate evidence entities when merging persons

### DIFF
--- a/internal/query/history_queries_test.go
+++ b/internal/query/history_queries_test.go
@@ -350,6 +350,9 @@ func (m *mockReadModelStore) ListEvidenceAnalyses(ctx context.Context, opts repo
 func (m *mockReadModelStore) GetAnalysesForFact(ctx context.Context, factType domain.FactType, subjectID uuid.UUID) ([]repository.EvidenceAnalysisReadModel, error) {
 	return nil, nil
 }
+func (m *mockReadModelStore) GetAnalysesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.EvidenceAnalysisReadModel, error) {
+	return nil, nil
+}
 func (m *mockReadModelStore) SaveEvidenceAnalysis(ctx context.Context, analysis *repository.EvidenceAnalysisReadModel) error {
 	return nil
 }
@@ -402,6 +405,9 @@ func (m *mockReadModelStore) ListProofSummaries(ctx context.Context, opts reposi
 	return nil, 0, nil
 }
 func (m *mockReadModelStore) GetProofSummariesForFact(ctx context.Context, factType domain.FactType, subjectID uuid.UUID) ([]repository.ProofSummaryReadModel, error) {
+	return nil, nil
+}
+func (m *mockReadModelStore) GetProofSummariesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.ProofSummaryReadModel, error) {
 	return nil, nil
 }
 func (m *mockReadModelStore) SaveProofSummary(ctx context.Context, summary *repository.ProofSummaryReadModel) error {

--- a/internal/repository/memory/readmodel.go
+++ b/internal/repository/memory/readmodel.go
@@ -1945,6 +1945,20 @@ func (s *ReadModelStore) GetAnalysesForFact(ctx context.Context, factType domain
 	return results, nil
 }
 
+// GetAnalysesBySubject returns all evidence analyses for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetAnalysesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.EvidenceAnalysisReadModel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []repository.EvidenceAnalysisReadModel
+	for _, a := range s.evidenceAnalyses {
+		if a.SubjectID == subjectID {
+			results = append(results, *a)
+		}
+	}
+	return results, nil
+}
+
 // SaveEvidenceAnalysis saves or updates an evidence analysis.
 func (s *ReadModelStore) SaveEvidenceAnalysis(ctx context.Context, analysis *repository.EvidenceAnalysisReadModel) error {
 	s.mu.Lock()
@@ -2238,6 +2252,20 @@ func (s *ReadModelStore) GetProofSummariesForFact(ctx context.Context, factType 
 	var results []repository.ProofSummaryReadModel
 	for _, ps := range s.proofSummaries {
 		if ps.FactType == factType && ps.SubjectID == subjectID {
+			results = append(results, *ps)
+		}
+	}
+	return results, nil
+}
+
+// GetProofSummariesBySubject returns all proof summaries for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetProofSummariesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.ProofSummaryReadModel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []repository.ProofSummaryReadModel
+	for _, ps := range s.proofSummaries {
+		if ps.SubjectID == subjectID {
 			results = append(results, *ps)
 		}
 	}

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -3940,6 +3940,44 @@ func (s *ReadModelStore) GetAnalysesForFact(ctx context.Context, factType domain
 	return results, rows.Err()
 }
 
+// GetAnalysesBySubject returns all evidence analyses for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetAnalysesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.EvidenceAnalysisReadModel, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, fact_type, subject_id, citation_ids, conclusion, research_status, notes, version, created_at, updated_at
+		FROM evidence_analyses
+		WHERE subject_id = $1
+	`, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("query analyses by subject: %w", err)
+	}
+	defer rows.Close()
+
+	var results []repository.EvidenceAnalysisReadModel
+	for rows.Next() {
+		var a repository.EvidenceAnalysisReadModel
+		var citationIDs, researchStatus, notes sql.NullString
+		if err := rows.Scan(
+			&a.ID, &a.FactType, &a.SubjectID, &citationIDs,
+			&a.Conclusion, &researchStatus, &notes,
+			&a.Version, &a.CreatedAt, &a.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan evidence_analysis: %w", err)
+		}
+		if citationIDs.Valid {
+			a.CitationIDsJSON = citationIDs.String
+		}
+		if researchStatus.Valid {
+			a.ResearchStatus = domain.ResearchStatus(researchStatus.String)
+		}
+		if notes.Valid {
+			a.Notes = notes.String
+		}
+		results = append(results, a)
+	}
+
+	return results, rows.Err()
+}
+
 // SaveEvidenceAnalysis saves or updates an evidence analysis.
 func (s *ReadModelStore) SaveEvidenceAnalysis(ctx context.Context, analysis *repository.EvidenceAnalysisReadModel) error {
 	_, err := s.db.ExecContext(ctx, `
@@ -4394,6 +4432,41 @@ func (s *ReadModelStore) GetProofSummariesForFact(ctx context.Context, factType 
 	`, string(factType), subjectID)
 	if err != nil {
 		return nil, fmt.Errorf("query proof summaries for fact: %w", err)
+	}
+	defer rows.Close()
+
+	var results []repository.ProofSummaryReadModel
+	for rows.Next() {
+		var ps repository.ProofSummaryReadModel
+		var analysisIDs, researchStatus sql.NullString
+		if err := rows.Scan(
+			&ps.ID, &ps.FactType, &ps.SubjectID, &ps.Conclusion,
+			&ps.Argument, &analysisIDs, &researchStatus,
+			&ps.Version, &ps.CreatedAt, &ps.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan proof_summary: %w", err)
+		}
+		if analysisIDs.Valid {
+			ps.AnalysisIDsJSON = analysisIDs.String
+		}
+		if researchStatus.Valid {
+			ps.ResearchStatus = domain.ResearchStatus(researchStatus.String)
+		}
+		results = append(results, ps)
+	}
+
+	return results, rows.Err()
+}
+
+// GetProofSummariesBySubject returns all proof summaries for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetProofSummariesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.ProofSummaryReadModel, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, fact_type, subject_id, conclusion, argument, analysis_ids, research_status, version, created_at, updated_at
+		FROM proof_summaries
+		WHERE subject_id = $1
+	`, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("query proof summaries by subject: %w", err)
 	}
 	defer rows.Close()
 

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -1300,19 +1300,19 @@ func (p *Projector) projectPersonMerged(ctx context.Context, e domain.PersonMerg
 	// 4. Reassign citations from merged person to survivor
 	citations, err := p.readStore.GetCitationsForPerson(ctx, e.MergedID)
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch citations for merged person %s: %w", e.MergedID, err)
 	}
 	for _, citation := range citations {
 		citation.FactOwnerID = e.SurvivorID
 		if err := p.readStore.SaveCitation(ctx, &citation); err != nil {
-			return err
+			return fmt.Errorf("migrate citation %s for merged person %s: %w", citation.ID, e.MergedID, err)
 		}
 	}
 
 	// 5. Transfer PersonName records from merged to survivor
 	names, err := p.readStore.GetPersonNames(ctx, e.MergedID)
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch person names for merged person %s: %w", e.MergedID, err)
 	}
 	for _, name := range names {
 		// Change the person ID to survivor and mark as non-primary
@@ -1320,48 +1320,96 @@ func (p *Projector) projectPersonMerged(ctx context.Context, e domain.PersonMerg
 		name.IsPrimary = false // Transferred names become alternate names
 		name.UpdatedAt = e.OccurredAt()
 		if err := p.readStore.SavePersonName(ctx, &name); err != nil {
-			return err
+			return fmt.Errorf("migrate person name %s for merged person %s: %w", name.ID, e.MergedID, err)
 		}
 	}
 
 	// 6. Transfer life events from merged person to survivor
 	events, err := p.readStore.ListEventsForPerson(ctx, e.MergedID)
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch events for merged person %s: %w", e.MergedID, err)
 	}
 	for _, event := range events {
 		event.OwnerID = e.SurvivorID
 		if err := p.readStore.SaveEvent(ctx, &event); err != nil {
-			return err
+			return fmt.Errorf("migrate event %s for merged person %s: %w", event.ID, e.MergedID, err)
 		}
 	}
 
 	// 7. Transfer media from merged person to survivor
 	mediaList, _, err := p.readStore.ListMediaForEntity(ctx, "person", e.MergedID, ListOptions{Limit: 10000})
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch media for merged person %s: %w", e.MergedID, err)
 	}
 	for _, media := range mediaList {
 		media.EntityID = e.SurvivorID
 		media.UpdatedAt = e.OccurredAt()
 		if err := p.readStore.SaveMedia(ctx, &media); err != nil {
-			return err
+			return fmt.Errorf("migrate media %s for merged person %s: %w", media.ID, e.MergedID, err)
 		}
 	}
 
 	// 8. Transfer attributes from merged person to survivor
 	attributes, err := p.readStore.ListAttributesForPerson(ctx, e.MergedID)
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch attributes for merged person %s: %w", e.MergedID, err)
 	}
 	for _, attr := range attributes {
 		attr.PersonID = e.SurvivorID
 		if err := p.readStore.SaveAttribute(ctx, &attr); err != nil {
-			return err
+			return fmt.Errorf("migrate attribute %s for merged person %s: %w", attr.ID, e.MergedID, err)
 		}
 	}
 
-	// 9. Delete merged person from read model
+	// 9. Transfer evidence analyses from merged person to survivor
+	analyses, err := p.readStore.GetAnalysesBySubject(ctx, e.MergedID)
+	if err != nil {
+		return fmt.Errorf("fetch evidence analyses for merged person %s: %w", e.MergedID, err)
+	}
+	for _, analysis := range analyses {
+		analysis.SubjectID = e.SurvivorID
+		if err := p.readStore.SaveEvidenceAnalysis(ctx, &analysis); err != nil {
+			return fmt.Errorf("migrate evidence analysis %s for merged person %s: %w", analysis.ID, e.MergedID, err)
+		}
+	}
+
+	// 10. Transfer evidence conflicts from merged person to survivor
+	conflicts, err := p.readStore.GetConflictsForSubject(ctx, e.MergedID)
+	if err != nil {
+		return fmt.Errorf("fetch evidence conflicts for merged person %s: %w", e.MergedID, err)
+	}
+	for _, conflict := range conflicts {
+		conflict.SubjectID = e.SurvivorID
+		if err := p.readStore.SaveEvidenceConflict(ctx, &conflict); err != nil {
+			return fmt.Errorf("migrate evidence conflict %s for merged person %s: %w", conflict.ID, e.MergedID, err)
+		}
+	}
+
+	// 11. Transfer research logs from merged person to survivor
+	researchLogs, err := p.readStore.GetResearchLogsForSubject(ctx, e.MergedID)
+	if err != nil {
+		return fmt.Errorf("fetch research logs for merged person %s: %w", e.MergedID, err)
+	}
+	for _, log := range researchLogs {
+		log.SubjectID = e.SurvivorID
+		if err := p.readStore.SaveResearchLog(ctx, &log); err != nil {
+			return fmt.Errorf("migrate research log %s for merged person %s: %w", log.ID, e.MergedID, err)
+		}
+	}
+
+	// 12. Transfer proof summaries from merged person to survivor
+	summaries, err := p.readStore.GetProofSummariesBySubject(ctx, e.MergedID)
+	if err != nil {
+		return fmt.Errorf("fetch proof summaries for merged person %s: %w", e.MergedID, err)
+	}
+	for _, summary := range summaries {
+		summary.SubjectID = e.SurvivorID
+		if err := p.readStore.SaveProofSummary(ctx, &summary); err != nil {
+			return fmt.Errorf("migrate proof summary %s for merged person %s: %w", summary.ID, e.MergedID, err)
+		}
+	}
+
+	// 13. Delete merged person from read model
 	return p.readStore.DeletePerson(ctx, e.MergedID)
 }
 

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -2777,6 +2777,338 @@ func TestProjector_PersonMerged_AttributeTransfer(t *testing.T) {
 	}
 }
 
+func TestProjector_PersonMerged_EvidenceAnalysisTransfer(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Create persons
+	survivor := domain.NewPerson("John", "Doe")
+	merged := domain.NewPerson("Johnny", "Doe")
+
+	projector.Project(ctx, domain.NewPersonCreated(survivor), 1)
+	projector.Project(ctx, domain.NewPersonCreated(merged), 1)
+
+	// Create evidence analysis for merged person
+	ea := &domain.EvidenceAnalysis{
+		ID:             uuid.New(),
+		FactType:       domain.FactPersonBirth,
+		SubjectID:      merged.ID,
+		CitationIDs:    []uuid.UUID{uuid.New()},
+		Conclusion:     "Birth date confirmed",
+		ResearchStatus: domain.ResearchStatusCertain,
+		Notes:          "Based on birth certificate",
+	}
+	if err := projector.Project(ctx, domain.NewEvidenceAnalysisCreated(ea), 2); err != nil {
+		t.Fatalf("Project EvidenceAnalysisCreated failed: %v", err)
+	}
+
+	// Verify analysis is on merged person before merge
+	mergedAnalyses, _ := readStore.GetAnalysesBySubject(ctx, merged.ID)
+	if len(mergedAnalyses) != 1 {
+		t.Fatalf("Expected 1 analysis for merged person, got %d", len(mergedAnalyses))
+	}
+
+	// Merge
+	event := domain.NewPersonMerged(
+		survivor.ID,
+		merged.ID,
+		map[string]any{},
+		map[string]any{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+	)
+
+	if err := projector.Project(ctx, event, 3); err != nil {
+		t.Fatalf("Project PersonMerged failed: %v", err)
+	}
+
+	// Verify analysis was transferred to survivor
+	survivorAnalyses, err := readStore.GetAnalysesBySubject(ctx, survivor.ID)
+	if err != nil {
+		t.Fatalf("GetAnalysesBySubject(survivor) failed: %v", err)
+	}
+	if len(survivorAnalyses) != 1 {
+		t.Fatalf("Expected 1 analysis for survivor, got %d", len(survivorAnalyses))
+	}
+	if survivorAnalyses[0].SubjectID != survivor.ID {
+		t.Errorf("Analysis SubjectID = %v, want %v", survivorAnalyses[0].SubjectID, survivor.ID)
+	}
+	if survivorAnalyses[0].ID != ea.ID {
+		t.Errorf("Analysis ID = %v, want %v", survivorAnalyses[0].ID, ea.ID)
+	}
+
+	// Verify analysis no longer returned for merged person ID
+	mergedAnalyses, err = readStore.GetAnalysesBySubject(ctx, merged.ID)
+	if err != nil {
+		t.Fatalf("GetAnalysesBySubject(merged) failed: %v", err)
+	}
+	if len(mergedAnalyses) != 0 {
+		t.Errorf("Expected 0 analyses for merged person after merge, got %d", len(mergedAnalyses))
+	}
+
+	// Verify record read back directly has the new SubjectID
+	rm, _ := readStore.GetEvidenceAnalysis(ctx, ea.ID)
+	if rm == nil {
+		t.Fatal("EvidenceAnalysis should still exist after merge")
+	}
+	if rm.SubjectID != survivor.ID {
+		t.Errorf("Direct read SubjectID = %v, want %v", rm.SubjectID, survivor.ID)
+	}
+}
+
+func TestProjector_PersonMerged_EvidenceConflictTransfer(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Create persons
+	survivor := domain.NewPerson("John", "Doe")
+	merged := domain.NewPerson("Johnny", "Doe")
+
+	projector.Project(ctx, domain.NewPersonCreated(survivor), 1)
+	projector.Project(ctx, domain.NewPersonCreated(merged), 1)
+
+	// Create evidence conflict for merged person
+	ec := &domain.EvidenceConflict{
+		ID:          uuid.New(),
+		FactType:    domain.FactPersonBirth,
+		SubjectID:   merged.ID,
+		AnalysisIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		Description: "Conflicting birth dates",
+		Status:      domain.ConflictStatusOpen,
+	}
+	if err := projector.Project(ctx, domain.NewEvidenceConflictDetected(ec), 2); err != nil {
+		t.Fatalf("Project EvidenceConflictDetected failed: %v", err)
+	}
+
+	// Verify conflict is on merged person before merge
+	mergedConflicts, _ := readStore.GetConflictsForSubject(ctx, merged.ID)
+	if len(mergedConflicts) != 1 {
+		t.Fatalf("Expected 1 conflict for merged person, got %d", len(mergedConflicts))
+	}
+
+	// Merge
+	event := domain.NewPersonMerged(
+		survivor.ID,
+		merged.ID,
+		map[string]any{},
+		map[string]any{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+	)
+
+	if err := projector.Project(ctx, event, 3); err != nil {
+		t.Fatalf("Project PersonMerged failed: %v", err)
+	}
+
+	// Verify conflict was transferred to survivor
+	survivorConflicts, err := readStore.GetConflictsForSubject(ctx, survivor.ID)
+	if err != nil {
+		t.Fatalf("GetConflictsForSubject(survivor) failed: %v", err)
+	}
+	if len(survivorConflicts) != 1 {
+		t.Fatalf("Expected 1 conflict for survivor, got %d", len(survivorConflicts))
+	}
+	if survivorConflicts[0].SubjectID != survivor.ID {
+		t.Errorf("Conflict SubjectID = %v, want %v", survivorConflicts[0].SubjectID, survivor.ID)
+	}
+	if survivorConflicts[0].ID != ec.ID {
+		t.Errorf("Conflict ID = %v, want %v", survivorConflicts[0].ID, ec.ID)
+	}
+
+	// Verify conflict no longer returned for merged person ID
+	mergedConflicts, err = readStore.GetConflictsForSubject(ctx, merged.ID)
+	if err != nil {
+		t.Fatalf("GetConflictsForSubject(merged) failed: %v", err)
+	}
+	if len(mergedConflicts) != 0 {
+		t.Errorf("Expected 0 conflicts for merged person after merge, got %d", len(mergedConflicts))
+	}
+
+	// Verify record read back directly has the new SubjectID
+	rm, _ := readStore.GetEvidenceConflict(ctx, ec.ID)
+	if rm == nil {
+		t.Fatal("EvidenceConflict should still exist after merge")
+	}
+	if rm.SubjectID != survivor.ID {
+		t.Errorf("Direct read SubjectID = %v, want %v", rm.SubjectID, survivor.ID)
+	}
+}
+
+func TestProjector_PersonMerged_ResearchLogTransfer(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Create persons
+	survivor := domain.NewPerson("John", "Doe")
+	merged := domain.NewPerson("Johnny", "Doe")
+
+	projector.Project(ctx, domain.NewPersonCreated(survivor), 1)
+	projector.Project(ctx, domain.NewPersonCreated(merged), 1)
+
+	// Create research log for merged person
+	rl := &domain.ResearchLog{
+		ID:                uuid.New(),
+		SubjectID:         merged.ID,
+		SubjectType:       "person",
+		Repository:        "National Archives",
+		SearchDescription: "Census records",
+		Outcome:           domain.ResearchOutcomeFound,
+		Notes:             "Found in 1850 census",
+		SearchDate:        time.Now().UTC(),
+	}
+	if err := projector.Project(ctx, domain.NewResearchLogCreated(rl), 2); err != nil {
+		t.Fatalf("Project ResearchLogCreated failed: %v", err)
+	}
+
+	// Verify log is on merged person before merge
+	mergedLogs, _ := readStore.GetResearchLogsForSubject(ctx, merged.ID)
+	if len(mergedLogs) != 1 {
+		t.Fatalf("Expected 1 research log for merged person, got %d", len(mergedLogs))
+	}
+
+	// Merge
+	event := domain.NewPersonMerged(
+		survivor.ID,
+		merged.ID,
+		map[string]any{},
+		map[string]any{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+	)
+
+	if err := projector.Project(ctx, event, 3); err != nil {
+		t.Fatalf("Project PersonMerged failed: %v", err)
+	}
+
+	// Verify research log was transferred to survivor
+	survivorLogs, err := readStore.GetResearchLogsForSubject(ctx, survivor.ID)
+	if err != nil {
+		t.Fatalf("GetResearchLogsForSubject(survivor) failed: %v", err)
+	}
+	if len(survivorLogs) != 1 {
+		t.Fatalf("Expected 1 research log for survivor, got %d", len(survivorLogs))
+	}
+	if survivorLogs[0].SubjectID != survivor.ID {
+		t.Errorf("ResearchLog SubjectID = %v, want %v", survivorLogs[0].SubjectID, survivor.ID)
+	}
+	if survivorLogs[0].ID != rl.ID {
+		t.Errorf("ResearchLog ID = %v, want %v", survivorLogs[0].ID, rl.ID)
+	}
+
+	// Verify log no longer returned for merged person ID
+	mergedLogs, err = readStore.GetResearchLogsForSubject(ctx, merged.ID)
+	if err != nil {
+		t.Fatalf("GetResearchLogsForSubject(merged) failed: %v", err)
+	}
+	if len(mergedLogs) != 0 {
+		t.Errorf("Expected 0 research logs for merged person after merge, got %d", len(mergedLogs))
+	}
+
+	// Verify record read back directly has the new SubjectID
+	rm, _ := readStore.GetResearchLog(ctx, rl.ID)
+	if rm == nil {
+		t.Fatal("ResearchLog should still exist after merge")
+	}
+	if rm.SubjectID != survivor.ID {
+		t.Errorf("Direct read SubjectID = %v, want %v", rm.SubjectID, survivor.ID)
+	}
+}
+
+func TestProjector_PersonMerged_ProofSummaryTransfer(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Create persons
+	survivor := domain.NewPerson("John", "Doe")
+	merged := domain.NewPerson("Johnny", "Doe")
+
+	projector.Project(ctx, domain.NewPersonCreated(survivor), 1)
+	projector.Project(ctx, domain.NewPersonCreated(merged), 1)
+
+	// Create proof summary for merged person
+	ps := &domain.ProofSummary{
+		ID:             uuid.New(),
+		FactType:       domain.FactPersonBirth,
+		SubjectID:      merged.ID,
+		Conclusion:     "Birth year is 1850",
+		Argument:       "Multiple sources agree on this date",
+		AnalysisIDs:    []uuid.UUID{uuid.New()},
+		ResearchStatus: domain.ResearchStatusProbable,
+	}
+	if err := projector.Project(ctx, domain.NewProofSummaryCreated(ps), 2); err != nil {
+		t.Fatalf("Project ProofSummaryCreated failed: %v", err)
+	}
+
+	// Verify summary is on merged person before merge
+	mergedSummaries, _ := readStore.GetProofSummariesBySubject(ctx, merged.ID)
+	if len(mergedSummaries) != 1 {
+		t.Fatalf("Expected 1 proof summary for merged person, got %d", len(mergedSummaries))
+	}
+
+	// Merge
+	event := domain.NewPersonMerged(
+		survivor.ID,
+		merged.ID,
+		map[string]any{},
+		map[string]any{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+		[]uuid.UUID{},
+	)
+
+	if err := projector.Project(ctx, event, 3); err != nil {
+		t.Fatalf("Project PersonMerged failed: %v", err)
+	}
+
+	// Verify proof summary was transferred to survivor
+	survivorSummaries, err := readStore.GetProofSummariesBySubject(ctx, survivor.ID)
+	if err != nil {
+		t.Fatalf("GetProofSummariesBySubject(survivor) failed: %v", err)
+	}
+	if len(survivorSummaries) != 1 {
+		t.Fatalf("Expected 1 proof summary for survivor, got %d", len(survivorSummaries))
+	}
+	if survivorSummaries[0].SubjectID != survivor.ID {
+		t.Errorf("ProofSummary SubjectID = %v, want %v", survivorSummaries[0].SubjectID, survivor.ID)
+	}
+	if survivorSummaries[0].ID != ps.ID {
+		t.Errorf("ProofSummary ID = %v, want %v", survivorSummaries[0].ID, ps.ID)
+	}
+
+	// Verify summary no longer returned for merged person ID
+	mergedSummaries, err = readStore.GetProofSummariesBySubject(ctx, merged.ID)
+	if err != nil {
+		t.Fatalf("GetProofSummariesBySubject(merged) failed: %v", err)
+	}
+	if len(mergedSummaries) != 0 {
+		t.Errorf("Expected 0 proof summaries for merged person after merge, got %d", len(mergedSummaries))
+	}
+
+	// Verify record read back directly has the new SubjectID
+	rm, _ := readStore.GetProofSummary(ctx, ps.ID)
+	if rm == nil {
+		t.Fatal("ProofSummary should still exist after merge")
+	}
+	if rm.SubjectID != survivor.ID {
+		t.Errorf("Direct read SubjectID = %v, want %v", rm.SubjectID, survivor.ID)
+	}
+}
+
 func TestProjector_PersonMerged_PedigreeEdgeTransfer(t *testing.T) {
 	readStore := memory.NewReadModelStore()
 	projector := repository.NewProjector(readStore)

--- a/internal/repository/readmodel.go
+++ b/internal/repository/readmodel.go
@@ -397,6 +397,7 @@ type ReadModelStore interface {
 	GetEvidenceAnalysis(ctx context.Context, id uuid.UUID) (*EvidenceAnalysisReadModel, error)
 	ListEvidenceAnalyses(ctx context.Context, opts ListOptions) ([]EvidenceAnalysisReadModel, int, error)
 	GetAnalysesForFact(ctx context.Context, factType domain.FactType, subjectID uuid.UUID) ([]EvidenceAnalysisReadModel, error)
+	GetAnalysesBySubject(ctx context.Context, subjectID uuid.UUID) ([]EvidenceAnalysisReadModel, error)
 	SaveEvidenceAnalysis(ctx context.Context, analysis *EvidenceAnalysisReadModel) error
 	DeleteEvidenceAnalysis(ctx context.Context, id uuid.UUID) error
 
@@ -419,6 +420,7 @@ type ReadModelStore interface {
 	GetProofSummary(ctx context.Context, id uuid.UUID) (*ProofSummaryReadModel, error)
 	ListProofSummaries(ctx context.Context, opts ListOptions) ([]ProofSummaryReadModel, int, error)
 	GetProofSummariesForFact(ctx context.Context, factType domain.FactType, subjectID uuid.UUID) ([]ProofSummaryReadModel, error)
+	GetProofSummariesBySubject(ctx context.Context, subjectID uuid.UUID) ([]ProofSummaryReadModel, error)
 	SaveProofSummary(ctx context.Context, summary *ProofSummaryReadModel) error
 	DeleteProofSummary(ctx context.Context, id uuid.UUID) error
 

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -4537,6 +4537,56 @@ func (s *ReadModelStore) GetAnalysesForFact(ctx context.Context, factType domain
 	return results, rows.Err()
 }
 
+// GetAnalysesBySubject returns all evidence analyses for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetAnalysesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.EvidenceAnalysisReadModel, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, fact_type, subject_id, citation_ids, conclusion, research_status, notes, version, created_at, updated_at
+		FROM evidence_analyses
+		WHERE subject_id = ?
+	`, subjectID.String())
+	if err != nil {
+		return nil, fmt.Errorf("query analyses by subject: %w", err)
+	}
+	defer rows.Close()
+
+	var results []repository.EvidenceAnalysisReadModel
+	for rows.Next() {
+		var a repository.EvidenceAnalysisReadModel
+		var idStr, subjectIDStr string
+		var citationIDs, researchStatus, notes sql.NullString
+		var createdAtStr, updatedAtStr string
+
+		if err := rows.Scan(
+			&idStr, &a.FactType, &subjectIDStr, &citationIDs,
+			&a.Conclusion, &researchStatus, &notes,
+			&a.Version, &createdAtStr, &updatedAtStr,
+		); err != nil {
+			return nil, fmt.Errorf("scan evidence_analysis: %w", err)
+		}
+
+		a.ID, _ = uuid.Parse(idStr)
+		a.SubjectID, _ = uuid.Parse(subjectIDStr)
+		if citationIDs.Valid {
+			a.CitationIDsJSON = citationIDs.String
+		}
+		if researchStatus.Valid {
+			a.ResearchStatus = domain.ResearchStatus(researchStatus.String)
+		}
+		if notes.Valid {
+			a.Notes = notes.String
+		}
+		if t, err := parseTimestamp(createdAtStr); err == nil {
+			a.CreatedAt = t
+		}
+		if t, err := parseTimestamp(updatedAtStr); err == nil {
+			a.UpdatedAt = t
+		}
+		results = append(results, a)
+	}
+
+	return results, rows.Err()
+}
+
 // SaveEvidenceAnalysis saves or updates an evidence analysis.
 func (s *ReadModelStore) SaveEvidenceAnalysis(ctx context.Context, analysis *repository.EvidenceAnalysisReadModel) error {
 	var citationIDs, researchStatus, notes any
@@ -5133,6 +5183,53 @@ func (s *ReadModelStore) GetProofSummariesForFact(ctx context.Context, factType 
 	`, string(factType), subjectID.String())
 	if err != nil {
 		return nil, fmt.Errorf("query proof summaries for fact: %w", err)
+	}
+	defer rows.Close()
+
+	var results []repository.ProofSummaryReadModel
+	for rows.Next() {
+		var ps repository.ProofSummaryReadModel
+		var idStr, subjectIDStr string
+		var analysisIDs, researchStatus sql.NullString
+		var createdAtStr, updatedAtStr string
+
+		if err := rows.Scan(
+			&idStr, &ps.FactType, &subjectIDStr, &ps.Conclusion,
+			&ps.Argument, &analysisIDs, &researchStatus,
+			&ps.Version, &createdAtStr, &updatedAtStr,
+		); err != nil {
+			return nil, fmt.Errorf("scan proof_summary: %w", err)
+		}
+
+		ps.ID, _ = uuid.Parse(idStr)
+		ps.SubjectID, _ = uuid.Parse(subjectIDStr)
+		if analysisIDs.Valid {
+			ps.AnalysisIDsJSON = analysisIDs.String
+		}
+		if researchStatus.Valid {
+			ps.ResearchStatus = domain.ResearchStatus(researchStatus.String)
+		}
+		if t, err := parseTimestamp(createdAtStr); err == nil {
+			ps.CreatedAt = t
+		}
+		if t, err := parseTimestamp(updatedAtStr); err == nil {
+			ps.UpdatedAt = t
+		}
+		results = append(results, ps)
+	}
+
+	return results, rows.Err()
+}
+
+// GetProofSummariesBySubject returns all proof summaries for a given subject, regardless of fact type.
+func (s *ReadModelStore) GetProofSummariesBySubject(ctx context.Context, subjectID uuid.UUID) ([]repository.ProofSummaryReadModel, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, fact_type, subject_id, conclusion, argument, analysis_ids, research_status, version, created_at, updated_at
+		FROM proof_summaries
+		WHERE subject_id = ?
+	`, subjectID.String())
+	if err != nil {
+		return nil, fmt.Errorf("query proof summaries by subject: %w", err)
 	}
 	defer rows.Close()
 


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in `projectPersonMerged`: the handler migrated citations, names, events, media, and attributes from the merged person to the survivor, but four evidence-related entity types added in #51 / PR #385 were left orphaned — evidence analyses, evidence conflicts, research logs, and proof summaries. After a merge, subject-scoped queries silently dropped the merged person's evidence history.

Also retrofits the pre-existing migration blocks with consistent `fmt.Errorf(...: %w)` error wrapping so the full handler is stylistically uniform.

## Changes

### Store layer (read model)
- `internal/repository/readmodel.go` — add `GetAnalysesBySubject` and `GetProofSummariesBySubject` to `ReadModelStore`. The existing `GetAnalysesForFact` / `GetProofSummariesForFact` variants require a `fact_type` filter that can't be sensibly applied to a subject-wide merge migration.
- `internal/repository/postgres/readmodel.go` — mirror the `ForFact` SQL minus the `fact_type` predicate
- `internal/repository/sqlite/readmodel.go` — same, with sqlite placeholder quirks
- `internal/repository/memory/readmodel.go` — map iteration filtered by `SubjectID`
- `internal/query/history_queries_test.go` — stub the two new methods on `mockReadModelStore`

### Merge projection
- `internal/repository/projection.go` — extend `projectPersonMerged` with four new migration blocks (analyses → conflicts → research logs → proof summaries) that fetch by `e.MergedID`, reassign `SubjectID = e.SurvivorID`, and save. Direct read-model mutation, no new events emitted, matching the existing transfer pattern.
- **Also retrofits** the pre-existing citation/name/event/media/attribute blocks to wrap errors with `fmt.Errorf(...: %w)` so all nine migration blocks in the function are stylistically consistent.

### Tests
- `internal/repository/projection_test.go` — four new `TestProjector_PersonMerged_*Transfer` tests mirroring the existing `CitationTransfer` template:
  - `TestProjector_PersonMerged_EvidenceAnalysisTransfer`
  - `TestProjector_PersonMerged_EvidenceConflictTransfer`
  - `TestProjector_PersonMerged_ResearchLogTransfer`
  - `TestProjector_PersonMerged_ProofSummaryTransfer`

  Each creates two persons, an evidence record on the merged person, projects `PersonMerged`, then asserts the record is queryable under the survivor's `SubjectID` and gone from the merged ID.

## Verification

- [x] `make lint` — 0 issues
- [x] `make test` — all Go packages + 225 frontend tests pass
- [x] `make check-coverage` — package 85% PASS, total 75% PASS (76.2%)
- [x] Pre-push hook passed (now works thanks to #409)
- [x] Targeted: all 4 new `TestProjector_PersonMerged_*Transfer` tests pass

## Design decisions

- **Direct read-model mutation vs. new reassignment events**: the issue explicitly allowed either approach. I chose direct mutation to match the pattern of the existing five transfer blocks in the same function. Introducing new event types would have added event-sourcing scope the bug fix doesn't require, and would have been inconsistent with how citations/names/events/media/attributes are already handled.
- **New store methods vs. iterating fact types**: `GetAnalysesForFact` / `GetProofSummariesForFact` require a fact-type filter. Enumerating all known fact types in the merge handler would be brittle (leaks abstraction, requires handler-side knowledge of the full fact-type set). Adding two subject-only query methods keeps the merge handler clean and provides reusable building blocks.
- **Style retrofit**: scope creep, but minor and justified. The new evidence blocks use wrapped errors; matching the old blocks keeps one function internally consistent.

Closes #386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve all evidence analyses and proof summaries associated with a specific person.
  * Enhanced person merge functionality to properly transfer evidence-related records (analyses, conflicts, research logs, proof summaries) to the merged person.

* **Tests**
  * Added comprehensive tests validating person merge transfer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->