### PR TITLE
Split partner and child names in family read model

### DIFF
--- a/internal/api/family_handlers_test.go
+++ b/internal/api/family_handlers_test.go
@@ -141,23 +141,28 @@ func TestListFamilies(t *testing.T) {
 
 	// Regression: list endpoint must populate partner1/partner2 so the
 	// frontend can render names without an extra round trip (issue #252).
-	// The read model stores the partner's full name as a single string and
-	// places it in given_name (see partnerSummary in server_strict.go); until
-	// that is split, asserting on the full string is the correct contract.
+	// Partner summaries must carry split given_name/surname per the
+	// PersonSummary contract (issue #483).
 	family := families[0].(map[string]interface{})
 	partner1, ok := family["partner1"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected partner1 object in list response, got %v", family["partner1"])
 	}
-	if got := partner1["given_name"]; got != "John Doe" {
-		t.Errorf("partner1.given_name: want %q, got %q", "John Doe", got)
+	if got := partner1["given_name"]; got != "John" {
+		t.Errorf("partner1.given_name: want %q, got %q", "John", got)
+	}
+	if got := partner1["surname"]; got != "Doe" {
+		t.Errorf("partner1.surname: want %q, got %q", "Doe", got)
 	}
 	partner2, ok := family["partner2"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected partner2 object in list response, got %v", family["partner2"])
 	}
-	if got := partner2["given_name"]; got != "Jane Smith" {
-		t.Errorf("partner2.given_name: want %q, got %q", "Jane Smith", got)
+	if got := partner2["given_name"]; got != "Jane" {
+		t.Errorf("partner2.given_name: want %q, got %q", "Jane", got)
+	}
+	if got := partner2["surname"]; got != "Smith" {
+		t.Errorf("partner2.surname: want %q, got %q", "Smith", got)
 	}
 }
 
@@ -210,8 +215,11 @@ func TestListFamilies_SinglePartner(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected partner2 object in list response, got %v", family["partner2"])
 	}
-	if got := partner2["given_name"]; got != "Jane Doe" {
-		t.Errorf("partner2.given_name: want %q, got %q", "Jane Doe", got)
+	if got := partner2["given_name"]; got != "Jane" {
+		t.Errorf("partner2.given_name: want %q, got %q", "Jane", got)
+	}
+	if got := partner2["surname"]; got != "Doe" {
+		t.Errorf("partner2.surname: want %q, got %q", "Doe", got)
 	}
 }
 
@@ -252,6 +260,75 @@ func TestGetFamily(t *testing.T) {
 
 	if result["marriage_place"] != "Chicago, IL" {
 		t.Errorf("Expected marriage_place 'Chicago, IL', got %v", result["marriage_place"])
+	}
+}
+
+func TestGetFamily_ChildrenHaveSplitNames(t *testing.T) {
+	server := setupFamilyTestServer(t)
+
+	// Parents + child with distinct given/surname values to verify the split.
+	parent1 := createTestPerson(t, server, "John", "Doe")
+	parent2 := createTestPerson(t, server, "Jane", "Smith")
+	child := createTestPerson(t, server, "Alice", "Doe")
+
+	familyBody := map[string]interface{}{
+		"partner1_id":       parent1["id"],
+		"partner2_id":       parent2["id"],
+		"relationship_type": "marriage",
+	}
+	jsonBody, _ := json.Marshal(familyBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/families", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Setup: create family failed: %d %s", rec.Code, rec.Body.String())
+	}
+	var family map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &family); err != nil {
+		t.Fatalf("unmarshal family: %v", err)
+	}
+	familyID := family["id"].(string)
+
+	// Add the child.
+	childBody := map[string]interface{}{
+		"person_id":         child["id"],
+		"relationship_type": "biological",
+	}
+	jsonBody, _ = json.Marshal(childBody)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/families/"+familyID+"/children", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Setup: add child failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Fetch family detail and assert the child's person summary has split names.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/families/"+familyID, http.NoBody)
+	rec = httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET family: %d %s", rec.Code, rec.Body.String())
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	children, ok := result["children"].([]interface{})
+	if !ok || len(children) != 1 {
+		t.Fatalf("expected 1 child in response, got %v", result["children"])
+	}
+	childEntry := children[0].(map[string]interface{})
+	person, ok := childEntry["person"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected child.person object, got %v", childEntry["person"])
+	}
+	if got := person["given_name"]; got != "Alice" {
+		t.Errorf("child.person.given_name: want %q, got %q", "Alice", got)
+	}
+	if got := person["surname"]; got != "Doe" {
+		t.Errorf("child.person.surname: want %q, got %q", "Doe", got)
 	}
 }
 

--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -2311,19 +2311,11 @@ type FamilyDetail struct {
 	// MarriagePlaceLongitude Longitude in GEDCOM format (e.g., "W89.6501")
 	MarriagePlaceLongitude *string `json:"marriage_place_longitude,omitempty"`
 
-	// Partner1 Partner 1 summary. May be absent even when partner1_id is set
-	// if the partner's name has not been projected yet. The given_name
-	// field carries the partner's full display name until the read
-	// model is split into separate given/surname components; surname
-	// will be empty.
+	// Partner1 Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet.
 	Partner1   *PersonSummary      `json:"partner1,omitempty"`
 	Partner1Id *openapi_types.UUID `json:"partner1_id,omitempty"`
 
-	// Partner2 Partner 2 summary. May be absent even when partner2_id is set
-	// if the partner's name has not been projected yet. The given_name
-	// field carries the partner's full display name until the read
-	// model is split into separate given/surname components; surname
-	// will be empty.
+	// Partner2 Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet.
 	Partner2         *PersonSummary                `json:"partner2,omitempty"`
 	Partner2Id       *openapi_types.UUID           `json:"partner2_id,omitempty"`
 	RelationshipType *FamilyDetailRelationshipType `json:"relationship_type,omitempty"`

--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -2311,11 +2311,11 @@ type FamilyDetail struct {
 	// MarriagePlaceLongitude Longitude in GEDCOM format (e.g., "W89.6501")
 	MarriagePlaceLongitude *string `json:"marriage_place_longitude,omitempty"`
 
-	// Partner1 Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet.
+	// Partner1 Partner 1 summary. Present whenever partner1_id is set; given_name and surname may be empty strings if the partner has no recorded name.
 	Partner1   *PersonSummary      `json:"partner1,omitempty"`
 	Partner1Id *openapi_types.UUID `json:"partner1_id,omitempty"`
 
-	// Partner2 Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet.
+	// Partner2 Partner 2 summary. Present whenever partner2_id is set; given_name and surname may be empty strings if the partner has no recorded name.
 	Partner2         *PersonSummary                `json:"partner2,omitempty"`
 	Partner2Id       *openapi_types.UUID           `json:"partner2_id,omitempty"`
 	RelationshipType *FamilyDetailRelationshipType `json:"relationship_type,omitempty"`

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3841,21 +3841,11 @@ components:
             partner1:
               allOf:
                 - $ref: '#/components/schemas/PersonSummary'
-              description: |
-                Partner 1 summary. May be absent even when partner1_id is set
-                if the partner's name has not been projected yet. The given_name
-                field carries the partner's full display name until the read
-                model is split into separate given/surname components; surname
-                will be empty.
+              description: Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet.
             partner2:
               allOf:
                 - $ref: '#/components/schemas/PersonSummary'
-              description: |
-                Partner 2 summary. May be absent even when partner2_id is set
-                if the partner's name has not been projected yet. The given_name
-                field carries the partner's full display name until the read
-                model is split into separate given/surname components; surname
-                will be empty.
+              description: Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet.
             children:
               type: array
               items:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3841,11 +3841,11 @@ components:
             partner1:
               allOf:
                 - $ref: '#/components/schemas/PersonSummary'
-              description: Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet.
+              description: Partner 1 summary. Present whenever partner1_id is set; given_name and surname may be empty strings if the partner has no recorded name.
             partner2:
               allOf:
                 - $ref: '#/components/schemas/PersonSummary'
-              description: Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet.
+              description: Partner 2 summary. Present whenever partner2_id is set; given_name and surname may be empty strings if the partner has no recorded name.
             children:
               type: array
               items:

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -3535,18 +3535,12 @@ func convertQueryFamilyToGenerated(f query.Family) Family {
 	return resp
 }
 
-// partnerSummary builds a PersonSummary for a family partner from the
-// denormalized full name carried by the FamilyReadModel. The name is stored
-// as a single string (see internal/repository/projection.go:289 where it is
-// assigned from PersonReadModel.FullName), so Surname is left empty and the
-// full display name is placed in GivenName. Until the read model carries the
-// name parts separately, callers reading PersonSummary.Surname on a partner
-// will see an empty string. See issue #483.
-func partnerSummary(id uuid.UUID, fullName string) *PersonSummary {
+// partnerSummary builds a PersonSummary for a family partner.
+func partnerSummary(id uuid.UUID, given, surname string) *PersonSummary {
 	return &PersonSummary{
 		Id:        id,
-		GivenName: fullName,
-		Surname:   "",
+		GivenName: given,
+		Surname:   surname,
 	}
 }
 
@@ -3576,12 +3570,13 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 		resp.MarriagePlace = fd.MarriagePlace
 	}
 
-	// Add partner details if available
-	if fd.Partner1ID != nil && fd.Partner1Name != nil {
-		resp.Partner1 = partnerSummary(*fd.Partner1ID, *fd.Partner1Name)
+	// Add partner details if available. Either part may be missing on legacy data;
+	// fall back to empty string so we still render whatever we have.
+	if fd.Partner1ID != nil && (fd.Partner1GivenName != nil || fd.Partner1Surname != nil) {
+		resp.Partner1 = partnerSummary(*fd.Partner1ID, derefString(fd.Partner1GivenName), derefString(fd.Partner1Surname))
 	}
-	if fd.Partner2ID != nil && fd.Partner2Name != nil {
-		resp.Partner2 = partnerSummary(*fd.Partner2ID, *fd.Partner2Name)
+	if fd.Partner2ID != nil && (fd.Partner2GivenName != nil || fd.Partner2Surname != nil) {
+		resp.Partner2 = partnerSummary(*fd.Partner2ID, derefString(fd.Partner2GivenName), derefString(fd.Partner2Surname))
 	}
 
 	if len(fd.Children) > 0 {
@@ -3592,8 +3587,8 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 				RelationshipType: FamilyChildRelationshipType(c.RelationshipType),
 				Person: &PersonSummary{
 					Id:        c.ID,
-					GivenName: c.Name,
-					Surname:   "",
+					GivenName: c.GivenName,
+					Surname:   c.Surname,
 				},
 			}
 		}
@@ -3630,14 +3625,22 @@ func convertQueryFamilyToFamilyDetail(f query.Family) FamilyDetail {
 		resp.MarriagePlace = f.MarriagePlace
 	}
 
-	if f.Partner1ID != nil && f.Partner1Name != nil {
-		resp.Partner1 = partnerSummary(*f.Partner1ID, *f.Partner1Name)
+	if f.Partner1ID != nil && (f.Partner1GivenName != nil || f.Partner1Surname != nil) {
+		resp.Partner1 = partnerSummary(*f.Partner1ID, derefString(f.Partner1GivenName), derefString(f.Partner1Surname))
 	}
-	if f.Partner2ID != nil && f.Partner2Name != nil {
-		resp.Partner2 = partnerSummary(*f.Partner2ID, *f.Partner2Name)
+	if f.Partner2ID != nil && (f.Partner2GivenName != nil || f.Partner2Surname != nil) {
+		resp.Partner2 = partnerSummary(*f.Partner2ID, derefString(f.Partner2GivenName), derefString(f.Partner2Surname))
 	}
 
 	return resp
+}
+
+// derefString returns *s, or "" if s is nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // convertQueryGroupSheetToGenerated converts a query.GroupSheet to the generated FamilyGroupSheet type.

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -3570,13 +3570,15 @@ func convertQueryFamilyDetailToGenerated(fd query.FamilyDetail) FamilyDetail {
 		resp.MarriagePlace = fd.MarriagePlace
 	}
 
-	// Add partner details if available. Either part may be missing on legacy data;
-	// fall back to empty string so we still render whatever we have.
-	if fd.Partner1ID != nil && (fd.Partner1GivenName != nil || fd.Partner1Surname != nil) {
-		resp.Partner1 = partnerSummary(*fd.Partner1ID, derefString(fd.Partner1GivenName), derefString(fd.Partner1Surname))
+	// Emit the partner summary whenever the partner ID is set so callers can
+	// always pair partner1_id with a partner1 object. Either name part may be
+	// nil for legacy or unprojected data; missing parts render as empty
+	// strings rather than dropping the whole summary.
+	if fd.Partner1ID != nil {
+		resp.Partner1 = partnerSummary(*fd.Partner1ID, stringValue(fd.Partner1GivenName), stringValue(fd.Partner1Surname))
 	}
-	if fd.Partner2ID != nil && (fd.Partner2GivenName != nil || fd.Partner2Surname != nil) {
-		resp.Partner2 = partnerSummary(*fd.Partner2ID, derefString(fd.Partner2GivenName), derefString(fd.Partner2Surname))
+	if fd.Partner2ID != nil {
+		resp.Partner2 = partnerSummary(*fd.Partner2ID, stringValue(fd.Partner2GivenName), stringValue(fd.Partner2Surname))
 	}
 
 	if len(fd.Children) > 0 {
@@ -3625,18 +3627,20 @@ func convertQueryFamilyToFamilyDetail(f query.Family) FamilyDetail {
 		resp.MarriagePlace = f.MarriagePlace
 	}
 
-	if f.Partner1ID != nil && (f.Partner1GivenName != nil || f.Partner1Surname != nil) {
-		resp.Partner1 = partnerSummary(*f.Partner1ID, derefString(f.Partner1GivenName), derefString(f.Partner1Surname))
+	if f.Partner1ID != nil {
+		resp.Partner1 = partnerSummary(*f.Partner1ID, stringValue(f.Partner1GivenName), stringValue(f.Partner1Surname))
 	}
-	if f.Partner2ID != nil && (f.Partner2GivenName != nil || f.Partner2Surname != nil) {
-		resp.Partner2 = partnerSummary(*f.Partner2ID, derefString(f.Partner2GivenName), derefString(f.Partner2Surname))
+	if f.Partner2ID != nil {
+		resp.Partner2 = partnerSummary(*f.Partner2ID, stringValue(f.Partner2GivenName), stringValue(f.Partner2Surname))
 	}
 
 	return resp
 }
 
-// derefString returns *s, or "" if s is nil.
-func derefString(s *string) string {
+// stringValue dereferences a string pointer, treating nil as the empty string.
+// Used when converting query-layer `*string` fields into the API's required
+// string fields, where a nil pointer represents "absent in the read model".
+func stringValue(s *string) string {
 	if s == nil {
 		return ""
 	}

--- a/internal/exporter/csv.go
+++ b/internal/exporter/csv.go
@@ -26,8 +26,10 @@ var DefaultPersonFields = []string{
 // DefaultFamilyFields are the default fields exported for families.
 var DefaultFamilyFields = []string{
 	"id",
-	"partner1_name",
-	"partner2_name",
+	"partner1_given_name",
+	"partner1_surname",
+	"partner2_given_name",
+	"partner2_surname",
 	"relationship_type",
 	"marriage_date",
 	"marriage_place",
@@ -96,17 +98,19 @@ var AvailablePersonFields = map[string]bool{
 
 // AvailableFamilyFields lists all fields that can be exported for families.
 var AvailableFamilyFields = map[string]bool{
-	"id":                true,
-	"partner1_id":       true,
-	"partner1_name":     true,
-	"partner2_id":       true,
-	"partner2_name":     true,
-	"relationship_type": true,
-	"marriage_date":     true,
-	"marriage_place":    true,
-	"child_count":       true,
-	"version":           true,
-	"updated_at":        true,
+	"id":                  true,
+	"partner1_id":         true,
+	"partner1_given_name": true,
+	"partner1_surname":    true,
+	"partner2_id":         true,
+	"partner2_given_name": true,
+	"partner2_surname":    true,
+	"relationship_type":   true,
+	"marriage_date":       true,
+	"marriage_place":      true,
+	"child_count":         true,
+	"version":             true,
+	"updated_at":          true,
 }
 
 // AvailableSourceFields lists all fields that can be exported for sources.
@@ -372,15 +376,19 @@ func getFamilyFieldValue(f repository.FamilyReadModel, field string) string {
 			return f.Partner1ID.String()
 		}
 		return ""
-	case "partner1_name":
-		return f.Partner1Name
+	case "partner1_given_name":
+		return f.Partner1GivenName
+	case "partner1_surname":
+		return f.Partner1Surname
 	case "partner2_id":
 		if f.Partner2ID != nil {
 			return f.Partner2ID.String()
 		}
 		return ""
-	case "partner2_name":
-		return f.Partner2Name
+	case "partner2_given_name":
+		return f.Partner2GivenName
+	case "partner2_surname":
+		return f.Partner2Surname
 	case "relationship_type":
 		return string(f.RelationshipType)
 	case "marriage_date":

--- a/internal/exporter/csv.go
+++ b/internal/exporter/csv.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/cacack/my-family/internal/repository"
 )
@@ -97,14 +98,19 @@ var AvailablePersonFields = map[string]bool{
 }
 
 // AvailableFamilyFields lists all fields that can be exported for families.
+// The deprecated keys "partner1_name" and "partner2_name" remain valid for
+// backward compatibility with saved export configurations from before #483;
+// they render the trimmed "given surname" concatenation.
 var AvailableFamilyFields = map[string]bool{
 	"id":                  true,
 	"partner1_id":         true,
 	"partner1_given_name": true,
 	"partner1_surname":    true,
+	"partner1_name":       true, // deprecated alias, kept for backcompat
 	"partner2_id":         true,
 	"partner2_given_name": true,
 	"partner2_surname":    true,
+	"partner2_name":       true, // deprecated alias, kept for backcompat
 	"relationship_type":   true,
 	"marriage_date":       true,
 	"marriage_place":      true,
@@ -380,6 +386,8 @@ func getFamilyFieldValue(f repository.FamilyReadModel, field string) string {
 		return f.Partner1GivenName
 	case "partner1_surname":
 		return f.Partner1Surname
+	case "partner1_name": // deprecated; concatenated for callers using the pre-#483 field
+		return strings.TrimSpace(f.Partner1GivenName + " " + f.Partner1Surname)
 	case "partner2_id":
 		if f.Partner2ID != nil {
 			return f.Partner2ID.String()
@@ -389,6 +397,8 @@ func getFamilyFieldValue(f repository.FamilyReadModel, field string) string {
 		return f.Partner2GivenName
 	case "partner2_surname":
 		return f.Partner2Surname
+	case "partner2_name": // deprecated; concatenated for callers using the pre-#483 field
+		return strings.TrimSpace(f.Partner2GivenName + " " + f.Partner2Surname)
 	case "relationship_type":
 		return string(f.RelationshipType)
 	case "marriage_date":

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -417,13 +417,54 @@ func TestCSVExporter_ExportFamilies_WithData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, records, 2) // Header + 1 data row
 
-	// Check data contains expected values (split per issue #483)
-	allData := buf.String()
-	assert.Contains(t, allData, "John")
-	assert.Contains(t, allData, "Doe")
-	assert.Contains(t, allData, "Jane")
-	assert.Contains(t, allData, "Smith")
-	assert.Contains(t, allData, "marriage")
+	// Bind given name to surname per partner so a regression that swapped
+	// surnames between partners (e.g., "John Smith" / "Jane Doe") would fail
+	// here. Look up each name column by header index and assert the matching
+	// values land together.
+	headers := records[0]
+	row := records[1]
+	idx := func(col string) int {
+		for i, h := range headers {
+			if h == col {
+				return i
+			}
+		}
+		t.Fatalf("missing column %q in CSV header %v", col, headers)
+		return -1
+	}
+	assert.Equal(t, "John", row[idx("partner1_given_name")])
+	assert.Equal(t, "Doe", row[idx("partner1_surname")])
+	assert.Equal(t, "Jane", row[idx("partner2_given_name")])
+	assert.Equal(t, "Smith", row[idx("partner2_surname")])
+	assert.Contains(t, buf.String(), "marriage")
+}
+
+// TestCSVExporter_DeprecatedFamilyNameFields covers backward compatibility for
+// callers (saved export configs, scripts) that still pass the pre-#483 field
+// keys "partner1_name" / "partner2_name". They must validate and render the
+// trimmed "given surname" concatenation.
+func TestCSVExporter_DeprecatedFamilyNameFields(t *testing.T) {
+	store := setupTestStore(t)
+	person1 := createTestPerson(t, store, "John", "Doe", domain.GenderMale)
+	person2 := createTestPerson(t, store, "Jane", "Smith", domain.GenderFemale)
+	_ = createTestFamily(t, store, &person1, &person2)
+
+	exp := exporter.NewDataExporter(store)
+	var buf bytes.Buffer
+	_, err := exp.Export(context.Background(), &buf, exporter.ExportOptions{
+		Format:     exporter.FormatCSV,
+		EntityType: exporter.EntityTypeFamilies,
+		Fields:     []string{"id", "partner1_name", "partner2_name"},
+	})
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{"id", "partner1_name", "partner2_name"}, records[0])
+	assert.Equal(t, "John Doe", records[1][1])
+	assert.Equal(t, "Jane Smith", records[1][2])
 }
 
 func TestCSVExporter_ExportFamilies_CustomFields(t *testing.T) {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -62,11 +62,13 @@ func createTestFamily(t *testing.T, store *memory.ReadModelStore, partner1, part
 	}
 	if partner1 != nil {
 		family.Partner1ID = &partner1.ID
-		family.Partner1Name = partner1.FullName
+		family.Partner1GivenName = partner1.GivenName
+		family.Partner1Surname = partner1.Surname
 	}
 	if partner2 != nil {
 		family.Partner2ID = &partner2.ID
-		family.Partner2Name = partner2.FullName
+		family.Partner2GivenName = partner2.GivenName
+		family.Partner2Surname = partner2.Surname
 	}
 	err := store.SaveFamily(context.Background(), &family)
 	require.NoError(t, err)
@@ -415,10 +417,12 @@ func TestCSVExporter_ExportFamilies_WithData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, records, 2) // Header + 1 data row
 
-	// Check data contains expected values
+	// Check data contains expected values (split per issue #483)
 	allData := buf.String()
-	assert.Contains(t, allData, "John Doe")
-	assert.Contains(t, allData, "Jane Smith")
+	assert.Contains(t, allData, "John")
+	assert.Contains(t, allData, "Doe")
+	assert.Contains(t, allData, "Jane")
+	assert.Contains(t, allData, "Smith")
 	assert.Contains(t, allData, "marriage")
 }
 
@@ -433,7 +437,7 @@ func TestCSVExporter_ExportFamilies_CustomFields(t *testing.T) {
 	exp := exporter.NewDataExporter(store)
 
 	var buf bytes.Buffer
-	customFields := []string{"id", "partner1_name", "partner2_name"}
+	customFields := []string{"id", "partner1_given_name", "partner1_surname", "partner2_given_name", "partner2_surname"}
 	result, err := exp.Export(context.Background(), &buf, exporter.ExportOptions{
 		Format:     exporter.FormatCSV,
 		EntityType: exporter.EntityTypeFamilies,
@@ -452,8 +456,8 @@ func TestCSVExporter_ExportFamilies_CustomFields(t *testing.T) {
 	// Check headers match custom fields
 	assert.Equal(t, customFields, records[0])
 
-	// Check row has only 3 columns
-	assert.Len(t, records[1], 3)
+	// Check row has only 5 columns
+	assert.Len(t, records[1], 5)
 }
 
 func TestCSVExporter_ExportFamilies_InvalidField(t *testing.T) {
@@ -595,17 +599,19 @@ func TestCSVExporter_AllFamilyFieldValues(t *testing.T) {
 
 	// Create family with all fields populated
 	family := repository.FamilyReadModel{
-		ID:               uuid.New(),
-		Partner1ID:       &person1.ID,
-		Partner1Name:     person1.FullName,
-		Partner2ID:       &person2.ID,
-		Partner2Name:     person2.FullName,
-		RelationshipType: domain.RelationMarriage,
-		MarriageDateRaw:  "10 JUN 1875",
-		MarriagePlace:    "Springfield, IL",
-		ChildCount:       3,
-		Version:          2,
-		UpdatedAt:        now,
+		ID:                uuid.New(),
+		Partner1ID:        &person1.ID,
+		Partner1GivenName: person1.GivenName,
+		Partner1Surname:   person1.Surname,
+		Partner2ID:        &person2.ID,
+		Partner2GivenName: person2.GivenName,
+		Partner2Surname:   person2.Surname,
+		RelationshipType:  domain.RelationMarriage,
+		MarriageDateRaw:   "10 JUN 1875",
+		MarriagePlace:     "Springfield, IL",
+		ChildCount:        3,
+		Version:           2,
+		UpdatedAt:         now,
 	}
 	err = store.SaveFamily(context.Background(), &family)
 	require.NoError(t, err)
@@ -614,7 +620,8 @@ func TestCSVExporter_AllFamilyFieldValues(t *testing.T) {
 
 	// Test all available family fields
 	allFields := []string{
-		"id", "partner1_id", "partner1_name", "partner2_id", "partner2_name",
+		"id", "partner1_id", "partner1_given_name", "partner1_surname",
+		"partner2_id", "partner2_given_name", "partner2_surname",
 		"relationship_type", "marriage_date", "marriage_place", "child_count",
 		"version", "updated_at",
 	}
@@ -639,15 +646,17 @@ func TestCSVExporter_AllFamilyFieldValues(t *testing.T) {
 	row := records[1]
 	assert.Equal(t, family.ID.String(), row[0])  // id
 	assert.Equal(t, person1.ID.String(), row[1]) // partner1_id
-	assert.Equal(t, "John Doe", row[2])          // partner1_name
-	assert.Equal(t, person2.ID.String(), row[3]) // partner2_id
-	assert.Equal(t, "Jane Smith", row[4])        // partner2_name
-	assert.Equal(t, "marriage", row[5])          // relationship_type
-	assert.Equal(t, "10 JUN 1875", row[6])       // marriage_date
-	assert.Equal(t, "Springfield, IL", row[7])   // marriage_place
-	assert.Equal(t, "3", row[8])                 // child_count
-	assert.Equal(t, "2", row[9])                 // version
-	assert.NotEmpty(t, row[10])                  // updated_at
+	assert.Equal(t, "John", row[2])              // partner1_given_name
+	assert.Equal(t, "Doe", row[3])               // partner1_surname
+	assert.Equal(t, person2.ID.String(), row[4]) // partner2_id
+	assert.Equal(t, "Jane", row[5])              // partner2_given_name
+	assert.Equal(t, "Smith", row[6])             // partner2_surname
+	assert.Equal(t, "marriage", row[7])          // relationship_type
+	assert.Equal(t, "10 JUN 1875", row[8])       // marriage_date
+	assert.Equal(t, "Springfield, IL", row[9])   // marriage_place
+	assert.Equal(t, "3", row[10])                // child_count
+	assert.Equal(t, "2", row[11])                // version
+	assert.NotEmpty(t, row[12])                  // updated_at
 }
 
 func TestCSVExporter_FamilyWithNilPartners(t *testing.T) {

--- a/internal/gedcom/exporter_test.go
+++ b/internal/gedcom/exporter_test.go
@@ -64,14 +64,16 @@ func setupExportTestData(t *testing.T, readStore *memory.ReadModelStore) (uuid.U
 	// Create family
 	familyID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:               familyID,
-		Partner1ID:       &john,
-		Partner1Name:     "John Doe",
-		Partner2ID:       &jane,
-		Partner2Name:     "Jane Smith",
-		RelationshipType: domain.RelationMarriage,
-		MarriageDateRaw:  "10 JUN 1875",
-		MarriagePlace:    "Springfield, IL",
+		ID:                familyID,
+		Partner1ID:        &john,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &jane,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Smith",
+		RelationshipType:  domain.RelationMarriage,
+		MarriageDateRaw:   "10 JUN 1875",
+		MarriagePlace:     "Springfield, IL",
 	}
 	if err := readStore.SaveFamily(ctx, family); err != nil {
 		t.Fatal(err)
@@ -81,7 +83,8 @@ func setupExportTestData(t *testing.T, readStore *memory.ReadModelStore) (uuid.U
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         junior,
-		PersonName:       "Junior Doe",
+		PersonGivenName:  "Junior",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 	if err := readStore.SaveFamilyChild(ctx, child); err != nil {
@@ -323,14 +326,16 @@ func TestExport_SingleParentFamily(t *testing.T) {
 
 	familyID := uuid.New()
 	readStore.SaveFamily(ctx, &repository.FamilyReadModel{
-		ID:           familyID,
-		Partner2ID:   &mother,
-		Partner2Name: "Jane Doe",
+		ID:                familyID,
+		Partner2ID:        &mother,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
 	})
 	readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
-		FamilyID:   familyID,
-		PersonID:   child,
-		PersonName: "Child Doe",
+		FamilyID:        familyID,
+		PersonID:        child,
+		PersonGivenName: "Child",
+		PersonSurname:   "Doe",
 	})
 
 	exporter := gedcom.NewExporter(readStore)
@@ -2133,12 +2138,14 @@ func TestExport_LDSOrdinances(t *testing.T) {
 	}
 
 	family := &repository.FamilyReadModel{
-		ID:               familyID,
-		Partner1ID:       &personID,
-		Partner1Name:     "John Doe",
-		Partner2ID:       &partner2ID,
-		Partner2Name:     "Jane Smith",
-		RelationshipType: domain.RelationMarriage,
+		ID:                familyID,
+		Partner1ID:        &personID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &partner2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Smith",
+		RelationshipType:  domain.RelationMarriage,
 	}
 	if err := readStore.SaveFamily(ctx, family); err != nil {
 		t.Fatal(err)

--- a/internal/query/descendancy_queries.go
+++ b/internal/query/descendancy_queries.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -166,10 +167,10 @@ func (s *DescendancyService) getSpouseInfo(family repository.FamilyReadModel, pe
 	// Find the other partner
 	if family.Partner1ID != nil && *family.Partner1ID != personID {
 		spouseID = family.Partner1ID
-		spouseName = family.Partner1Name
+		spouseName = strings.TrimSpace(family.Partner1GivenName + " " + family.Partner1Surname)
 	} else if family.Partner2ID != nil && *family.Partner2ID != personID {
 		spouseID = family.Partner2ID
-		spouseName = family.Partner2Name
+		spouseName = strings.TrimSpace(family.Partner2GivenName + " " + family.Partner2Surname)
 	}
 
 	if spouseID == nil {

--- a/internal/query/descendancy_queries.go
+++ b/internal/query/descendancy_queries.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"strings"
 
 	"github.com/google/uuid"
 
@@ -167,10 +166,10 @@ func (s *DescendancyService) getSpouseInfo(family repository.FamilyReadModel, pe
 	// Find the other partner
 	if family.Partner1ID != nil && *family.Partner1ID != personID {
 		spouseID = family.Partner1ID
-		spouseName = strings.TrimSpace(family.Partner1GivenName + " " + family.Partner1Surname)
+		spouseName = fullName(family.Partner1GivenName, family.Partner1Surname)
 	} else if family.Partner2ID != nil && *family.Partner2ID != personID {
 		spouseID = family.Partner2ID
-		spouseName = strings.TrimSpace(family.Partner2GivenName + " " + family.Partner2Surname)
+		spouseName = fullName(family.Partner2GivenName, family.Partner2Surname)
 	}
 
 	if spouseID == nil {

--- a/internal/query/descendancy_queries_test.go
+++ b/internal/query/descendancy_queries_test.go
@@ -56,7 +56,8 @@ func setupDescendancyTestData(t *testing.T, readStore *memory.ReadModelStore) (g
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family1,
 		PersonID:         parent1,
-		PersonName:       "John Smith",
+		PersonGivenName:  "John",
+		PersonSurname:    "Smith",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -66,12 +67,14 @@ func setupDescendancyTestData(t *testing.T, readStore *memory.ReadModelStore) (g
 	// Family 2: parent1 + parent2 (spouse)
 	family2 := uuid.New()
 	err = readStore.SaveFamily(ctx, &repository.FamilyReadModel{
-		ID:              family2,
-		Partner1ID:      &parent1,
-		Partner1Name:    "John Smith",
-		Partner2ID:      &parent2,
-		Partner2Name:    "Jane Doe",
-		MarriageDateRaw: "15 JUN 1995",
+		ID:                family2,
+		Partner1ID:        &parent1,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Smith",
+		Partner2ID:        &parent2,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		MarriageDateRaw:   "15 JUN 1995",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +84,8 @@ func setupDescendancyTestData(t *testing.T, readStore *memory.ReadModelStore) (g
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family2,
 		PersonID:         child1,
-		PersonName:       "Junior Smith",
+		PersonGivenName:  "Junior",
+		PersonSurname:    "Smith",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -91,7 +95,8 @@ func setupDescendancyTestData(t *testing.T, readStore *memory.ReadModelStore) (g
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family2,
 		PersonID:         child2,
-		PersonName:       "Jenny Smith",
+		PersonGivenName:  "Jenny",
+		PersonSurname:    "Smith",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -111,7 +116,8 @@ func setupDescendancyTestData(t *testing.T, readStore *memory.ReadModelStore) (g
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family3,
 		PersonID:         grandchild,
-		PersonName:       "Baby Smith",
+		PersonGivenName:  "Baby",
+		PersonSurname:    "Smith",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -405,7 +411,8 @@ func TestGetDescendancy_CycleDetection(t *testing.T) {
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family1,
 		PersonID:         person2,
-		PersonName:       "Person2 Test",
+		PersonGivenName:  "Person2",
+		PersonSurname:    "Test",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -425,7 +432,8 @@ func TestGetDescendancy_CycleDetection(t *testing.T) {
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family2,
 		PersonID:         person1,
-		PersonName:       "Person1 Test",
+		PersonGivenName:  "Person1",
+		PersonSurname:    "Test",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -588,12 +596,14 @@ func TestGetDescendancy_MultipleSpouses(t *testing.T) {
 	// Create family 1: parent + spouse1
 	family1 := uuid.New()
 	err := readStore.SaveFamily(ctx, &repository.FamilyReadModel{
-		ID:              family1,
-		Partner1ID:      &parent,
-		Partner1Name:    "Parent Test",
-		Partner2ID:      &spouse1,
-		Partner2Name:    "Spouse1 Test",
-		MarriageDateRaw: "1 JAN 1990",
+		ID:                family1,
+		Partner1ID:        &parent,
+		Partner1GivenName: "Parent",
+		Partner1Surname:   "Test",
+		Partner2ID:        &spouse1,
+		Partner2GivenName: "Spouse1",
+		Partner2Surname:   "Test",
+		MarriageDateRaw:   "1 JAN 1990",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -602,7 +612,8 @@ func TestGetDescendancy_MultipleSpouses(t *testing.T) {
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family1,
 		PersonID:         child1,
-		PersonName:       "Child1 Test",
+		PersonGivenName:  "Child1",
+		PersonSurname:    "Test",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {
@@ -612,12 +623,14 @@ func TestGetDescendancy_MultipleSpouses(t *testing.T) {
 	// Create family 2: parent + spouse2
 	family2 := uuid.New()
 	err = readStore.SaveFamily(ctx, &repository.FamilyReadModel{
-		ID:              family2,
-		Partner1ID:      &parent,
-		Partner1Name:    "Parent Test",
-		Partner2ID:      &spouse2,
-		Partner2Name:    "Spouse2 Test",
-		MarriageDateRaw: "1 JAN 2000",
+		ID:                family2,
+		Partner1ID:        &parent,
+		Partner1GivenName: "Parent",
+		Partner1Surname:   "Test",
+		Partner2ID:        &spouse2,
+		Partner2GivenName: "Spouse2",
+		Partner2Surname:   "Test",
+		MarriageDateRaw:   "1 JAN 2000",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -626,7 +639,8 @@ func TestGetDescendancy_MultipleSpouses(t *testing.T) {
 	err = readStore.SaveFamilyChild(ctx, &repository.FamilyChildReadModel{
 		FamilyID:         family2,
 		PersonID:         child2,
-		PersonName:       "Child2 Test",
+		PersonGivenName:  "Child2",
+		PersonSurname:    "Test",
 		RelationshipType: domain.ChildBiological,
 	})
 	if err != nil {

--- a/internal/query/family_queries.go
+++ b/internal/query/family_queries.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -21,16 +22,18 @@ func NewFamilyService(readStore repository.ReadModelStore) *FamilyService {
 
 // Family represents a family in query results.
 type Family struct {
-	ID               uuid.UUID       `json:"id"`
-	Partner1ID       *uuid.UUID      `json:"partner1_id,omitempty"`
-	Partner1Name     *string         `json:"partner1_name,omitempty"`
-	Partner2ID       *uuid.UUID      `json:"partner2_id,omitempty"`
-	Partner2Name     *string         `json:"partner2_name,omitempty"`
-	RelationshipType *string         `json:"relationship_type,omitempty"`
-	MarriageDate     *domain.GenDate `json:"marriage_date,omitempty"`
-	MarriagePlace    *string         `json:"marriage_place,omitempty"`
-	ChildCount       int             `json:"child_count"`
-	Version          int64           `json:"version"`
+	ID                uuid.UUID       `json:"id"`
+	Partner1ID        *uuid.UUID      `json:"partner1_id,omitempty"`
+	Partner1GivenName *string         `json:"partner1_given_name,omitempty"`
+	Partner1Surname   *string         `json:"partner1_surname,omitempty"`
+	Partner2ID        *uuid.UUID      `json:"partner2_id,omitempty"`
+	Partner2GivenName *string         `json:"partner2_given_name,omitempty"`
+	Partner2Surname   *string         `json:"partner2_surname,omitempty"`
+	RelationshipType  *string         `json:"relationship_type,omitempty"`
+	MarriageDate      *domain.GenDate `json:"marriage_date,omitempty"`
+	MarriagePlace     *string         `json:"marriage_place,omitempty"`
+	ChildCount        int             `json:"child_count"`
+	Version           int64           `json:"version"`
 }
 
 // FamilyDetail includes children information.
@@ -42,7 +45,8 @@ type FamilyDetail struct {
 // FamilyChildInfo represents a child in a family.
 type FamilyChildInfo struct {
 	ID               uuid.UUID `json:"id"`
-	Name             string    `json:"name"`
+	GivenName        string    `json:"given_name"`
+	Surname          string    `json:"surname"`
 	RelationshipType string    `json:"relationship_type"`
 }
 
@@ -116,7 +120,8 @@ func (s *FamilyService) GetFamily(ctx context.Context, id uuid.UUID) (*FamilyDet
 	for _, c := range children {
 		detail.Children = append(detail.Children, FamilyChildInfo{
 			ID:               c.PersonID,
-			Name:             c.PersonName,
+			GivenName:        c.PersonGivenName,
+			Surname:          c.PersonSurname,
 			RelationshipType: string(c.RelationshipType),
 		})
 	}
@@ -149,11 +154,21 @@ func convertReadModelToFamily(rm repository.FamilyReadModel) Family {
 		Version:    rm.Version,
 	}
 
-	if rm.Partner1Name != "" {
-		f.Partner1Name = &rm.Partner1Name
+	if rm.Partner1GivenName != "" {
+		v := rm.Partner1GivenName
+		f.Partner1GivenName = &v
 	}
-	if rm.Partner2Name != "" {
-		f.Partner2Name = &rm.Partner2Name
+	if rm.Partner1Surname != "" {
+		v := rm.Partner1Surname
+		f.Partner1Surname = &v
+	}
+	if rm.Partner2GivenName != "" {
+		v := rm.Partner2GivenName
+		f.Partner2GivenName = &v
+	}
+	if rm.Partner2Surname != "" {
+		v := rm.Partner2Surname
+		f.Partner2Surname = &v
 	}
 	if rm.RelationshipType != "" {
 		rt := string(rm.RelationshipType)
@@ -404,12 +419,12 @@ func (s *FamilyService) getGroupSheetChild(ctx context.Context, child repository
 			// Find the other partner
 			if fam.Partner1ID != nil && *fam.Partner1ID != person.ID {
 				gsc.SpouseID = fam.Partner1ID
-				gsc.SpouseName = fam.Partner1Name
+				gsc.SpouseName = strings.TrimSpace(fam.Partner1GivenName + " " + fam.Partner1Surname)
 				break
 			}
 			if fam.Partner2ID != nil && *fam.Partner2ID != person.ID {
 				gsc.SpouseID = fam.Partner2ID
-				gsc.SpouseName = fam.Partner2Name
+				gsc.SpouseName = strings.TrimSpace(fam.Partner2GivenName + " " + fam.Partner2Surname)
 				break
 			}
 		}

--- a/internal/query/family_queries.go
+++ b/internal/query/family_queries.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"strings"
 
 	"github.com/google/uuid"
 
@@ -419,12 +418,12 @@ func (s *FamilyService) getGroupSheetChild(ctx context.Context, child repository
 			// Find the other partner
 			if fam.Partner1ID != nil && *fam.Partner1ID != person.ID {
 				gsc.SpouseID = fam.Partner1ID
-				gsc.SpouseName = strings.TrimSpace(fam.Partner1GivenName + " " + fam.Partner1Surname)
+				gsc.SpouseName = fullName(fam.Partner1GivenName, fam.Partner1Surname)
 				break
 			}
 			if fam.Partner2ID != nil && *fam.Partner2ID != person.ID {
 				gsc.SpouseID = fam.Partner2ID
-				gsc.SpouseName = strings.TrimSpace(fam.Partner2GivenName + " " + fam.Partner2Surname)
+				gsc.SpouseName = fullName(fam.Partner2GivenName, fam.Partner2Surname)
 				break
 			}
 		}

--- a/internal/query/family_queries_test.go
+++ b/internal/query/family_queries_test.go
@@ -359,11 +359,17 @@ func TestGetFamily_AllOptionalFields(t *testing.T) {
 		t.Fatalf("GetFamily failed: %v", err)
 	}
 
-	if family.Partner1Name == nil {
-		t.Error("Partner1Name should be set")
+	if family.Partner1GivenName == nil {
+		t.Error("Partner1GivenName should be set")
 	}
-	if family.Partner2Name == nil {
-		t.Error("Partner2Name should be set")
+	if family.Partner1Surname == nil {
+		t.Error("Partner1Surname should be set")
+	}
+	if family.Partner2GivenName == nil {
+		t.Error("Partner2GivenName should be set")
+	}
+	if family.Partner2Surname == nil {
+		t.Error("Partner2Surname should be set")
 	}
 	if family.RelationshipType == nil {
 		t.Error("RelationshipType should be set")

--- a/internal/query/history_queries.go
+++ b/internal/query/history_queries.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -308,8 +307,8 @@ func (s *HistoryService) getFamilyName(ctx context.Context, familyID uuid.UUID, 
 	// Try to get from read model first
 	family, err := s.readStore.GetFamily(ctx, familyID)
 	if err == nil && family != nil {
-		p1Name := strings.TrimSpace(family.Partner1GivenName + " " + family.Partner1Surname)
-		p2Name := strings.TrimSpace(family.Partner2GivenName + " " + family.Partner2Surname)
+		p1Name := fullName(family.Partner1GivenName, family.Partner1Surname)
+		p2Name := fullName(family.Partner2GivenName, family.Partner2Surname)
 		if p1Name != "" && p2Name != "" {
 			return fmt.Sprintf("%s & %s", p1Name, p2Name)
 		}

--- a/internal/query/history_queries.go
+++ b/internal/query/history_queries.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -307,14 +308,16 @@ func (s *HistoryService) getFamilyName(ctx context.Context, familyID uuid.UUID, 
 	// Try to get from read model first
 	family, err := s.readStore.GetFamily(ctx, familyID)
 	if err == nil && family != nil {
-		if family.Partner1Name != "" && family.Partner2Name != "" {
-			return fmt.Sprintf("%s & %s", family.Partner1Name, family.Partner2Name)
+		p1Name := strings.TrimSpace(family.Partner1GivenName + " " + family.Partner1Surname)
+		p2Name := strings.TrimSpace(family.Partner2GivenName + " " + family.Partner2Surname)
+		if p1Name != "" && p2Name != "" {
+			return fmt.Sprintf("%s & %s", p1Name, p2Name)
 		}
-		if family.Partner1Name != "" {
-			return family.Partner1Name
+		if p1Name != "" {
+			return p1Name
 		}
-		if family.Partner2Name != "" {
-			return family.Partner2Name
+		if p2Name != "" {
+			return p2Name
 		}
 	}
 

--- a/internal/query/history_queries_test.go
+++ b/internal/query/history_queries_test.go
@@ -794,9 +794,11 @@ func TestGetEntityName(t *testing.T) {
 		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
 			if id == familyID {
 				return &repository.FamilyReadModel{
-					ID:           familyID,
-					Partner1Name: "John Smith",
-					Partner2Name: "Jane Doe",
+					ID:                familyID,
+					Partner1GivenName: "John",
+					Partner1Surname:   "Smith",
+					Partner2GivenName: "Jane",
+					Partner2Surname:   "Doe",
 				}, nil
 			}
 			return nil, repository.ErrStreamNotFound
@@ -942,36 +944,36 @@ func TestGetFamilyNameVariations(t *testing.T) {
 		{
 			name: "both partners",
 			family: &repository.FamilyReadModel{
-				ID:           familyID,
-				Partner1Name: "John Smith",
-				Partner2Name: "Jane Doe",
+				ID:                familyID,
+				Partner1GivenName: "John",
+				Partner1Surname:   "Smith",
+				Partner2GivenName: "Jane",
+				Partner2Surname:   "Doe",
 			},
 			wantName: "John Smith & Jane Doe",
 		},
 		{
 			name: "partner1 only",
 			family: &repository.FamilyReadModel{
-				ID:           familyID,
-				Partner1Name: "John Smith",
-				Partner2Name: "",
+				ID:                familyID,
+				Partner1GivenName: "John",
+				Partner1Surname:   "Smith",
 			},
 			wantName: "John Smith",
 		},
 		{
 			name: "partner2 only",
 			family: &repository.FamilyReadModel{
-				ID:           familyID,
-				Partner1Name: "",
-				Partner2Name: "Jane Doe",
+				ID:                familyID,
+				Partner2GivenName: "Jane",
+				Partner2Surname:   "Doe",
 			},
 			wantName: "Jane Doe",
 		},
 		{
 			name: "no partners (deleted)",
 			family: &repository.FamilyReadModel{
-				ID:           familyID,
-				Partner1Name: "",
-				Partner2Name: "",
+				ID: familyID,
 			},
 			wantName: familyID.String(),
 		},
@@ -1142,9 +1144,11 @@ func TestChildLinkedToFamilyProducesUpdatedAction(t *testing.T) {
 		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
 			if id == familyID {
 				return &repository.FamilyReadModel{
-					ID:           familyID,
-					Partner1Name: "John Smith",
-					Partner2Name: "Jane Smith",
+					ID:                familyID,
+					Partner1GivenName: "John",
+					Partner1Surname:   "Smith",
+					Partner2GivenName: "Jane",
+					Partner2Surname:   "Smith",
 				}, nil
 			}
 			return nil, repository.ErrStreamNotFound
@@ -1199,9 +1203,11 @@ func TestChildUnlinkedFromFamilyProducesUpdatedAction(t *testing.T) {
 		getFamilyFunc: func(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
 			if id == familyID {
 				return &repository.FamilyReadModel{
-					ID:           familyID,
-					Partner1Name: "John Smith",
-					Partner2Name: "Jane Smith",
+					ID:                familyID,
+					Partner1GivenName: "John",
+					Partner1Surname:   "Smith",
+					Partner2GivenName: "Jane",
+					Partner2Surname:   "Smith",
 				}, nil
 			}
 			return nil, repository.ErrStreamNotFound

--- a/internal/query/names.go
+++ b/internal/query/names.go
@@ -1,0 +1,11 @@
+package query
+
+import "strings"
+
+// fullName joins a given name and surname with a single space, trimming the
+// result. Either part may be empty; the helper centralizes the convention so
+// adding middle names or supporting culture-specific orderings (e.g.,
+// surname-first locales) is a single-site change rather than a grep.
+func fullName(given, surname string) string {
+	return strings.TrimSpace(given + " " + surname)
+}

--- a/internal/query/person_queries.go
+++ b/internal/query/person_queries.go
@@ -4,7 +4,6 @@ package query
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -302,10 +301,10 @@ func convertToFamilySummary(rm repository.FamilyReadModel) FamilySummary {
 	s := FamilySummary{
 		ID: rm.ID,
 	}
-	if p1 := strings.TrimSpace(rm.Partner1GivenName + " " + rm.Partner1Surname); p1 != "" {
+	if p1 := fullName(rm.Partner1GivenName, rm.Partner1Surname); p1 != "" {
 		s.Partner1Name = &p1
 	}
-	if p2 := strings.TrimSpace(rm.Partner2GivenName + " " + rm.Partner2Surname); p2 != "" {
+	if p2 := fullName(rm.Partner2GivenName, rm.Partner2Surname); p2 != "" {
 		s.Partner2Name = &p2
 	}
 	if rm.RelationshipType != "" {

--- a/internal/query/person_queries.go
+++ b/internal/query/person_queries.go
@@ -4,6 +4,7 @@ package query
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -301,11 +302,11 @@ func convertToFamilySummary(rm repository.FamilyReadModel) FamilySummary {
 	s := FamilySummary{
 		ID: rm.ID,
 	}
-	if rm.Partner1Name != "" {
-		s.Partner1Name = &rm.Partner1Name
+	if p1 := strings.TrimSpace(rm.Partner1GivenName + " " + rm.Partner1Surname); p1 != "" {
+		s.Partner1Name = &p1
 	}
-	if rm.Partner2Name != "" {
-		s.Partner2Name = &rm.Partner2Name
+	if p2 := strings.TrimSpace(rm.Partner2GivenName + " " + rm.Partner2Surname); p2 != "" {
+		s.Partner2Name = &p2
 	}
 	if rm.RelationshipType != "" {
 		rt := string(rm.RelationshipType)

--- a/internal/query/relationship_queries.go
+++ b/internal/query/relationship_queries.go
@@ -166,7 +166,7 @@ func (s *RelationshipService) GetRelationship(ctx context.Context, personID1, pe
 
 // personDisplayName returns a display name for a person.
 func personDisplayName(p Person) string {
-	name := strings.TrimSpace(p.GivenName + " " + p.Surname)
+	name := fullName(p.GivenName, p.Surname)
 	if name == "" {
 		return "Unknown"
 	}

--- a/internal/query/validation_service.go
+++ b/internal/query/validation_service.go
@@ -469,7 +469,7 @@ func getDisplayNameFromIndividual(ind *gedcom.Individual) string {
 		return strings.ReplaceAll(strings.ReplaceAll(name.Full, "/", ""), "  ", " ")
 	}
 	if name.Given != "" || name.Surname != "" {
-		return strings.TrimSpace(name.Given + " " + name.Surname)
+		return fullName(name.Given, name.Surname)
 	}
 	return ""
 }

--- a/internal/repository/memory/readmodel_test.go
+++ b/internal/repository/memory/readmodel_test.go
@@ -508,15 +508,17 @@ func TestReadModelStore_SaveAndGetFamily(t *testing.T) {
 	partner1ID := uuid.New()
 	partner2ID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:               uuid.New(),
-		Partner1ID:       &partner1ID,
-		Partner1Name:     "John Doe",
-		Partner2ID:       &partner2ID,
-		Partner2Name:     "Jane Doe",
-		RelationshipType: domain.RelationMarriage,
-		ChildCount:       2,
-		Version:          1,
-		UpdatedAt:        time.Now(),
+		ID:                uuid.New(),
+		Partner1ID:        &partner1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &partner2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		RelationshipType:  domain.RelationMarriage,
+		ChildCount:        2,
+		Version:           1,
+		UpdatedAt:         time.Now(),
 	}
 
 	// Save family
@@ -590,7 +592,8 @@ func TestReadModelStore_DeleteFamily(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Child",
+		PersonGivenName:  "Child",
+		PersonSurname:    "",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child)
@@ -774,7 +777,8 @@ func TestReadModelStore_SaveAndGetFamilyChildren(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Child Doe",
+		PersonGivenName:  "Child",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 
@@ -816,7 +820,8 @@ func TestReadModelStore_SaveFamilyChildUpdate(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Child Doe",
+		PersonGivenName:  "Child",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 
@@ -860,7 +865,8 @@ func TestReadModelStore_DeleteFamilyChild(t *testing.T) {
 	child1 := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         child1ID,
-		PersonName:       "Child 1",
+		PersonGivenName:  "Child 1",
+		PersonSurname:    "",
 		RelationshipType: domain.ChildBiological,
 	}
 	err := store.SaveFamilyChild(ctx, child1)
@@ -871,7 +877,8 @@ func TestReadModelStore_DeleteFamilyChild(t *testing.T) {
 	child2 := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         child2ID,
-		PersonName:       "Child 2",
+		PersonGivenName:  "Child 2",
+		PersonSurname:    "",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child2)
@@ -937,7 +944,8 @@ func TestReadModelStore_GetChildrenOfFamily(t *testing.T) {
 	child1 := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         child1ID,
-		PersonName:       "Alice Doe",
+		PersonGivenName:  "Alice",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child1)
@@ -948,7 +956,8 @@ func TestReadModelStore_GetChildrenOfFamily(t *testing.T) {
 	child2 := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         child2ID,
-		PersonName:       "Bob Doe",
+		PersonGivenName:  "Bob",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child2)
@@ -1003,7 +1012,8 @@ func TestReadModelStore_GetChildFamily(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Child Doe",
+		PersonGivenName:  "Child",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child)
@@ -1173,7 +1183,8 @@ func TestReadModelStore_Reset(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         personID,
-		PersonName:       "John Doe",
+		PersonGivenName:  "John",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 	}
 	err = store.SaveFamilyChild(ctx, child)

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -450,37 +450,44 @@ func (s *ReadModelStore) runMigrations() {
 	// Add is_negated column for negative assertions / NO tags (issue #222)
 	_, _ = s.db.Exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS is_negated BOOLEAN NOT NULL DEFAULT FALSE`)
 
-	// Split family partner names and family-child names into given_name / surname (issue #483)
-	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_given_name VARCHAR(200)`)
-	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_surname VARCHAR(200)`)
-	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_given_name VARCHAR(200)`)
-	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_surname VARCHAR(200)`)
-	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_given_name VARCHAR(200)`)
-	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_surname VARCHAR(200)`)
+	// Split family partner names and family-child names into given_name / surname (issue #483).
+	// Wrapped in a single transaction so a mid-migration crash leaves either the pre-migration
+	// or post-migration state, never a half-state where legacy columns are dropped before the
+	// new ones are populated. SQLite-side does NOT drop the legacy columns (project convention
+	// never drops columns on SQLite), so the two backends diverge intentionally here.
+	if tx, err := s.db.Begin(); err == nil {
+		_, _ = tx.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_given_name VARCHAR(200)`)
+		_, _ = tx.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_surname VARCHAR(200)`)
+		_, _ = tx.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_given_name VARCHAR(200)`)
+		_, _ = tx.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_surname VARCHAR(200)`)
+		_, _ = tx.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_given_name VARCHAR(200)`)
+		_, _ = tx.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_surname VARCHAR(200)`)
 
-	// Backfill split fields from persons table; idempotent via IS NULL guard.
-	_, _ = s.db.Exec(`
-		UPDATE families f SET
-			partner1_given_name = p.given_name,
-			partner1_surname    = p.surname
-		FROM persons p WHERE f.partner1_id = p.id AND f.partner1_given_name IS NULL
-	`)
-	_, _ = s.db.Exec(`
-		UPDATE families f SET
-			partner2_given_name = p.given_name,
-			partner2_surname    = p.surname
-		FROM persons p WHERE f.partner2_id = p.id AND f.partner2_given_name IS NULL
-	`)
-	_, _ = s.db.Exec(`
-		UPDATE family_children fc SET
-			person_given_name = p.given_name,
-			person_surname    = p.surname
-		FROM persons p WHERE fc.person_id = p.id AND fc.person_given_name IS NULL
-	`)
+		// Backfill split fields from persons table; idempotent via IS NULL guard.
+		_, _ = tx.Exec(`
+			UPDATE families f SET
+				partner1_given_name = p.given_name,
+				partner1_surname    = p.surname
+			FROM persons p WHERE f.partner1_id = p.id AND f.partner1_given_name IS NULL
+		`)
+		_, _ = tx.Exec(`
+			UPDATE families f SET
+				partner2_given_name = p.given_name,
+				partner2_surname    = p.surname
+			FROM persons p WHERE f.partner2_id = p.id AND f.partner2_given_name IS NULL
+		`)
+		_, _ = tx.Exec(`
+			UPDATE family_children fc SET
+				person_given_name = p.given_name,
+				person_surname    = p.surname
+			FROM persons p WHERE fc.person_id = p.id AND fc.person_given_name IS NULL
+		`)
 
-	// Drop legacy denormalized columns once the split is populated.
-	_, _ = s.db.Exec(`ALTER TABLE families DROP COLUMN IF EXISTS partner1_name, DROP COLUMN IF EXISTS partner2_name`)
-	_, _ = s.db.Exec(`ALTER TABLE family_children DROP COLUMN IF EXISTS person_name`)
+		// Drop legacy denormalized columns once the split is populated.
+		_, _ = tx.Exec(`ALTER TABLE families DROP COLUMN IF EXISTS partner1_name, DROP COLUMN IF EXISTS partner2_name`)
+		_, _ = tx.Exec(`ALTER TABLE family_children DROP COLUMN IF EXISTS person_name`)
+		_ = tx.Commit()
+	}
 }
 
 // GetPerson retrieves a person by ID.

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -82,9 +82,11 @@ func (s *ReadModelStore) createTables() error {
 		CREATE TABLE IF NOT EXISTS families (
 			id UUID PRIMARY KEY,
 			partner1_id UUID REFERENCES persons(id),
-			partner1_name VARCHAR(200),
+			partner1_given_name VARCHAR(200),
+			partner1_surname VARCHAR(200),
 			partner2_id UUID REFERENCES persons(id),
-			partner2_name VARCHAR(200),
+			partner2_given_name VARCHAR(200),
+			partner2_surname VARCHAR(200),
 			relationship_type VARCHAR(20),
 			marriage_date_raw VARCHAR(100),
 			marriage_date_sort DATE,
@@ -101,7 +103,8 @@ func (s *ReadModelStore) createTables() error {
 		CREATE TABLE IF NOT EXISTS family_children (
 			family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
 			person_id UUID NOT NULL REFERENCES persons(id),
-			person_name VARCHAR(200),
+			person_given_name VARCHAR(200),
+			person_surname VARCHAR(200),
 			relationship_type VARCHAR(20) NOT NULL DEFAULT 'biological',
 			sequence INTEGER,
 			PRIMARY KEY (family_id, person_id)
@@ -446,6 +449,38 @@ func (s *ReadModelStore) runMigrations() {
 
 	// Add is_negated column for negative assertions / NO tags (issue #222)
 	_, _ = s.db.Exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS is_negated BOOLEAN NOT NULL DEFAULT FALSE`)
+
+	// Split family partner names and family-child names into given_name / surname (issue #483)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_given_name VARCHAR(200)`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner1_surname VARCHAR(200)`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_given_name VARCHAR(200)`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN IF NOT EXISTS partner2_surname VARCHAR(200)`)
+	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_given_name VARCHAR(200)`)
+	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN IF NOT EXISTS person_surname VARCHAR(200)`)
+
+	// Backfill split fields from persons table; idempotent via IS NULL guard.
+	_, _ = s.db.Exec(`
+		UPDATE families f SET
+			partner1_given_name = p.given_name,
+			partner1_surname    = p.surname
+		FROM persons p WHERE f.partner1_id = p.id AND f.partner1_given_name IS NULL
+	`)
+	_, _ = s.db.Exec(`
+		UPDATE families f SET
+			partner2_given_name = p.given_name,
+			partner2_surname    = p.surname
+		FROM persons p WHERE f.partner2_id = p.id AND f.partner2_given_name IS NULL
+	`)
+	_, _ = s.db.Exec(`
+		UPDATE family_children fc SET
+			person_given_name = p.given_name,
+			person_surname    = p.surname
+		FROM persons p WHERE fc.person_id = p.id AND fc.person_given_name IS NULL
+	`)
+
+	// Drop legacy denormalized columns once the split is populated.
+	_, _ = s.db.Exec(`ALTER TABLE families DROP COLUMN IF EXISTS partner1_name, DROP COLUMN IF EXISTS partner2_name`)
+	_, _ = s.db.Exec(`ALTER TABLE family_children DROP COLUMN IF EXISTS person_name`)
 }
 
 // GetPerson retrieves a person by ID.
@@ -905,7 +940,8 @@ func scanPersonNameRow(rows *sql.Rows) (*repository.PersonNameReadModel, error) 
 // GetFamily retrieves a family by ID.
 func (s *ReadModelStore) GetFamily(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -924,7 +960,8 @@ func (s *ReadModelStore) ListFamilies(ctx context.Context, opts repository.ListO
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -952,7 +989,8 @@ func (s *ReadModelStore) ListFamilies(ctx context.Context, opts repository.ListO
 // GetFamiliesForPerson returns all families where the person is a partner.
 func (s *ReadModelStore) GetFamiliesForPerson(ctx context.Context, personID uuid.UUID) ([]repository.FamilyReadModel, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -979,16 +1017,19 @@ func (s *ReadModelStore) GetFamiliesForPerson(ctx context.Context, personID uuid
 // SaveFamily saves or updates a family.
 func (s *ReadModelStore) SaveFamily(ctx context.Context, family *repository.FamilyReadModel) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO families (id, partner1_id, partner1_name, partner2_id, partner2_name,
+		INSERT INTO families (id, partner1_id, partner1_given_name, partner1_surname,
+							  partner2_id, partner2_given_name, partner2_surname,
 							  relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 							  marriage_place_lat, marriage_place_long,
 							  child_count, version, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT(id) DO UPDATE SET
 			partner1_id = EXCLUDED.partner1_id,
-			partner1_name = EXCLUDED.partner1_name,
+			partner1_given_name = EXCLUDED.partner1_given_name,
+			partner1_surname = EXCLUDED.partner1_surname,
 			partner2_id = EXCLUDED.partner2_id,
-			partner2_name = EXCLUDED.partner2_name,
+			partner2_given_name = EXCLUDED.partner2_given_name,
+			partner2_surname = EXCLUDED.partner2_surname,
 			relationship_type = EXCLUDED.relationship_type,
 			marriage_date_raw = EXCLUDED.marriage_date_raw,
 			marriage_date_sort = EXCLUDED.marriage_date_sort,
@@ -998,8 +1039,9 @@ func (s *ReadModelStore) SaveFamily(ctx context.Context, family *repository.Fami
 			child_count = EXCLUDED.child_count,
 			version = EXCLUDED.version,
 			updated_at = EXCLUDED.updated_at
-	`, family.ID, nullableUUID(family.Partner1ID), nullableString(family.Partner1Name),
-		nullableUUID(family.Partner2ID), nullableString(family.Partner2Name),
+	`, family.ID,
+		nullableUUID(family.Partner1ID), nullableString(family.Partner1GivenName), nullableString(family.Partner1Surname),
+		nullableUUID(family.Partner2ID), nullableString(family.Partner2GivenName), nullableString(family.Partner2Surname),
 		nullableString(string(family.RelationshipType)), nullableString(family.MarriageDateRaw),
 		nullableTime(family.MarriageDateSort), nullableString(family.MarriagePlace),
 		nullableStringPtr(family.MarriagePlaceLat), nullableStringPtr(family.MarriagePlaceLong),
@@ -1017,10 +1059,10 @@ func (s *ReadModelStore) DeleteFamily(ctx context.Context, id uuid.UUID) error {
 // GetFamilyChildren returns all children for a family.
 func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UUID) ([]repository.FamilyChildReadModel, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT family_id, person_id, person_name, relationship_type, sequence
+		SELECT family_id, person_id, person_given_name, person_surname, relationship_type, sequence
 		FROM family_children
 		WHERE family_id = $1
-		ORDER BY sequence NULLS LAST, person_name
+		ORDER BY sequence NULLS LAST, person_surname, person_given_name
 	`, familyID)
 	if err != nil {
 		return nil, fmt.Errorf("query family children: %w", err)
@@ -1030,11 +1072,12 @@ func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UU
 	var children []repository.FamilyChildReadModel
 	for rows.Next() {
 		var (
-			familyID, personID  uuid.UUID
-			personName, relType string
-			sequence            sql.NullInt64
+			familyID, personID             uuid.UUID
+			personGivenName, personSurname sql.NullString
+			relType                        string
+			sequence                       sql.NullInt64
 		)
-		err := rows.Scan(&familyID, &personID, &personName, &relType, &sequence)
+		err := rows.Scan(&familyID, &personID, &personGivenName, &personSurname, &relType, &sequence)
 		if err != nil {
 			return nil, fmt.Errorf("scan family child: %w", err)
 		}
@@ -1042,7 +1085,8 @@ func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UU
 		child := repository.FamilyChildReadModel{
 			FamilyID:         familyID,
 			PersonID:         personID,
-			PersonName:       personName,
+			PersonGivenName:  personGivenName.String,
+			PersonSurname:    personSurname.String,
 			RelationshipType: domain.ChildRelationType(relType),
 		}
 		if sequence.Valid {
@@ -1088,7 +1132,8 @@ func (s *ReadModelStore) GetChildrenOfFamily(ctx context.Context, familyID uuid.
 // GetChildFamily returns the family where the person is a child.
 func (s *ReadModelStore) GetChildFamily(ctx context.Context, personID uuid.UUID) (*repository.FamilyReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT f.id, f.partner1_id, f.partner1_name, f.partner2_id, f.partner2_name,
+		SELECT f.id, f.partner1_id, f.partner1_given_name, f.partner1_surname,
+			   f.partner2_id, f.partner2_given_name, f.partner2_surname,
 			   f.relationship_type, f.marriage_date_raw, f.marriage_date_sort, f.marriage_place,
 			   f.marriage_place_lat, f.marriage_place_long,
 			   f.child_count, f.version, f.updated_at
@@ -1103,13 +1148,15 @@ func (s *ReadModelStore) GetChildFamily(ctx context.Context, personID uuid.UUID)
 // SaveFamilyChild saves a family child relationship.
 func (s *ReadModelStore) SaveFamilyChild(ctx context.Context, child *repository.FamilyChildReadModel) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO family_children (family_id, person_id, person_name, relationship_type, sequence)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO family_children (family_id, person_id, person_given_name, person_surname, relationship_type, sequence)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT(family_id, person_id) DO UPDATE SET
-			person_name = EXCLUDED.person_name,
+			person_given_name = EXCLUDED.person_given_name,
+			person_surname = EXCLUDED.person_surname,
 			relationship_type = EXCLUDED.relationship_type,
 			sequence = EXCLUDED.sequence
-	`, child.FamilyID, child.PersonID, child.PersonName, string(child.RelationshipType), nullableInt(child.Sequence))
+	`, child.FamilyID, child.PersonID, nullableString(child.PersonGivenName), nullableString(child.PersonSurname),
+		string(child.RelationshipType), nullableInt(child.Sequence))
 
 	return err
 }
@@ -1273,7 +1320,8 @@ func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 	var (
 		id                                      uuid.UUID
 		partner1ID, partner2ID                  sql.NullString
-		partner1Name, partner2Name              sql.NullString
+		partner1GivenName, partner1Surname      sql.NullString
+		partner2GivenName, partner2Surname      sql.NullString
 		relType, marriageDateRaw, marriagePlace sql.NullString
 		marriagePlaceLat, marriagePlaceLong     sql.NullString
 		marriageDateSort                        sql.NullTime
@@ -1282,7 +1330,9 @@ func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 		updatedAt                               time.Time
 	)
 
-	err := row.Scan(&id, &partner1ID, &partner1Name, &partner2ID, &partner2Name,
+	err := row.Scan(&id,
+		&partner1ID, &partner1GivenName, &partner1Surname,
+		&partner2ID, &partner2GivenName, &partner2Surname,
 		&relType, &marriageDateRaw, &marriageDateSort, &marriagePlace,
 		&marriagePlaceLat, &marriagePlaceLong,
 		&childCount, &version, &updatedAt)
@@ -1295,15 +1345,17 @@ func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 	}
 
 	f := &repository.FamilyReadModel{
-		ID:               id,
-		Partner1Name:     partner1Name.String,
-		Partner2Name:     partner2Name.String,
-		RelationshipType: domain.RelationType(relType.String),
-		MarriageDateRaw:  marriageDateRaw.String,
-		MarriagePlace:    marriagePlace.String,
-		ChildCount:       childCount,
-		Version:          version,
-		UpdatedAt:        updatedAt,
+		ID:                id,
+		Partner1GivenName: partner1GivenName.String,
+		Partner1Surname:   partner1Surname.String,
+		Partner2GivenName: partner2GivenName.String,
+		Partner2Surname:   partner2Surname.String,
+		RelationshipType:  domain.RelationType(relType.String),
+		MarriageDateRaw:   marriageDateRaw.String,
+		MarriagePlace:     marriagePlace.String,
+		ChildCount:        childCount,
+		Version:           version,
+		UpdatedAt:         updatedAt,
 	}
 
 	if partner1ID.Valid {

--- a/internal/repository/postgres/readmodel_test.go
+++ b/internal/repository/postgres/readmodel_test.go
@@ -277,17 +277,19 @@ func TestReadModelStore_FamilyCRUD(t *testing.T) {
 	// Create family
 	familyID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:               familyID,
-		Partner1ID:       &partner1ID,
-		Partner1Name:     "John Doe",
-		Partner2ID:       &partner2ID,
-		Partner2Name:     "Jane Doe",
-		RelationshipType: domain.RelationMarriage,
-		MarriageDateRaw:  "15 JUN 1875",
-		MarriagePlace:    "Boston, MA",
-		ChildCount:       0,
-		Version:          1,
-		UpdatedAt:        now,
+		ID:                familyID,
+		Partner1ID:        &partner1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &partner2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		RelationshipType:  domain.RelationMarriage,
+		MarriageDateRaw:   "15 JUN 1875",
+		MarriagePlace:     "Boston, MA",
+		ChildCount:        0,
+		Version:           1,
+		UpdatedAt:         now,
 	}
 
 	err := store.SaveFamily(ctx, family)
@@ -304,8 +306,8 @@ func TestReadModelStore_FamilyCRUD(t *testing.T) {
 		t.Fatal("family not found")
 	}
 
-	if retrieved.Partner1Name != "John Doe" {
-		t.Errorf("expected Partner1Name John Doe, got %s", retrieved.Partner1Name)
+	if retrieved.Partner1GivenName != "John" || retrieved.Partner1Surname != "Doe" {
+		t.Errorf("expected Partner1 John/Doe, got %q/%q", retrieved.Partner1GivenName, retrieved.Partner1Surname)
 	}
 	if retrieved.RelationshipType != domain.RelationMarriage {
 		t.Errorf("expected RelationshipType married, got %s", retrieved.RelationshipType)
@@ -367,14 +369,16 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	// Create family
 	familyID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:           familyID,
-		Partner1ID:   &partner1ID,
-		Partner1Name: "John Doe",
-		Partner2ID:   &partner2ID,
-		Partner2Name: "Jane Doe",
-		ChildCount:   0,
-		Version:      1,
-		UpdatedAt:    now,
+		ID:                familyID,
+		Partner1ID:        &partner1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &partner2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		ChildCount:        0,
+		Version:           1,
+		UpdatedAt:         now,
 	}
 
 	if err := store.SaveFamily(ctx, family); err != nil {
@@ -386,7 +390,8 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	child := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Jimmy Doe",
+		PersonGivenName:  "Jimmy",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 		Sequence:         &seq,
 	}
@@ -403,8 +408,8 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	if len(children) != 1 {
 		t.Fatalf("expected 1 child, got %d", len(children))
 	}
-	if children[0].PersonName != "Jimmy Doe" {
-		t.Errorf("expected child name Jimmy Doe, got %s", children[0].PersonName)
+	if children[0].PersonGivenName != "Jimmy" || children[0].PersonSurname != "Doe" {
+		t.Errorf("expected child Jimmy/Doe, got %q/%q", children[0].PersonGivenName, children[0].PersonSurname)
 	}
 
 	// Get child family
@@ -547,14 +552,16 @@ func TestReadModelStore_GetChildrenOfFamily(t *testing.T) {
 	// Create family
 	familyID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:           familyID,
-		Partner1ID:   &partner1ID,
-		Partner1Name: "John Doe",
-		Partner2ID:   &partner2ID,
-		Partner2Name: "Jane Doe",
-		ChildCount:   2,
-		Version:      1,
-		UpdatedAt:    now,
+		ID:                familyID,
+		Partner1ID:        &partner1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &partner2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		ChildCount:        2,
+		Version:           1,
+		UpdatedAt:         now,
 	}
 
 	if err := store.SaveFamily(ctx, family); err != nil {
@@ -564,8 +571,8 @@ func TestReadModelStore_GetChildrenOfFamily(t *testing.T) {
 	// Add children
 	seq1, seq2 := 1, 2
 	children := []*repository.FamilyChildReadModel{
-		{FamilyID: familyID, PersonID: child1ID, PersonName: "Jimmy Doe", RelationshipType: domain.ChildBiological, Sequence: &seq1},
-		{FamilyID: familyID, PersonID: child2ID, PersonName: "Jenny Doe", RelationshipType: domain.ChildBiological, Sequence: &seq2},
+		{FamilyID: familyID, PersonID: child1ID, PersonGivenName: "Jimmy", PersonSurname: "Doe", RelationshipType: domain.ChildBiological, Sequence: &seq1},
+		{FamilyID: familyID, PersonID: child2ID, PersonGivenName: "Jenny", PersonSurname: "Doe", RelationshipType: domain.ChildBiological, Sequence: &seq2},
 	}
 
 	for _, c := range children {

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -270,32 +270,36 @@ func (p *Projector) projectFamilyCreated(ctx context.Context, e domain.FamilyCre
 		}
 	}
 
-	// Get partner names if available
-	var partner1Name, partner2Name string
+	// Get partner names if available (split into given/surname for API contract)
+	var partner1GivenName, partner1Surname, partner2GivenName, partner2Surname string
 	if e.Partner1ID != nil {
 		if p1, _ := p.readStore.GetPerson(ctx, *e.Partner1ID); p1 != nil {
-			partner1Name = p1.FullName
+			partner1GivenName = p1.GivenName
+			partner1Surname = p1.Surname
 		}
 	}
 	if e.Partner2ID != nil {
 		if p2, _ := p.readStore.GetPerson(ctx, *e.Partner2ID); p2 != nil {
-			partner2Name = p2.FullName
+			partner2GivenName = p2.GivenName
+			partner2Surname = p2.Surname
 		}
 	}
 
 	family := &FamilyReadModel{
-		ID:               e.FamilyID,
-		Partner1ID:       e.Partner1ID,
-		Partner1Name:     partner1Name,
-		Partner2ID:       e.Partner2ID,
-		Partner2Name:     partner2Name,
-		RelationshipType: e.RelationshipType,
-		MarriageDateRaw:  marriageDateRaw,
-		MarriageDateSort: marriageDateSort,
-		MarriagePlace:    e.MarriagePlace,
-		ChildCount:       0,
-		Version:          version,
-		UpdatedAt:        e.OccurredAt(),
+		ID:                e.FamilyID,
+		Partner1ID:        e.Partner1ID,
+		Partner1GivenName: partner1GivenName,
+		Partner1Surname:   partner1Surname,
+		Partner2ID:        e.Partner2ID,
+		Partner2GivenName: partner2GivenName,
+		Partner2Surname:   partner2Surname,
+		RelationshipType:  e.RelationshipType,
+		MarriageDateRaw:   marriageDateRaw,
+		MarriageDateSort:  marriageDateSort,
+		MarriagePlace:     e.MarriagePlace,
+		ChildCount:        0,
+		Version:           version,
+		UpdatedAt:         e.OccurredAt(),
 	}
 
 	return p.readStore.SaveFamily(ctx, family)
@@ -346,16 +350,18 @@ func (p *Projector) projectFamilyUpdated(ctx context.Context, e domain.FamilyUpd
 }
 
 func (p *Projector) projectChildLinked(ctx context.Context, e domain.ChildLinkedToFamily) error {
-	// Get child name
-	var childName string
+	// Get child name (split into given/surname)
+	var childGivenName, childSurname string
 	if child, _ := p.readStore.GetPerson(ctx, e.PersonID); child != nil {
-		childName = child.FullName
+		childGivenName = child.GivenName
+		childSurname = child.Surname
 	}
 
 	fc := &FamilyChildReadModel{
 		FamilyID:         e.FamilyID,
 		PersonID:         e.PersonID,
-		PersonName:       childName,
+		PersonGivenName:  childGivenName,
+		PersonSurname:    childSurname,
 		RelationshipType: e.RelationshipType,
 		Sequence:         e.Sequence,
 	}
@@ -1219,11 +1225,13 @@ func (p *Projector) projectPersonMerged(ctx context.Context, e domain.PersonMerg
 	for _, family := range families {
 		if family.Partner1ID != nil && *family.Partner1ID == e.MergedID {
 			family.Partner1ID = &e.SurvivorID
-			family.Partner1Name = survivor.FullName
+			family.Partner1GivenName = survivor.GivenName
+			family.Partner1Surname = survivor.Surname
 		}
 		if family.Partner2ID != nil && *family.Partner2ID == e.MergedID {
 			family.Partner2ID = &e.SurvivorID
-			family.Partner2Name = survivor.FullName
+			family.Partner2GivenName = survivor.GivenName
+			family.Partner2Surname = survivor.Surname
 		}
 		family.UpdatedAt = e.OccurredAt()
 		if err := p.readStore.SaveFamily(ctx, &family); err != nil {
@@ -1266,7 +1274,8 @@ func (p *Projector) projectPersonMerged(ctx context.Context, e domain.PersonMerg
 				fc := &FamilyChildReadModel{
 					FamilyID:         mergedChildFamily.ID,
 					PersonID:         e.SurvivorID,
-					PersonName:       survivor.FullName,
+					PersonGivenName:  survivor.GivenName,
+					PersonSurname:    survivor.Surname,
 					RelationshipType: domain.ChildBiological, // Default, could be improved
 				}
 				if err := p.readStore.SaveFamilyChild(ctx, fc); err != nil {

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -318,9 +318,15 @@ func (p *Projector) projectFamilyUpdated(ctx context.Context, e domain.FamilyUpd
 	for key, value := range e.Changes {
 		switch key {
 		case "partner1_id":
-			// Handle partner ID changes - complex, may need to fetch new name
+			newID, given, surname := p.resolvePartnerChange(ctx, value)
+			family.Partner1ID = newID
+			family.Partner1GivenName = given
+			family.Partner1Surname = surname
 		case "partner2_id":
-			// Handle partner ID changes
+			newID, given, surname := p.resolvePartnerChange(ctx, value)
+			family.Partner2ID = newID
+			family.Partner2GivenName = given
+			family.Partner2Surname = surname
 		case "relationship_type":
 			if v, ok := value.(string); ok {
 				family.RelationshipType = domain.RelationType(v)
@@ -347,6 +353,27 @@ func (p *Projector) projectFamilyUpdated(ctx context.Context, e domain.FamilyUpd
 	family.UpdatedAt = e.OccurredAt()
 
 	return p.readStore.SaveFamily(ctx, family)
+}
+
+// resolvePartnerChange resolves a partner_id value from a FamilyUpdated.Changes
+// map into the new partner ID and split name fields. Values arrive as untyped
+// JSON: a string UUID for a swap, nil/empty to clear. Unknown person IDs leave
+// the names empty rather than failing — the name will be backfilled the next
+// time the projection sees the person.
+func (p *Projector) resolvePartnerChange(ctx context.Context, value any) (*uuid.UUID, string, string) {
+	s, ok := value.(string)
+	if !ok || s == "" {
+		return nil, "", ""
+	}
+	parsed, err := uuid.Parse(s)
+	if err != nil {
+		return nil, "", ""
+	}
+	person, _ := p.readStore.GetPerson(ctx, parsed)
+	if person == nil {
+		return &parsed, "", ""
+	}
+	return &parsed, person.GivenName, person.Surname
 }
 
 func (p *Projector) projectChildLinked(ctx context.Context, e domain.ChildLinkedToFamily) error {

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -384,6 +384,57 @@ func TestProjector_FamilyUpdated(t *testing.T) {
 	}
 }
 
+func TestProjector_FamilyUpdated_PartnerSwap(t *testing.T) {
+	// Issue #483: changing partner1_id / partner2_id via FamilyUpdated must
+	// refresh the denormalized split-name fields, otherwise the family row
+	// keeps showing the former partner's name next to the new partner's ID.
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Seed three persons: the initial partners and a replacement.
+	p1 := &domain.Person{ID: uuid.New(), GivenName: "John", Surname: "Doe"}
+	p2 := &domain.Person{ID: uuid.New(), GivenName: "Jane", Surname: "Doe"}
+	p3 := &domain.Person{ID: uuid.New(), GivenName: "Mary", Surname: "Smith"}
+	for i, p := range []*domain.Person{p1, p2, p3} {
+		if err := projector.Project(ctx, domain.NewPersonCreated(p), int64(i+1)); err != nil {
+			t.Fatalf("seed person %d: %v", i, err)
+		}
+	}
+
+	// Create the family with p1 and p2.
+	family := domain.NewFamily()
+	family.Partner1ID = &p1.ID
+	family.Partner2ID = &p2.ID
+	family.RelationshipType = domain.RelationMarriage
+	if err := projector.Project(ctx, domain.NewFamilyCreated(family), 4); err != nil {
+		t.Fatalf("create family: %v", err)
+	}
+
+	// Swap partner1 to p3.
+	update := domain.NewFamilyUpdated(family.ID, map[string]any{
+		"partner1_id": p3.ID.String(),
+	})
+	if err := projector.Project(ctx, update, 5); err != nil {
+		t.Fatalf("project update: %v", err)
+	}
+
+	rm, err := readStore.GetFamily(ctx, family.ID)
+	if err != nil || rm == nil {
+		t.Fatalf("get family: %v (rm=%v)", err, rm)
+	}
+	if rm.Partner1ID == nil || *rm.Partner1ID != p3.ID {
+		t.Errorf("Partner1ID = %v, want %v", rm.Partner1ID, p3.ID)
+	}
+	if rm.Partner1GivenName != "Mary" || rm.Partner1Surname != "Smith" {
+		t.Errorf("Partner1 name = %q %q, want Mary Smith", rm.Partner1GivenName, rm.Partner1Surname)
+	}
+	// Partner2 must be untouched.
+	if rm.Partner2GivenName != "Jane" || rm.Partner2Surname != "Doe" {
+		t.Errorf("Partner2 name = %q %q, want Jane Doe", rm.Partner2GivenName, rm.Partner2Surname)
+	}
+}
+
 func TestProjector_FamilyUpdated_NonExistent(t *testing.T) {
 	readStore := memory.NewReadModelStore()
 	projector := repository.NewProjector(readStore)

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -157,11 +157,11 @@ func TestProjector_FamilyCreated(t *testing.T) {
 	if rm == nil {
 		t.Fatal("Family not found in read model")
 	}
-	if rm.Partner1Name != "John Doe" {
-		t.Errorf("Partner1Name = %s, want John Doe", rm.Partner1Name)
+	if rm.Partner1GivenName != "John" || rm.Partner1Surname != "Doe" {
+		t.Errorf("Partner1 split = %q/%q, want John/Doe", rm.Partner1GivenName, rm.Partner1Surname)
 	}
-	if rm.Partner2Name != "Jane Doe" {
-		t.Errorf("Partner2Name = %s, want Jane Doe", rm.Partner2Name)
+	if rm.Partner2GivenName != "Jane" || rm.Partner2Surname != "Doe" {
+		t.Errorf("Partner2 split = %q/%q, want Jane/Doe", rm.Partner2GivenName, rm.Partner2Surname)
 	}
 	if rm.RelationshipType != domain.RelationMarriage {
 		t.Errorf("RelationshipType = %s, want marriage", rm.RelationshipType)
@@ -2212,11 +2212,11 @@ func TestProjector_FamilyCreated_NoPartners(t *testing.T) {
 	if rm == nil {
 		t.Fatal("Family not found")
 	}
-	if rm.Partner1Name != "" {
-		t.Errorf("Partner1Name = %s, want empty string", rm.Partner1Name)
+	if rm.Partner1GivenName != "" || rm.Partner1Surname != "" {
+		t.Errorf("Partner1 split = %q/%q, want empty", rm.Partner1GivenName, rm.Partner1Surname)
 	}
-	if rm.Partner2Name != "" {
-		t.Errorf("Partner2Name = %s, want empty string", rm.Partner2Name)
+	if rm.Partner2GivenName != "" || rm.Partner2Surname != "" {
+		t.Errorf("Partner2 split = %q/%q, want empty", rm.Partner2GivenName, rm.Partner2Surname)
 	}
 }
 
@@ -2428,8 +2428,8 @@ func TestProjector_PersonMerged_FamilyPartnerUpdate(t *testing.T) {
 
 	// Verify initial family state
 	familyRM, _ := readStore.GetFamily(ctx, family.ID)
-	if familyRM.Partner1Name != "Johnny Doe" {
-		t.Errorf("Initial Partner1Name = %s, want 'Johnny Doe'", familyRM.Partner1Name)
+	if familyRM.Partner1GivenName != "Johnny" || familyRM.Partner1Surname != "Doe" {
+		t.Errorf("Initial Partner1 split = %q/%q, want Johnny/Doe", familyRM.Partner1GivenName, familyRM.Partner1Surname)
 	}
 
 	// Merge merged into survivor
@@ -2455,8 +2455,8 @@ func TestProjector_PersonMerged_FamilyPartnerUpdate(t *testing.T) {
 	if familyRM.Partner1ID == nil || *familyRM.Partner1ID != survivor.ID {
 		t.Error("Partner1ID should be updated to survivor ID")
 	}
-	if familyRM.Partner1Name != "John Doe" {
-		t.Errorf("Partner1Name = %s, want 'John Doe'", familyRM.Partner1Name)
+	if familyRM.Partner1GivenName != "John" || familyRM.Partner1Surname != "Doe" {
+		t.Errorf("Partner1 split = %q/%q, want John/Doe", familyRM.Partner1GivenName, familyRM.Partner1Surname)
 	}
 }
 
@@ -2505,8 +2505,8 @@ func TestProjector_PersonMerged_FamilyPartner2Update(t *testing.T) {
 	if familyRM.Partner2ID == nil || *familyRM.Partner2ID != survivor.ID {
 		t.Error("Partner2ID should be updated to survivor ID")
 	}
-	if familyRM.Partner2Name != "Jane Doe" {
-		t.Errorf("Partner2Name = %s, want 'Jane Doe'", familyRM.Partner2Name)
+	if familyRM.Partner2GivenName != "Jane" || familyRM.Partner2Surname != "Doe" {
+		t.Errorf("Partner2 split = %q/%q, want Jane/Doe", familyRM.Partner2GivenName, familyRM.Partner2Surname)
 	}
 }
 

--- a/internal/repository/readmodel.go
+++ b/internal/repository/readmodel.go
@@ -39,9 +39,11 @@ type PersonReadModel struct {
 type FamilyReadModel struct {
 	ID                uuid.UUID           `json:"id"`
 	Partner1ID        *uuid.UUID          `json:"partner1_id,omitempty"`
-	Partner1Name      string              `json:"partner1_name,omitempty"`
+	Partner1GivenName string              `json:"partner1_given_name,omitempty"`
+	Partner1Surname   string              `json:"partner1_surname,omitempty"`
 	Partner2ID        *uuid.UUID          `json:"partner2_id,omitempty"`
-	Partner2Name      string              `json:"partner2_name,omitempty"`
+	Partner2GivenName string              `json:"partner2_given_name,omitempty"`
+	Partner2Surname   string              `json:"partner2_surname,omitempty"`
 	RelationshipType  domain.RelationType `json:"relationship_type,omitempty"`
 	MarriageDateRaw   string              `json:"marriage_date_raw,omitempty"`
 	MarriageDateSort  *time.Time          `json:"marriage_date_sort,omitempty"`
@@ -57,7 +59,8 @@ type FamilyReadModel struct {
 type FamilyChildReadModel struct {
 	FamilyID         uuid.UUID                `json:"family_id"`
 	PersonID         uuid.UUID                `json:"person_id"`
-	PersonName       string                   `json:"person_name"`
+	PersonGivenName  string                   `json:"person_given_name"`
+	PersonSurname    string                   `json:"person_surname"`
 	RelationshipType domain.ChildRelationType `json:"relationship_type"`
 	Sequence         *int                     `json:"sequence,omitempty"`
 }

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -62,9 +62,11 @@ func (s *ReadModelStore) createTables() error {
 		CREATE TABLE IF NOT EXISTS families (
 			id TEXT PRIMARY KEY,
 			partner1_id TEXT,
-			partner1_name TEXT,
+			partner1_given_name TEXT,
+			partner1_surname TEXT,
 			partner2_id TEXT,
-			partner2_name TEXT,
+			partner2_given_name TEXT,
+			partner2_surname TEXT,
 			relationship_type TEXT,
 			marriage_date_raw TEXT,
 			marriage_date_sort TEXT,
@@ -83,7 +85,8 @@ func (s *ReadModelStore) createTables() error {
 		CREATE TABLE IF NOT EXISTS family_children (
 			family_id TEXT NOT NULL,
 			person_id TEXT NOT NULL,
-			person_name TEXT,
+			person_given_name TEXT,
+			person_surname TEXT,
 			relationship_type TEXT NOT NULL DEFAULT 'biological',
 			sequence INTEGER,
 			PRIMARY KEY (family_id, person_id),
@@ -422,6 +425,37 @@ func (s *ReadModelStore) runMigrations() {
 
 	// Add is_negated column for negative assertions / NO tags (issue #222)
 	_, _ = s.db.Exec(`ALTER TABLE events ADD COLUMN is_negated INTEGER NOT NULL DEFAULT 0`)
+
+	// Split family partner names and family-child names into given_name / surname (issue #483).
+	// SQLite ALTER TABLE ADD COLUMN has no IF NOT EXISTS; rely on the existing _,_ = swallowing.
+	// Legacy columns (partner1_name/partner2_name/person_name) are intentionally NOT dropped
+	// on SQLite — project convention is to leave dead columns rather than rebuild tables.
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN partner1_given_name TEXT`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN partner1_surname TEXT`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN partner2_given_name TEXT`)
+	_, _ = s.db.Exec(`ALTER TABLE families ADD COLUMN partner2_surname TEXT`)
+	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN person_given_name TEXT`)
+	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN person_surname TEXT`)
+
+	// Backfill split fields from persons; idempotent via IS NULL guard.
+	_, _ = s.db.Exec(`
+		UPDATE families SET
+			partner1_given_name = (SELECT given_name FROM persons WHERE id = partner1_id),
+			partner1_surname    = (SELECT surname    FROM persons WHERE id = partner1_id)
+		WHERE partner1_id IS NOT NULL AND partner1_given_name IS NULL
+	`)
+	_, _ = s.db.Exec(`
+		UPDATE families SET
+			partner2_given_name = (SELECT given_name FROM persons WHERE id = partner2_id),
+			partner2_surname    = (SELECT surname    FROM persons WHERE id = partner2_id)
+		WHERE partner2_id IS NOT NULL AND partner2_given_name IS NULL
+	`)
+	_, _ = s.db.Exec(`
+		UPDATE family_children SET
+			person_given_name = (SELECT given_name FROM persons WHERE id = person_id),
+			person_surname    = (SELECT surname    FROM persons WHERE id = person_id)
+		WHERE person_id IS NOT NULL AND person_given_name IS NULL
+	`)
 }
 
 // tryCreateFTS5 attempts to create FTS5 virtual table for full-text search.
@@ -1254,7 +1288,8 @@ func scanPersonNameRow(rows *sql.Rows) (*repository.PersonNameReadModel, error) 
 // GetFamily retrieves a family by ID.
 func (s *ReadModelStore) GetFamily(ctx context.Context, id uuid.UUID) (*repository.FamilyReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -1273,7 +1308,8 @@ func (s *ReadModelStore) ListFamilies(ctx context.Context, opts repository.ListO
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -1301,7 +1337,8 @@ func (s *ReadModelStore) ListFamilies(ctx context.Context, opts repository.ListO
 // GetFamiliesForPerson returns all families where the person is a partner.
 func (s *ReadModelStore) GetFamiliesForPerson(ctx context.Context, personID uuid.UUID) ([]repository.FamilyReadModel, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, partner1_id, partner1_name, partner2_id, partner2_name,
+		SELECT id, partner1_id, partner1_given_name, partner1_surname,
+			   partner2_id, partner2_given_name, partner2_surname,
 			   relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 			   marriage_place_lat, marriage_place_long,
 			   child_count, version, updated_at
@@ -1350,16 +1387,19 @@ func (s *ReadModelStore) SaveFamily(ctx context.Context, family *repository.Fami
 	}
 
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO families (id, partner1_id, partner1_name, partner2_id, partner2_name,
+		INSERT INTO families (id, partner1_id, partner1_given_name, partner1_surname,
+							  partner2_id, partner2_given_name, partner2_surname,
 							  relationship_type, marriage_date_raw, marriage_date_sort, marriage_place,
 							  marriage_place_lat, marriage_place_long,
 							  child_count, version, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			partner1_id = excluded.partner1_id,
-			partner1_name = excluded.partner1_name,
+			partner1_given_name = excluded.partner1_given_name,
+			partner1_surname = excluded.partner1_surname,
 			partner2_id = excluded.partner2_id,
-			partner2_name = excluded.partner2_name,
+			partner2_given_name = excluded.partner2_given_name,
+			partner2_surname = excluded.partner2_surname,
 			relationship_type = excluded.relationship_type,
 			marriage_date_raw = excluded.marriage_date_raw,
 			marriage_date_sort = excluded.marriage_date_sort,
@@ -1369,7 +1409,9 @@ func (s *ReadModelStore) SaveFamily(ctx context.Context, family *repository.Fami
 			child_count = excluded.child_count,
 			version = excluded.version,
 			updated_at = excluded.updated_at
-	`, family.ID.String(), partner1ID, family.Partner1Name, partner2ID, family.Partner2Name,
+	`, family.ID.String(),
+		partner1ID, family.Partner1GivenName, family.Partner1Surname,
+		partner2ID, family.Partner2GivenName, family.Partner2Surname,
 		string(family.RelationshipType), family.MarriageDateRaw, marriageDateSort, family.MarriagePlace,
 		marriagePlaceLat, marriagePlaceLong,
 		family.ChildCount, family.Version, formatTimestamp(family.UpdatedAt))
@@ -1387,10 +1429,10 @@ func (s *ReadModelStore) DeleteFamily(ctx context.Context, id uuid.UUID) error {
 // GetFamilyChildren returns all children for a family.
 func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UUID) ([]repository.FamilyChildReadModel, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT family_id, person_id, person_name, relationship_type, sequence
+		SELECT family_id, person_id, person_given_name, person_surname, relationship_type, sequence
 		FROM family_children
 		WHERE family_id = ?
-		ORDER BY sequence, person_name
+		ORDER BY sequence, person_surname, person_given_name
 	`, familyID.String())
 	if err != nil {
 		return nil, fmt.Errorf("query family children: %w", err)
@@ -1400,10 +1442,11 @@ func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UU
 	var children []repository.FamilyChildReadModel
 	for rows.Next() {
 		var (
-			familyIDStr, personIDStr, personName, relType string
-			sequence                                      sql.NullInt64
+			familyIDStr, personIDStr, relType string
+			personGivenName, personSurname    sql.NullString
+			sequence                          sql.NullInt64
 		)
-		err := rows.Scan(&familyIDStr, &personIDStr, &personName, &relType, &sequence)
+		err := rows.Scan(&familyIDStr, &personIDStr, &personGivenName, &personSurname, &relType, &sequence)
 		if err != nil {
 			return nil, fmt.Errorf("scan family child: %w", err)
 		}
@@ -1414,7 +1457,8 @@ func (s *ReadModelStore) GetFamilyChildren(ctx context.Context, familyID uuid.UU
 		child := repository.FamilyChildReadModel{
 			FamilyID:         fID,
 			PersonID:         pID,
-			PersonName:       personName,
+			PersonGivenName:  personGivenName.String,
+			PersonSurname:    personSurname.String,
 			RelationshipType: domain.ChildRelationType(relType),
 		}
 		if sequence.Valid {
@@ -1460,7 +1504,8 @@ func (s *ReadModelStore) GetChildrenOfFamily(ctx context.Context, familyID uuid.
 // GetChildFamily returns the family where the person is a child.
 func (s *ReadModelStore) GetChildFamily(ctx context.Context, personID uuid.UUID) (*repository.FamilyReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT f.id, f.partner1_id, f.partner1_name, f.partner2_id, f.partner2_name,
+		SELECT f.id, f.partner1_id, f.partner1_given_name, f.partner1_surname,
+			   f.partner2_id, f.partner2_given_name, f.partner2_surname,
 			   f.relationship_type, f.marriage_date_raw, f.marriage_date_sort, f.marriage_place,
 			   f.marriage_place_lat, f.marriage_place_long,
 			   f.child_count, f.version, f.updated_at
@@ -1480,13 +1525,16 @@ func (s *ReadModelStore) SaveFamilyChild(ctx context.Context, child *repository.
 	}
 
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO family_children (family_id, person_id, person_name, relationship_type, sequence)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO family_children (family_id, person_id, person_given_name, person_surname, relationship_type, sequence)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(family_id, person_id) DO UPDATE SET
-			person_name = excluded.person_name,
+			person_given_name = excluded.person_given_name,
+			person_surname = excluded.person_surname,
 			relationship_type = excluded.relationship_type,
 			sequence = excluded.sequence
-	`, child.FamilyID.String(), child.PersonID.String(), child.PersonName, string(child.RelationshipType), sequence)
+	`, child.FamilyID.String(), child.PersonID.String(),
+		child.PersonGivenName, child.PersonSurname,
+		string(child.RelationshipType), sequence)
 
 	return err
 }
@@ -1663,7 +1711,9 @@ func scanPersonRow(rows *sql.Rows) (*repository.PersonReadModel, error) {
 func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 	var (
 		idStr                                                     string
-		partner1ID, partner1Name, partner2ID, partner2Name        sql.NullString
+		partner1ID, partner2ID                                    sql.NullString
+		partner1GivenName, partner1Surname                        sql.NullString
+		partner2GivenName, partner2Surname                        sql.NullString
 		relType, marriageDateRaw, marriageDateSort, marriagePlace sql.NullString
 		marriagePlaceLat, marriagePlaceLong                       sql.NullString
 		childCount                                                int
@@ -1671,7 +1721,9 @@ func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 		updatedAt                                                 string
 	)
 
-	err := row.Scan(&idStr, &partner1ID, &partner1Name, &partner2ID, &partner2Name,
+	err := row.Scan(&idStr,
+		&partner1ID, &partner1GivenName, &partner1Surname,
+		&partner2ID, &partner2GivenName, &partner2Surname,
 		&relType, &marriageDateRaw, &marriageDateSort, &marriagePlace,
 		&marriagePlaceLat, &marriagePlaceLong,
 		&childCount, &version, &updatedAt)
@@ -1685,14 +1737,16 @@ func scanFamily(row rowScanner) (*repository.FamilyReadModel, error) {
 
 	id, _ := uuid.Parse(idStr)
 	f := &repository.FamilyReadModel{
-		ID:               id,
-		Partner1Name:     partner1Name.String,
-		Partner2Name:     partner2Name.String,
-		RelationshipType: domain.RelationType(relType.String),
-		MarriageDateRaw:  marriageDateRaw.String,
-		MarriagePlace:    marriagePlace.String,
-		ChildCount:       childCount,
-		Version:          version,
+		ID:                id,
+		Partner1GivenName: partner1GivenName.String,
+		Partner1Surname:   partner1Surname.String,
+		Partner2GivenName: partner2GivenName.String,
+		Partner2Surname:   partner2Surname.String,
+		RelationshipType:  domain.RelationType(relType.String),
+		MarriageDateRaw:   marriageDateRaw.String,
+		MarriagePlace:     marriagePlace.String,
+		ChildCount:        childCount,
+		Version:           version,
 	}
 
 	if partner1ID.Valid {

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -438,22 +438,25 @@ func (s *ReadModelStore) runMigrations() {
 	_, _ = s.db.Exec(`ALTER TABLE family_children ADD COLUMN person_surname TEXT`)
 
 	// Backfill split fields from persons; idempotent via IS NULL guard.
+	// COALESCE the subquery to '' so an orphan partner_id (no matching persons row)
+	// converges to a written empty string rather than NULL, which would otherwise
+	// re-trigger the backfill on every startup.
 	_, _ = s.db.Exec(`
 		UPDATE families SET
-			partner1_given_name = (SELECT given_name FROM persons WHERE id = partner1_id),
-			partner1_surname    = (SELECT surname    FROM persons WHERE id = partner1_id)
+			partner1_given_name = COALESCE((SELECT given_name FROM persons WHERE id = partner1_id), ''),
+			partner1_surname    = COALESCE((SELECT surname    FROM persons WHERE id = partner1_id), '')
 		WHERE partner1_id IS NOT NULL AND partner1_given_name IS NULL
 	`)
 	_, _ = s.db.Exec(`
 		UPDATE families SET
-			partner2_given_name = (SELECT given_name FROM persons WHERE id = partner2_id),
-			partner2_surname    = (SELECT surname    FROM persons WHERE id = partner2_id)
+			partner2_given_name = COALESCE((SELECT given_name FROM persons WHERE id = partner2_id), ''),
+			partner2_surname    = COALESCE((SELECT surname    FROM persons WHERE id = partner2_id), '')
 		WHERE partner2_id IS NOT NULL AND partner2_given_name IS NULL
 	`)
 	_, _ = s.db.Exec(`
 		UPDATE family_children SET
-			person_given_name = (SELECT given_name FROM persons WHERE id = person_id),
-			person_surname    = (SELECT surname    FROM persons WHERE id = person_id)
+			person_given_name = COALESCE((SELECT given_name FROM persons WHERE id = person_id), ''),
+			person_surname    = COALESCE((SELECT surname    FROM persons WHERE id = person_id), '')
 		WHERE person_id IS NOT NULL AND person_given_name IS NULL
 	`)
 }

--- a/internal/repository/sqlite/readmodel_test.go
+++ b/internal/repository/sqlite/readmodel_test.go
@@ -287,17 +287,19 @@ func TestReadModelStore_FamilyCRUD(t *testing.T) {
 	familyID := uuid.New()
 	marriageDate := time.Date(1875, 6, 15, 0, 0, 0, 0, time.UTC)
 	family := &repository.FamilyReadModel{
-		ID:               familyID,
-		Partner1ID:       &person1ID,
-		Partner1Name:     "John Doe",
-		Partner2ID:       &person2ID,
-		Partner2Name:     "Jane Doe",
-		RelationshipType: domain.RelationMarriage,
-		MarriageDateRaw:  "15 JUN 1875",
-		MarriageDateSort: &marriageDate,
-		MarriagePlace:    "Springfield, IL",
-		Version:          1,
-		UpdatedAt:        time.Now(),
+		ID:                familyID,
+		Partner1ID:        &person1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &person2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		RelationshipType:  domain.RelationMarriage,
+		MarriageDateRaw:   "15 JUN 1875",
+		MarriageDateSort:  &marriageDate,
+		MarriagePlace:     "Springfield, IL",
+		Version:           1,
+		UpdatedAt:         time.Now(),
 	}
 
 	err := store.SaveFamily(ctx, family)
@@ -314,8 +316,8 @@ func TestReadModelStore_FamilyCRUD(t *testing.T) {
 		t.Fatal("expected family, got nil")
 	}
 
-	if retrieved.Partner1Name != "John Doe" {
-		t.Errorf("expected Partner1Name John Doe, got %s", retrieved.Partner1Name)
+	if retrieved.Partner1GivenName != "John" || retrieved.Partner1Surname != "Doe" {
+		t.Errorf("expected Partner1 John/Doe, got %q/%q", retrieved.Partner1GivenName, retrieved.Partner1Surname)
 	}
 	if retrieved.RelationshipType != domain.RelationMarriage {
 		t.Errorf("expected RelationshipType marriage, got %s", retrieved.RelationshipType)
@@ -373,14 +375,16 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	// Create family
 	familyID := uuid.New()
 	family := &repository.FamilyReadModel{
-		ID:           familyID,
-		Partner1ID:   &parent1ID,
-		Partner1Name: "John Doe",
-		Partner2ID:   &parent2ID,
-		Partner2Name: "Jane Doe",
-		ChildCount:   0,
-		Version:      1,
-		UpdatedAt:    time.Now(),
+		ID:                familyID,
+		Partner1ID:        &parent1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &parent2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		ChildCount:        0,
+		Version:           1,
+		UpdatedAt:         time.Now(),
 	}
 	store.SaveFamily(ctx, family)
 
@@ -389,7 +393,8 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	familyChild := &repository.FamilyChildReadModel{
 		FamilyID:         familyID,
 		PersonID:         childID,
-		PersonName:       "Bobby Doe",
+		PersonGivenName:  "Bobby",
+		PersonSurname:    "Doe",
 		RelationshipType: domain.ChildBiological,
 		Sequence:         &seq,
 	}
@@ -407,8 +412,8 @@ func TestReadModelStore_FamilyChildren(t *testing.T) {
 	if len(children) != 1 {
 		t.Fatalf("expected 1 child, got %d", len(children))
 	}
-	if children[0].PersonName != "Bobby Doe" {
-		t.Errorf("expected PersonName Bobby Doe, got %s", children[0].PersonName)
+	if children[0].PersonGivenName != "Bobby" || children[0].PersonSurname != "Doe" {
+		t.Errorf("expected child Bobby/Doe, got %q/%q", children[0].PersonGivenName, children[0].PersonSurname)
 	}
 
 	// Get child family
@@ -588,20 +593,23 @@ func TestReadModelStore_ListFamilies(t *testing.T) {
 	family2ID := uuid.New()
 
 	family1 := &repository.FamilyReadModel{
-		ID:           family1ID,
-		Partner1ID:   &person1ID,
-		Partner1Name: "John Doe",
-		Partner2ID:   &person2ID,
-		Partner2Name: "Jane Doe",
-		Version:      1,
-		UpdatedAt:    time.Now().Add(-1 * time.Hour), // Older
+		ID:                family1ID,
+		Partner1ID:        &person1ID,
+		Partner1GivenName: "John",
+		Partner1Surname:   "Doe",
+		Partner2ID:        &person2ID,
+		Partner2GivenName: "Jane",
+		Partner2Surname:   "Doe",
+		Version:           1,
+		UpdatedAt:         time.Now().Add(-1 * time.Hour), // Older
 	}
 	family2 := &repository.FamilyReadModel{
-		ID:           family2ID,
-		Partner1ID:   &person3ID,
-		Partner1Name: "Bob Smith",
-		Version:      1,
-		UpdatedAt:    time.Now(), // Newer
+		ID:                family2ID,
+		Partner1ID:        &person3ID,
+		Partner1GivenName: "Bob",
+		Partner1Surname:   "Smith",
+		Version:           1,
+		UpdatedAt:         time.Now(), // Newer
 	}
 
 	store.SaveFamily(ctx, family1)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1841,8 +1841,29 @@ export function formatGenDate(date?: GenDate): string {
 	return parts.join(' ');
 }
 
-export function formatPersonName(person: { given_name: string; surname: string }): string {
-	return `${person.given_name} ${person.surname}`;
+/**
+ * Format a person's display name from given_name + surname.
+ *
+ * Handles missing/empty fields without producing dangling spaces. Returns
+ * 'Unknown' when no usable name parts are available — matches the historical
+ * fallback used by FamilyCard before the surname field was populated by the
+ * backend (issue #483).
+ *
+ * Examples:
+ *   formatPersonName({ given_name: 'Jane', surname: 'Smith' }) -> 'Jane Smith'
+ *   formatPersonName({ given_name: 'Jane', surname: '' })      -> 'Jane'
+ *   formatPersonName({ given_name: '', surname: 'Smith' })     -> 'Smith'
+ *   formatPersonName({})                                       -> 'Unknown'
+ *   formatPersonName(null)                                     -> 'Unknown'
+ */
+export function formatPersonName(
+	person: { given_name?: string; surname?: string } | null | undefined
+): string {
+	if (!person) return 'Unknown';
+	const parts = [person.given_name, person.surname]
+		.map((s) => (s ?? '').trim())
+		.filter((s) => s.length > 0);
+	return parts.length > 0 ? parts.join(' ') : 'Unknown';
 }
 
 export function formatLifespan(person: { birth_date?: GenDate; death_date?: GenDate }): string {

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -2243,21 +2243,9 @@ export interface components {
             version: number;
         };
         FamilyDetail: components["schemas"]["Family"] & {
-            /**
-             * @description Partner 1 summary. May be absent even when partner1_id is set
-             *     if the partner's name has not been projected yet. The given_name
-             *     field carries the partner's full display name until the read
-             *     model is split into separate given/surname components; surname
-             *     will be empty.
-             */
+            /** @description Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet. */
             partner1?: components["schemas"]["PersonSummary"];
-            /**
-             * @description Partner 2 summary. May be absent even when partner2_id is set
-             *     if the partner's name has not been projected yet. The given_name
-             *     field carries the partner's full display name until the read
-             *     model is split into separate given/surname components; surname
-             *     will be empty.
-             */
+            /** @description Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet. */
             partner2?: components["schemas"]["PersonSummary"];
             children?: components["schemas"]["FamilyChild"][];
         };

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -2243,9 +2243,9 @@ export interface components {
             version: number;
         };
         FamilyDetail: components["schemas"]["Family"] & {
-            /** @description Partner 1 summary. May be absent even when partner1_id is set if the partner's name has not been projected yet. */
+            /** @description Partner 1 summary. Present whenever partner1_id is set; given_name and surname may be empty strings if the partner has no recorded name. */
             partner1?: components["schemas"]["PersonSummary"];
-            /** @description Partner 2 summary. May be absent even when partner2_id is set if the partner's name has not been projected yet. */
+            /** @description Partner 2 summary. Present whenever partner2_id is set; given_name and surname may be empty strings if the partner has no recorded name. */
             partner2?: components["schemas"]["PersonSummary"];
             children?: components["schemas"]["FamilyChild"][];
         };

--- a/web/src/lib/components/FamilyCard.svelte
+++ b/web/src/lib/components/FamilyCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { FamilyDetail } from '$lib/api/client';
-	import { formatGenDate } from '$lib/api/client';
+	import { formatGenDate, formatPersonName } from '$lib/api/client';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
 
@@ -12,8 +12,8 @@
 
 	let { family, href, onclick }: Props = $props();
 
-	const partner1Name = family.partner1?.given_name ?? 'Unknown';
-	const partner2Name = family.partner2?.given_name ?? null;
+	const partner1Name = formatPersonName(family.partner1);
+	const partner2Name = family.partner2 ? formatPersonName(family.partner2) : null;
 	const marriageDate = family.marriage_date ? formatGenDate(family.marriage_date) : null;
 	const childCount = family.child_count ?? family.children?.length ?? 0;
 </script>

--- a/web/src/lib/components/FamilyCard.test.ts
+++ b/web/src/lib/components/FamilyCard.test.ts
@@ -45,10 +45,11 @@ describe('FamilyCard', () => {
 		expect(screen.getByText('Unknown')).toBeTruthy();
 	});
 
-	it('renders an empty name verbatim rather than falling back to "Unknown"', () => {
-		// ?? (nullish coalescing) only triggers on null/undefined, not on "".
-		// A partner with a deliberately-empty name should render blank, not be
-		// mislabeled "Unknown" — which would imply the partner record is absent.
+	it('falls back to "Unknown" when partner has empty given_name and surname', () => {
+		// Issue #483: rendering now flows through formatPersonName, which trims
+		// and filters both name parts and falls back to 'Unknown' when nothing
+		// usable remains. This intentionally replaces the older ?? behavior that
+		// would render a blank partner.
 		const family: FamilyDetail = {
 			id: 'fam-4',
 			version: 1,
@@ -58,6 +59,24 @@ describe('FamilyCard', () => {
 
 		render(FamilyCard, { props: { family } });
 
-		expect(screen.queryByText('Unknown')).toBeNull();
+		expect(screen.getByText('Unknown')).toBeTruthy();
+	});
+
+	it('renders given_name and surname together as a single spaced string', () => {
+		// Issue #483: backend now populates real surnames on FamilyDetail.partner*.
+		// The card must combine both parts rather than reading just given_name.
+		const family: FamilyDetail = {
+			id: 'fam-5',
+			version: 1,
+			partner1_id: 'p1',
+			partner2_id: 'p2',
+			partner1: { id: 'p1', given_name: 'Jane', surname: 'Smith' },
+			partner2: { id: 'p2', given_name: 'John', surname: 'Doe' }
+		};
+
+		render(FamilyCard, { props: { family } });
+
+		expect(screen.getByText('Jane Smith')).toBeTruthy();
+		expect(screen.getByText('John Doe')).toBeTruthy();
 	});
 });

--- a/web/src/routes/import/+page.svelte
+++ b/web/src/routes/import/+page.svelte
@@ -35,8 +35,10 @@
 
 	const familyFields = [
 		{ id: 'id', label: 'ID' },
-		{ id: 'partner1_name', label: 'Partner 1 Name' },
-		{ id: 'partner2_name', label: 'Partner 2 Name' },
+		{ id: 'partner1_given_name', label: 'Partner 1 Given Name' },
+		{ id: 'partner1_surname', label: 'Partner 1 Surname' },
+		{ id: 'partner2_given_name', label: 'Partner 2 Given Name' },
+		{ id: 'partner2_surname', label: 'Partner 2 Surname' },
 		{ id: 'relationship_type', label: 'Relationship Type' },
 		{ id: 'marriage_date', label: 'Marriage Date' },
 		{ id: 'marriage_place', label: 'Marriage Place' },


### PR DESCRIPTION
## Summary

Resolves issue #483 — splits the denormalized partner and child name strings on `FamilyReadModel` and `FamilyChildReadModel` into separate `GivenName` / `Surname` pairs so the API contract for `PersonSummary.surname` is honored instead of being faked with an empty string.

- Read model, projection, postgres + sqlite storage, query layer, API converter, OpenAPI, generated code, all backend + frontend tests, and the `FamilyCard` UI are updated coherently.
- Migration adds the new columns, backfills from `persons` via JOIN, and (on postgres) drops the legacy columns inside a single transaction. SQLite keeps the legacy columns as dead columns per project convention; the backfill uses `COALESCE` so orphan IDs converge instead of re-running every startup.
- A follow-up commit addresses panel-review findings: implements the previously stubbed `projectFamilyUpdated` partner-swap branches, makes the partner visibility guard always emit a summary when the partner ID is set, extracts a shared `fullName` helper, re-adds `partner1_name` / `partner2_name` as deprecated CSV field aliases for backward compatibility, and tightens the WithData test so a surname-swap regression no longer slips past.

## Acceptance criteria (issue #483)

- [x] `PersonSummary.surname` from family list / detail / group-sheet endpoints contains the real surname
- [x] `PersonSummary.given_name` contains only the given name
- [x] Workaround comment in `partnerSummary` is removed (and the helper is renamed to take split args)
- [x] Workaround language in OpenAPI `FamilyDetail.partner1` / `partner2` descriptions is removed
- [x] Frontend `FamilyCard` (and other family-render sites) read both fields via a shared `formatPersonName` helper
- [x] Migration applies cleanly to existing PostgreSQL and SQLite databases (backfill verified, postgres now transactional)

## Test plan

- [x] `make lint` clean
- [x] `make test` (Go + 230 frontend tests) passes
- [x] `make check-coverage` ≥85% per package, 76.2% total
- [x] `make verify-generated` clean
- [x] New `TestGetFamily_ChildrenHaveSplitNames` covers child-name split end-to-end
- [x] New `TestProjector_FamilyUpdated_PartnerSwap` covers the now-implemented partner-id branch
- [x] New `TestCSVExporter_DeprecatedFamilyNameFields` covers backcompat for pre-#483 CSV configs
- [x] `TestListFamilies` / `TestListFamilies_SinglePartner` now assert both `given_name` and `surname`

## Breaking changes

- `FamilyReadModel.Partner{1,2}Name` and `FamilyChildReadModel.PersonName` are removed in favor of split fields. Internal consumers updated in this PR; `gedcom-go` does not reference these types.
- `query.Family.Partner{1,2}Name` and `query.FamilyChildInfo.Name` removed; callers should use the new split fields.
- CSV export default field set uses `partner1_given_name` / `partner1_surname` (and partner2). The pre-#483 keys `partner1_name` / `partner2_name` remain valid as deprecated aliases that render the trimmed concat, so saved export configs keep working.
- Postgres drops the legacy `partner1_name` / `partner2_name` / `person_name` columns. SQLite leaves them as dead columns.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
