### PR TITLE
Show partner names on family list page

### DIFF
--- a/internal/api/family_handlers_test.go
+++ b/internal/api/family_handlers_test.go
@@ -130,11 +130,88 @@ func TestListFamilies(t *testing.T) {
 	}
 
 	var result map[string]interface{}
-	json.Unmarshal(rec.Body.Bytes(), &result)
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal list response: %v (body: %s)", err, rec.Body.String())
+	}
 
 	families := result["items"].([]interface{})
 	if len(families) != 1 {
-		t.Errorf("Expected 1 family, got %d", len(families))
+		t.Fatalf("Expected 1 family, got %d", len(families))
+	}
+
+	// Regression: list endpoint must populate partner1/partner2 so the
+	// frontend can render names without an extra round trip (issue #252).
+	// The read model stores the partner's full name as a single string and
+	// places it in given_name (see partnerSummary in server_strict.go); until
+	// that is split, asserting on the full string is the correct contract.
+	family := families[0].(map[string]interface{})
+	partner1, ok := family["partner1"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected partner1 object in list response, got %v", family["partner1"])
+	}
+	if got := partner1["given_name"]; got != "John Doe" {
+		t.Errorf("partner1.given_name: want %q, got %q", "John Doe", got)
+	}
+	partner2, ok := family["partner2"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected partner2 object in list response, got %v", family["partner2"])
+	}
+	if got := partner2["given_name"]; got != "Jane Smith" {
+		t.Errorf("partner2.given_name: want %q, got %q", "Jane Smith", got)
+	}
+}
+
+func TestListFamilies_SinglePartner(t *testing.T) {
+	server := setupFamilyTestServer(t)
+
+	// Models a family where only one partner is recorded. Using partner2_id
+	// (rather than partner1_id) exercises the asymmetric absence path: the
+	// list response must omit BOTH partner1 and partner1_id, while partner2
+	// and partner2_id must be present. This guards against partial-population
+	// inconsistencies where one field appears without the other.
+	person := createTestPerson(t, server, "Jane", "Doe")
+	body := map[string]interface{}{
+		"partner2_id": person["id"],
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/families", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Setup: create family failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/families", http.NoBody)
+	rec = httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal list response: %v (body: %s)", err, rec.Body.String())
+	}
+	families := result["items"].([]interface{})
+	if len(families) != 1 {
+		t.Fatalf("Expected 1 family, got %d", len(families))
+	}
+
+	family := families[0].(map[string]interface{})
+	if _, present := family["partner1"]; present {
+		t.Errorf("Expected partner1 to be omitted for single-partner family, got %v", family["partner1"])
+	}
+	if _, present := family["partner1_id"]; present {
+		t.Errorf("Expected partner1_id to be omitted alongside partner1, got %v", family["partner1_id"])
+	}
+	partner2, ok := family["partner2"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected partner2 object in list response, got %v", family["partner2"])
+	}
+	if got := partner2["given_name"]; got != "Jane Doe" {
+		t.Errorf("partner2.given_name: want %q, got %q", "Jane Doe", got)
 	}
 }
 

--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -2309,13 +2309,25 @@ type FamilyDetail struct {
 	MarriagePlaceLatitude *string `json:"marriage_place_latitude,omitempty"`
 
 	// MarriagePlaceLongitude Longitude in GEDCOM format (e.g., "W89.6501")
-	MarriagePlaceLongitude *string                       `json:"marriage_place_longitude,omitempty"`
-	Partner1               *PersonSummary                `json:"partner1,omitempty"`
-	Partner1Id             *openapi_types.UUID           `json:"partner1_id,omitempty"`
-	Partner2               *PersonSummary                `json:"partner2,omitempty"`
-	Partner2Id             *openapi_types.UUID           `json:"partner2_id,omitempty"`
-	RelationshipType       *FamilyDetailRelationshipType `json:"relationship_type,omitempty"`
-	Version                int64                         `json:"version"`
+	MarriagePlaceLongitude *string `json:"marriage_place_longitude,omitempty"`
+
+	// Partner1 Partner 1 summary. May be absent even when partner1_id is set
+	// if the partner's name has not been projected yet. The given_name
+	// field carries the partner's full display name until the read
+	// model is split into separate given/surname components; surname
+	// will be empty.
+	Partner1   *PersonSummary      `json:"partner1,omitempty"`
+	Partner1Id *openapi_types.UUID `json:"partner1_id,omitempty"`
+
+	// Partner2 Partner 2 summary. May be absent even when partner2_id is set
+	// if the partner's name has not been projected yet. The given_name
+	// field carries the partner's full display name until the read
+	// model is split into separate given/surname components; surname
+	// will be empty.
+	Partner2         *PersonSummary                `json:"partner2,omitempty"`
+	Partner2Id       *openapi_types.UUID           `json:"partner2_id,omitempty"`
+	RelationshipType *FamilyDetailRelationshipType `json:"relationship_type,omitempty"`
+	Version          int64                         `json:"version"`
 }
 
 // FamilyDetailRelationshipType defines model for FamilyDetail.RelationshipType.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3839,9 +3839,23 @@ components:
         - type: object
           properties:
             partner1:
-              $ref: '#/components/schemas/PersonSummary'
+              allOf:
+                - $ref: '#/components/schemas/PersonSummary'
+              description: |
+                Partner 1 summary. May be absent even when partner1_id is set
+                if the partner's name has not been projected yet. The given_name
+                field carries the partner's full display name until the read
+                model is split into separate given/surname components; surname
+                will be empty.
             partner2:
-              $ref: '#/components/schemas/PersonSummary'
+              allOf:
+                - $ref: '#/components/schemas/PersonSummary'
+              description: |
+                Partner 2 summary. May be absent even when partner2_id is set
+                if the partner's name has not been projected yet. The given_name
+                field carries the partner's full display name until the read
+                model is split into separate given/surname components; surname
+                will be empty.
             children:
               type: array
               items:

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -3535,6 +3535,21 @@ func convertQueryFamilyToGenerated(f query.Family) Family {
 	return resp
 }
 
+// partnerSummary builds a PersonSummary for a family partner from the
+// denormalized full name carried by the FamilyReadModel. The name is stored
+// as a single string (see internal/repository/projection.go:289 where it is
+// assigned from PersonReadModel.FullName), so Surname is left empty and the
+// full display name is placed in GivenName. Until the read model carries the
+// name parts separately, callers reading PersonSummary.Surname on a partner
+// will see an empty string. See issue #483.
+func partnerSummary(id uuid.UUID, fullName string) *PersonSummary {
+	return &PersonSummary{
+		Id:        id,
+		GivenName: fullName,
+		Surname:   "",
+	}
+}
+
 // convertQueryFamilyDetailToGenerated converts a query.FamilyDetail to the generated FamilyDetail type.
 func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 	resp := FamilyDetail{
@@ -3563,18 +3578,10 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 
 	// Add partner details if available
 	if fd.Partner1ID != nil && fd.Partner1Name != nil {
-		resp.Partner1 = &PersonSummary{
-			Id:        *fd.Partner1ID,
-			GivenName: *fd.Partner1Name,
-			Surname:   "",
-		}
+		resp.Partner1 = partnerSummary(*fd.Partner1ID, *fd.Partner1Name)
 	}
 	if fd.Partner2ID != nil && fd.Partner2Name != nil {
-		resp.Partner2 = &PersonSummary{
-			Id:        *fd.Partner2ID,
-			GivenName: *fd.Partner2Name,
-			Surname:   "",
-		}
+		resp.Partner2 = partnerSummary(*fd.Partner2ID, *fd.Partner2Name)
 	}
 
 	if len(fd.Children) > 0 {
@@ -3621,6 +3628,13 @@ func convertQueryFamilyToFamilyDetail(f query.Family) FamilyDetail {
 	}
 	if f.MarriagePlace != nil {
 		resp.MarriagePlace = f.MarriagePlace
+	}
+
+	if f.Partner1ID != nil && f.Partner1Name != nil {
+		resp.Partner1 = partnerSummary(*f.Partner1ID, *f.Partner1Name)
+	}
+	if f.Partner2ID != nil && f.Partner2Name != nil {
+		resp.Partner2 = partnerSummary(*f.Partner2ID, *f.Partner2Name)
 	}
 
 	return resp

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -2243,7 +2243,21 @@ export interface components {
             version: number;
         };
         FamilyDetail: components["schemas"]["Family"] & {
+            /**
+             * @description Partner 1 summary. May be absent even when partner1_id is set
+             *     if the partner's name has not been projected yet. The given_name
+             *     field carries the partner's full display name until the read
+             *     model is split into separate given/surname components; surname
+             *     will be empty.
+             */
             partner1?: components["schemas"]["PersonSummary"];
+            /**
+             * @description Partner 2 summary. May be absent even when partner2_id is set
+             *     if the partner's name has not been projected yet. The given_name
+             *     field carries the partner's full display name until the read
+             *     model is split into separate given/surname components; surname
+             *     will be empty.
+             */
             partner2?: components["schemas"]["PersonSummary"];
             children?: components["schemas"]["FamilyChild"][];
         };

--- a/web/src/lib/components/FamilyCard.svelte
+++ b/web/src/lib/components/FamilyCard.svelte
@@ -12,8 +12,8 @@
 
 	let { family, href, onclick }: Props = $props();
 
-	const partner1Name = family.partner1_name || 'Unknown';
-	const partner2Name = family.partner2_name || null;
+	const partner1Name = family.partner1?.given_name ?? 'Unknown';
+	const partner2Name = family.partner2?.given_name ?? null;
 	const marriageDate = family.marriage_date ? formatGenDate(family.marriage_date) : null;
 	const childCount = family.child_count ?? family.children?.length ?? 0;
 </script>

--- a/web/src/lib/components/FamilyCard.test.ts
+++ b/web/src/lib/components/FamilyCard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import FamilyCard from './FamilyCard.svelte';
+import type { FamilyDetail } from '$lib/api/client';
+
+describe('FamilyCard', () => {
+	it('renders both partner names from the nested partner objects', () => {
+		const family: FamilyDetail = {
+			id: 'fam-1',
+			version: 1,
+			partner1_id: 'p1',
+			partner2_id: 'p2',
+			partner1: { id: 'p1', given_name: 'John Smith', surname: '' },
+			partner2: { id: 'p2', given_name: 'Jane Smith', surname: '' }
+		};
+
+		render(FamilyCard, { props: { family } });
+
+		expect(screen.getByText('John Smith')).toBeTruthy();
+		expect(screen.getByText('Jane Smith')).toBeTruthy();
+	});
+
+	it('renders single partner without an ampersand when partner2 is missing', () => {
+		const family: FamilyDetail = {
+			id: 'fam-2',
+			version: 1,
+			partner1_id: 'p1',
+			partner1: { id: 'p1', given_name: 'Solo Parent', surname: '' }
+		};
+
+		render(FamilyCard, { props: { family } });
+
+		expect(screen.getByText('Solo Parent')).toBeTruthy();
+		expect(screen.queryByText('&')).toBeNull();
+	});
+
+	it('falls back to "Unknown" when partner1 is missing', () => {
+		const family: FamilyDetail = {
+			id: 'fam-3',
+			version: 1
+		};
+
+		render(FamilyCard, { props: { family } });
+
+		expect(screen.getByText('Unknown')).toBeTruthy();
+	});
+
+	it('renders an empty name verbatim rather than falling back to "Unknown"', () => {
+		// ?? (nullish coalescing) only triggers on null/undefined, not on "".
+		// A partner with a deliberately-empty name should render blank, not be
+		// mislabeled "Unknown" — which would imply the partner record is absent.
+		const family: FamilyDetail = {
+			id: 'fam-4',
+			version: 1,
+			partner1_id: 'p1',
+			partner1: { id: 'p1', given_name: '', surname: '' }
+		};
+
+		render(FamilyCard, { props: { family } });
+
+		expect(screen.queryByText('Unknown')).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- Family list page (`/families`) now displays partner names instead of "Unknown"
- Root cause was a missing converter populating Partner1/Partner2 + a frontend reading nonexistent `partner1_name`/`partner2_name` top-level fields
- Adds panel-review follow-ups: helper to dedupe the workaround, stronger tests, OpenAPI doc on the partial-population contract, `??` over `||` for empty-name handling

## Changes

**Backend** (`internal/api/server_strict.go`)
- New `partnerSummary(id, fullName)` helper documenting that the read model carries a denormalized full name and Surname will be empty until #483 lands
- `convertQueryFamilyToFamilyDetail` (used by list endpoint) now populates Partner1/Partner2
- `convertQueryFamilyDetailToGenerated` refactored to use the same helper

**API spec** (`internal/api/openapi.yaml`)
- Descriptions on `FamilyDetail.partner1`/`partner2` document the partial-population rule and the empty-surname workaround
- Regenerated `internal/api/generated.go` and `web/src/lib/api/types.generated.ts`

**Frontend** (`web/src/lib/components/FamilyCard.svelte`)
- Reads `family.partner1?.given_name` (nested PersonSummary per schema) instead of `family.partner1_name` (never existed on FamilyDetail)
- Uses `??` instead of `||` so an empty-string name renders blank rather than as "Unknown"

**Tests**
- `TestListFamilies` asserts exact name values + checks `json.Unmarshal` errors
- New `TestListFamilies_SinglePartner` verifies asymmetric absence (both `partner1` and `partner1_id` omitted)
- New `FamilyCard.test.ts` with 4 cases (both partners, single partner, missing partner1 fallback, empty-name edge case)

## Follow-up

#483 tracks the underlying read-model split that would let `PersonSummary.surname` carry real data. The current workaround is documented in the helper comment and OpenAPI descriptions.

## Test plan

- [x] `make test` — 229 frontend tests + all Go tests pass
- [x] `make check-coverage` — 85% per-package + 75% total satisfied (76.2% total)
- [x] `make lint` — 0 issues
- [x] Backend test asserts list response includes populated partner names
- [x] Backend test asserts single-partner family omits both `partner1` and `partner1_id`
- [x] Frontend test asserts FamilyCard renders names from nested partner objects
- [x] Frontend test asserts empty-string name renders blank, not "Unknown"
- [ ] Manual browser check of `/families` once merged to dev environment

Closes #252

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
