### PR TITLE
Add OSSF Scorecard workflow, security policy, and tighten token permissions

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   rebase:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # PR title validation - must NOT use conventional commit format
   pr-title:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
     # Run weekly on Sundays at 00:00 UTC
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cacack/my-family)](https://goreportcard.com/report/github.com/cacack/my-family)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/cacack/my-family)](https://github.com/cacack/my-family)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://opensource.org/licenses/AGPL-3.0)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cacack/my-family/badge)](https://scorecard.dev/viewer/?uri=github.com/cacack/my-family)
 
 Self-hosted genealogy software written in Go with an embedded Svelte frontend.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+This project is in active pre-1.0 development. Only the latest release on the `main` branch receives security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| latest `main` | Yes |
+| prior releases | No |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report suspected vulnerabilities privately via GitHub's [private vulnerability reporting](https://github.com/cacack/my-family/security/advisories/new) form.
+
+Include, where possible:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept code, affected endpoints, required preconditions)
+- The commit SHA or release version you tested against
+- Any suggested mitigation
+
+You can expect an initial acknowledgement within 7 days. Because this is a solo-maintained project, remediation timelines are best-effort and depend on severity.
+
+## Scope
+
+In scope:
+
+- The `myfamily` server binary and its HTTP API
+- The embedded Svelte frontend
+- GEDCOM import/export handling
+- Database projection and event-store code
+
+Out of scope:
+
+- Self-hosted deployments misconfigured by the operator (e.g. exposing the server to the public internet without a reverse proxy, auth, or TLS)
+- Denial of service from deliberately oversized or malformed GEDCOM files (the import path is trusted-input by design)
+- Issues in third-party dependencies that already have a published advisory — please report those upstream


### PR DESCRIPTION
## Summary

- Add OSSF Scorecard workflow (weekly + push to `main`) that publishes results to [scorecard.dev](https://scorecard.dev) and uploads SARIF to code scanning.
- Add `SECURITY.md` directing vuln reports to GitHub's private security advisories (closes Scorecard's `Security-Policy` check).
- Add top-level `permissions: contents: read` to `ci.yml`, `codeql.yml`, and `auto-rebase.yml` (closes Scorecard's `Token-Permissions` check). Job-level permissions continue to override where elevated scope is required (e.g. `security-events: write` in CodeQL and the CI security job).
- Add Scorecard badge to `README.md`.

## Expected Scorecard posture

Already satisfied by existing infra: `Pinned-Dependencies` (all actions SHA-pinned), `SAST` (CodeQL + gosec + semgrep), `Vulnerabilities` (govulncheck + trivy), `Dependency-Update-Tool` (Dependabot), `CI-Tests`, `License`, `Packaging` (release-please + goreleaser).

Remaining gap: `Branch-Protection` on `main` — solo-maintainer trade-off; not addressed here.

## Notes

- Badge will show "unknown" until the workflow has run at least once on `main` with `publish_results: true`.
- Scorecard workflow cron is set to Mondays 06:00 UTC to avoid colliding with the existing CodeQL (Sun 00:00) and nightly (daily 03:00) schedules.

## Test plan

- [ ] CI passes on PR
- [ ] After merge, verify `OSSF Scorecard` workflow runs successfully on `main`
- [ ] Verify badge resolves at `https://api.scorecard.dev/projects/github.com/cacack/my-family/badge`
- [ ] Verify Scorecard SARIF appears in the repo's Code Scanning tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
