### PR TITLE
Supply-chain defense tier 1: cooldown, harden-runner, ignore-scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -23,6 +27,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -38,6 +46,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -53,6 +65,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -11,6 +11,11 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Rebase open PRs
         uses: peter-evans/rebase@e4945786f7ca41fe6e101cead4395f5489593943 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Check PR title is not conventional commit format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -61,6 +66,11 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
@@ -178,6 +188,11 @@ jobs:
         working-directory: web
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
@@ -188,7 +203,11 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        # Block transitive postinstall/preinstall scripts (supply-chain mitigation).
+        # `npm run prepare` runs the project's own prepare (svelte-kit sync).
+        run: |
+          npm ci --ignore-scripts
+          npm run prepare
 
       - name: Verify TypeScript generated types
         run: |
@@ -213,6 +232,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency Review
@@ -228,6 +252,11 @@ jobs:
       security-events: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for gitleaks
@@ -254,7 +283,7 @@ jobs:
           echo "placeholder" > internal/web/dist/.gitkeep
 
       - name: Install frontend dependencies
-        run: cd web && npm ci
+        run: cd web && npm ci --ignore-scripts && npm run prepare
 
       # Supply chain: Go dependency vulnerabilities
       - name: Go vulnerability check
@@ -334,6 +363,11 @@ jobs:
     needs: [backend, frontend, security]
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
@@ -352,7 +386,8 @@ jobs:
       - name: Build frontend
         run: |
           cd web
-          npm ci
+          npm ci --ignore-scripts
+          npm run prepare
           npm run build
 
       - name: Build binary with embedded frontend
@@ -372,6 +407,11 @@ jobs:
     needs: [backend, frontend]
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build Docker image
@@ -411,6 +451,11 @@ jobs:
     needs: [backend, frontend, security, integration, docker-smoke-test, dependency-review]
     if: always()
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Check all jobs passed
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,11 @@ jobs:
         language: [go, javascript-typescript]
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -52,7 +57,7 @@ jobs:
 
       - name: Install frontend dependencies
         if: matrix.language == 'javascript-typescript'
-        run: cd web && npm ci
+        run: cd web && npm ci --ignore-scripts && npm run prepare
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,6 +13,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,11 @@ jobs:
             time: 2m
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -90,7 +95,7 @@ jobs:
         echo "placeholder" > internal/web/dist/.gitkeep
 
     - name: Install frontend dependencies
-      run: cd web && npm ci
+      run: cd web && npm ci --ignore-scripts && npm run prepare
 
     - name: Run govulncheck
       uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
@@ -148,6 +153,11 @@ jobs:
       contents: read
       issues: write
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,11 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
@@ -32,6 +37,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -53,7 +63,8 @@ jobs:
       - name: Build frontend
         run: |
           cd web
-          npm ci
+          npm ci --ignore-scripts
+          npm run prepare
           npm run build
 
       - name: Embed frontend in binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -38,7 +43,8 @@ jobs:
       - name: Build frontend
         run: |
           cd web
-          npm ci
+          npm ci --ignore-scripts
+          npm run prepare
           npm run build
 
       - name: Embed frontend in binary

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,11 @@ jobs:
       actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

Tier 1 supply-chain defenses in one PR — three independent changes layered together:

1. **Dependabot 5-day cooldown** across all four ecosystems (gomod, github-actions, npm, docker). Newly published versions must be public for 5 days before Dependabot opens a PR. Catches the majority of recent-era malicious publishes, which are typically detected and yanked within 24–72h.
2. **`step-security/harden-runner` in audit mode** on every job across every workflow (previously only on `nightly.yml`). Logs all runner egress; does not block anything yet. Defense against build-time exfiltration of `GITHUB_TOKEN` / npm auth tokens.
3. **`npm ci --ignore-scripts`** in CI, followed by explicit `npm run prepare` for our own `svelte-kit sync`. Blocks transitive postinstall scripts — the actual execution mechanism behind most recent npm supply-chain payloads.

Local dev flow unchanged (no `.npmrc` change), so `npm install` from `web/` still works as before for contributors.

## Follow-up

After ~1 week of audit-mode observation, flip `harden-runner` to `block` with an explicit `allowed-endpoints` list — tracked in #443.

## Test plan

- [ ] CI passes on this PR (covers `ci.yml` changes end-to-end)
- [ ] Verify StepSecurity insights appear on at least one job run in the Actions tab
- [ ] Confirm `svelte-kit sync` still produces `.svelte-kit/` output — `svelte-check` and `vite build` would fail in the frontend job otherwise
- [ ] Next Dependabot Monday run should open fewer PRs (only versions at least 5 days old)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security with runner hardening and egress auditing across all automated processes
  * Configured 5-day cooldown period for automated dependency updates
  * Optimized npm package script handling in build workflows for improved dependency isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->