### PR TITLE
Allow GPL-3.0 go-test-coverage action in dep-review config

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -13,3 +13,9 @@ allow-licenses:
   # Google patent license used by all golang.org/x packages (as compound expression)
   - LicenseRef-scancode-google-patent-license-golang
   - "BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang"
+
+# License-check exemptions for CI-only tooling. These run in the pipeline,
+# are never linked into the shipped binary, and so do not impose license
+# obligations on the project.
+allow-dependencies-licenses:
+  - 'pkg:githubactions/vladopajic/go-test-coverage'


### PR DESCRIPTION
## Summary

- Exempt `vladopajic/go-test-coverage` (GPL-3.0) from the dep-review license check via `allow-dependencies-licenses`.
- The action runs only in CI and never gets linked into the shipped binary, so GPL distribution/linking obligations do not apply to this project.
- Unblocks Dependabot PR #460 (and future bumps of this action).

## Rationale

Our `dependency-review-config.yml` uses an allow-list of permissive licenses tuned for runtime dependencies. The action doesn't distinguish "CI tool" from "runtime dep" — both surface in the same scan. Rather than broadening the global allow-list (which would also let GPL into `go.mod` / `package.json`), this change narrowly exempts the one CI-only action with a comment explaining the policy.

If future GPL CI tools are added, they can be appended to the same list.

## Test plan

- [ ] `dependency-review` check passes on this PR
- [ ] Once merged, rebase #460 and confirm its `dependency-review` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency review configuration to refine tooling dependency checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/my-family/pull/471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->