### PR TITLE
Address OSSF Scorecard easy wins (injection, token perms, vuln ignores)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,23 +17,23 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check PR title is not conventional commit format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-
           # Exempt release-please PRs
-          if echo "$TITLE" | grep -qE "^chore\(main\): release [0-9]"; then
+          if echo "$PR_TITLE" | grep -qE "^chore\(main\): release [0-9]"; then
             echo "✅ Release-please PR exempt"
             exit 0
           fi
 
           # Exempt Dependabot PRs
-          if echo "$TITLE" | grep -qE "^chore\(deps(-dev)?\): [Bb]ump "; then
+          if echo "$PR_TITLE" | grep -qE "^chore\(deps(-dev)?\): [Bb]ump "; then
             echo "✅ Dependabot PR exempt"
             exit 0
           fi
 
           PATTERN="^(feat|fix|perf|docs|refactor|ci|chore)(\(.+\))?!?:"
-          if echo "$TITLE" | grep -qE "$PATTERN"; then
+          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
             echo "::error::PR title should NOT use conventional commit format."
             echo "::error::Use a descriptive title instead (e.g., 'Add date support' not 'feat: add date support')"
             echo "::error::Conventional commit format is for commit messages only."

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,13 +3,15 @@ name: Dependabot Auto-Merge
 on: pull_request_target
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  security-events: write
 
 jobs:
   fuzz:
@@ -60,6 +58,9 @@ jobs:
     name: Security Scan (Nightly)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -143,6 +144,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fuzz, security]
     if: failure() && github.event_name == 'schedule'
+    permissions:
+      contents: read
+      issues: write
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,14 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -26,6 +28,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,13 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,30 @@
+# Vulnerability ignores consumed by OSV-Scanner and the OSSF Scorecard
+# Vulnerabilities check. Each entry documents why the finding is not
+# reachable or otherwise not actionable for this project.
+#
+# Review quarterly; remove entries as soon as upstreams publish fixes on
+# the module paths we actually depend on.
+
+[[IgnoredVulns]]
+id = "GO-2026-4883"
+# Moby/Docker off-by-one in plugin privilege validation. Reached only via
+# `github.com/docker/docker` (pulled by `testcontainers-go` for postgres
+# test harnesses). Our code never invokes the affected AuthZ/plugin paths
+# and `govulncheck` reports the symbol as unreachable. Upstream fix lives
+# on `github.com/moby/moby/v2` v2.0.0-beta.8+; no fix has been published
+# on the legacy `github.com/docker/docker` module path that our dep graph
+# uses. Re-evaluate when testcontainers-go migrates to moby/v2.
+
+[[IgnoredVulns]]
+id = "GO-2026-4887"
+# Same dependency/reachability story as GO-2026-4883: Moby AuthZ plugin
+# bypass on oversized request bodies, only fixed on the moby/v2 module
+# path, unreachable from this codebase.
+
+[[IgnoredVulns]]
+id = "GHSA-pxg6-pf52-xh8x"
+# `cookie` <0.7.0 accepts out-of-bounds characters. Pulled transitively
+# via `@sveltejs/kit` server runtime. This project ships the SvelteKit
+# app as a statically built SPA embedded in the Go binary; the SvelteKit
+# server and its cookie parsing are never executed. Will clear on the
+# next @sveltejs/kit major bump, which Dependabot tracks.


### PR DESCRIPTION
## Summary

Follow-up to #426. Addresses the three Scorecard checks that were the cheapest lift:

- **Dangerous-Workflow** (0 → 10): the `pr-title` step in `ci.yml` interpolated `github.event.pull_request.title` directly into a shell `run:` block — a standard GitHub Actions script-injection sink. Moved the title into an `env:` variable so it's only ever referenced as an already-quoted shell variable.
- **Token-Permissions** (0 → 10): moved top-level write scopes to the jobs that actually need them in `dependabot-automerge.yml`, `release.yml`, `release-please.yml`, and `nightly.yml`. Top-level is now `contents: read` everywhere, so any future job added to these workflows starts from least privilege.
- **Vulnerabilities** (7 → 10): added `osv-scanner.toml` ignoring three findings that `govulncheck` confirms are unreachable from this codebase:
  - `GO-2026-4883` / `GO-2026-4887` — Moby/Docker AuthZ plugin issues, reached only via `testcontainers-go`. Upstream fix only exists on `github.com/moby/moby/v2` v2.0.0-beta.8+, not the `github.com/docker/docker` path our dep graph uses.
  - `GHSA-pxg6-pf52-xh8x` — `cookie` <0.7.0 via `@sveltejs/kit` server runtime. This project ships SvelteKit as a statically built SPA embedded in the Go binary; the server runtime never executes.

Each `osv-scanner.toml` entry documents why the finding is unreachable and what would trigger re-evaluation.

## Expected Scorecard delta

5.7/10 → roughly 7.5/10 (exact score depends on how the composite is weighted).

Remaining lower-scoring checks are deliberate trade-offs:

- `Code-Review`, `Branch-Protection` — solo-maintainer flow
- `Contributors`, `CII-Best-Practices`, `Signed-Releases` — real work, not a quick win
- `Pinned-Dependencies` (8/10) — two nits left: `docker://semgrep/semgrep:latest` in ci.yml, `go install oapi-codegen@latest` in ci.yml, and unpinned Dockerfile base images. Worth a separate PR if we're willing to add a Docker ecosystem to Dependabot.

## Test plan

- [ ] CI passes on PR (including the repaired `pr-title` job)
- [ ] After merge, next Scorecard run shows `Dangerous-Workflow` = 10, `Token-Permissions` = 10, `Vulnerabilities` = 10
- [ ] Nightly and release workflows run successfully on their next triggers (permissions push-down didn't break anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
