### PR TITLE
Pin Docker base images, oapi-codegen, and semgrep by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,18 @@ updates:
     labels:
       - "dependencies"
       - "frontend"
+
+  # Docker base images in Dockerfile (SHA-pinned; Dependabot keeps digests fresh)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
         run: go mod download
 
       - name: Install oapi-codegen
-        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+        # Pin to the version declared in go.mod to satisfy Scorecard's
+        # Pinned-Dependencies check and keep generator output reproducible.
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
 
       - name: Verify Go generated code
         run: |
@@ -315,7 +317,7 @@ jobs:
       # Semgrep: Rule-based static analysis
       - name: Semgrep scan
         if: success() || failure()
-        uses: docker://semgrep/semgrep:latest
+        uses: docker://semgrep/semgrep:latest@sha256:d7d67e1e0c0ed26278ab35f0be082f0afdfd7a880f4927aee86f8127fdbce617
         with:
           args: semgrep scan --config p/security-audit --config p/secrets --config p/golang --config p/typescript --sarif --output semgrep.sarif .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: Frontend
-FROM node:22-alpine AS frontend-builder
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS frontend-builder
 
 WORKDIR /app/web
 COPY web/package*.json ./
@@ -9,7 +9,7 @@ COPY web/ ./
 RUN npm run build
 
 # Build stage: Backend
-FROM golang:1.26.2-alpine AS backend-builder
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS backend-builder
 
 # Install build dependencies for CGO (required for SQLite)
 RUN apk add --no-cache gcc musl-dev
@@ -36,7 +36,7 @@ ENV CGO_ENABLED=1
 RUN go build -o myfamily -ldflags="-s -w" ./cmd/myfamily
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ setup: deps ## Set up development environment
 	@echo "Installing development tools..."
 	go install github.com/vladopajic/go-test-coverage/v2@$(GO_TEST_COVERAGE_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
 	ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
 	ln -sf ../../scripts/pre-push .git/hooks/pre-push
 	@echo ""


### PR DESCRIPTION
## Summary

Stacked on top of #427. Addresses the remaining `Pinned-Dependencies` findings from Scorecard (8/10 → expected 10/10):

- **Dockerfile base images** pinned by digest. Scorecard's finding for `alpine:3.19` gave us the exact SHA it wanted; I fetched the other two from Docker Hub's manifest API.
  - `node:22-alpine` → `@sha256:8ea2348b…a7683f`
  - `golang:1.26.2-alpine` → `@sha256:f8533084…3a21b1`
  - `alpine:3.19` → `@sha256:6baf4358…11ca1`
- **`docker://semgrep/semgrep:latest`** in `ci.yml` pinned by digest.
- **`oapi-codegen@latest`** in both `ci.yml` and the `make setup` target pinned to `@v2.6.0` (matches `go.mod`), so CI's generator matches what the codebase was last regenerated against.
- **Dependabot Docker ecosystem** added at repo root so the Dockerfile digest pins get refreshed weekly instead of silently rotting. Without this, pinning digests is a downgrade — we lose automatic base-image security patches. With it, Dependabot proposes SHA bumps as they land.

## Why this ordering

The semgrep pin keeps the `:latest` tag as a human hint alongside the SHA, since Dependabot's `github-actions` ecosystem doesn't update `uses: docker://…` inline image references. We'd need a manual refresh occasionally. Acceptable trade-off given semgrep's rules auto-update at runtime regardless of image age.

## Expected Scorecard delta

`Pinned-Dependencies` 8/10 → 10/10. Combined with #427, overall score should land around **8.0/10**.

## Test plan

- [ ] CI passes (Dockerfile builds under new SHAs; oapi-codegen @v2.6.0 produces matching generated code; semgrep still runs)
- [ ] After both PRs merge, Scorecard run shows 0 Pinned-Dependencies warnings
- [ ] First Dependabot Docker PR arrives on next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)
