### PR TITLE
Refactor evidence UI to Tailwind + shadcn primitives (#392)

### DIFF
--- a/web/src/lib/components/EvidencePanel.svelte
+++ b/web/src/lib/components/EvidencePanel.svelte
@@ -8,7 +8,13 @@
 	} from '$lib/api/client';
 	import UncertaintyBadge from './UncertaintyBadge.svelte';
 	import { Badge } from '$lib/components/ui/badge';
-	import { formatFactTypeShort, subjectRoute, formatDate } from '$lib/utils/evidence';
+	import {
+		formatFactTypeShort,
+		formatDate,
+		outcomeBadgeProps,
+		conflictBadgeProps,
+		conflictRowClass
+	} from '$lib/utils/evidence';
 
 	interface Props {
 		subjectId: string;
@@ -38,17 +44,6 @@
 
 	// Use formatFactTypeShort in person/family context where prefix is redundant
 	const formatFactType = formatFactTypeShort;
-
-	function outcomeBadgeClass(outcome: string): string {
-		switch (outcome) {
-			case 'found':
-				return 'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400';
-			case 'not_found':
-				return 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400';
-			default:
-				return 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-400';
-		}
-	}
 
 	function summaryText(): string {
 		const parts: string[] = [];
@@ -229,11 +224,8 @@
 						</div>
 						<ul class="m-0 list-none p-0">
 							{#each conflicts as conflict}
-								<li
-									class="mb-2 overflow-hidden rounded-md border {conflict.status === 'open'
-										? 'border-amber-200 bg-amber-50'
-										: 'border-slate-200 bg-slate-50'}"
-								>
+								{@const statusBadge = conflictBadgeProps(conflict.status)}
+								<li class="mb-2 overflow-hidden rounded-md border {conflictRowClass(conflict.status)}">
 									<a
 										href="/evidence/conflicts/{conflict.id}"
 										class="block px-3 py-2.5 text-slate-800 no-underline hover:opacity-85"
@@ -241,8 +233,8 @@
 										<div class="flex items-center justify-between gap-2">
 											<span class="flex-1 text-[0.8125rem]">{conflict.description}</span>
 											<Badge
-												variant={conflict.status === 'open' ? 'destructive' : 'secondary'}
-												class="text-[0.625rem] uppercase"
+												variant={statusBadge.variant}
+												class="text-[0.625rem] uppercase {statusBadge.class}"
 											>
 												{conflict.status}
 											</Badge>
@@ -281,6 +273,7 @@
 						</div>
 						<ul class="m-0 list-none p-0">
 							{#each researchLogs as log}
+								{@const outcomeBadge = outcomeBadgeProps(log.outcome)}
 								<li class="flex gap-3 border-b border-slate-100 py-2 last:border-b-0">
 									<div class="min-w-20 flex-shrink-0 pt-0.5 text-[0.6875rem] text-slate-400">
 										{formatDate(log.search_date)}
@@ -290,8 +283,8 @@
 											<span class="text-[0.8125rem] font-medium text-slate-800">
 												{log.repository}
 											</span>
-											<Badge variant="outline" class={outcomeBadgeClass(log.outcome)}>
-												{log.outcome.replace('_', ' ')}
+											<Badge variant={outcomeBadge.variant} class={outcomeBadge.class}>
+												{outcomeBadge.label}
 											</Badge>
 										</div>
 										<span class="block text-xs text-slate-500">{log.search_description}</span>

--- a/web/src/lib/components/EvidencePanel.svelte
+++ b/web/src/lib/components/EvidencePanel.svelte
@@ -97,57 +97,100 @@
 	});
 </script>
 
-<div class="evidence-panel">
-	<button class="panel-header" onclick={() => (expanded = !expanded)} aria-expanded={expanded} aria-controls="evidence-panel-content">
-		<h2>
-			Evidence & Research
+<div class="mt-6 border-t border-slate-200 pt-6">
+	<button
+		class="flex w-full cursor-pointer items-center justify-between border-none bg-transparent p-0 text-left"
+		onclick={() => (expanded = !expanded)}
+		aria-expanded={expanded}
+		aria-controls="evidence-panel-content"
+	>
+		<h2 class="m-0 flex items-center text-sm font-semibold uppercase tracking-wider text-slate-500">
+			Evidence &amp; Research
 			{#if !loading && hasData}
-				<span class="summary-text">{summaryText()}</span>
+				<span class="ml-3 text-xs font-normal normal-case tracking-normal text-slate-400">
+					{summaryText()}
+				</span>
 			{/if}
 			{#if openConflictCount > 0}
 				<Badge variant="destructive" class="ml-1 text-[0.625rem]">{openConflictCount}</Badge>
 			{/if}
 		</h2>
-		<span class="expand-icon">{expanded ? '\u2212' : '+'}</span>
+		<span class="text-xl font-semibold text-slate-500">{expanded ? '−' : '+'}</span>
 	</button>
 
 	{#if expanded}
-		<div class="panel-content" id="evidence-panel-content">
+		<div class="mt-4" id="evidence-panel-content">
 			{#if loading}
-				<div class="loading-state" role="status" aria-live="polite">Loading evidence data...</div>
+				<div class="p-6 text-center text-sm text-slate-500" role="status" aria-live="polite">
+					Loading evidence data...
+				</div>
 			{:else if error}
-				<div class="error-state" role="alert">{error}</div>
+				<div
+					class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{:else if !hasData}
-				<div class="empty-state">
-					<p>No evidence data yet. Start by adding an analysis or logging your research.</p>
-					<div class="empty-actions">
-						<a href="/evidence/analyses/new?subjectId={subjectId}" class="action-link"
-							>Add Analysis</a
+				<div class="p-6 text-center text-sm text-slate-500">
+					<p class="m-0 mb-4">
+						No evidence data yet. Start by adding an analysis or logging your research.
+					</p>
+					<div class="flex justify-center gap-4">
+						<a
+							href="/evidence/analyses/new?subjectId={subjectId}"
+							class="rounded-md border border-slate-200 px-3 py-1.5 text-[0.8125rem] text-blue-500 no-underline hover:bg-slate-100"
 						>
-						<a href="/evidence/research-logs/new?subjectId={subjectId}" class="action-link"
-							>Log Research</a
+							Add Analysis
+						</a>
+						<a
+							href="/evidence/research-logs/new?subjectId={subjectId}"
+							class="rounded-md border border-slate-200 px-3 py-1.5 text-[0.8125rem] text-blue-500 no-underline hover:bg-slate-100"
 						>
+							Log Research
+						</a>
 					</div>
 				</div>
 			{:else}
 				<!-- Analyses -->
 				{#if analyses.length > 0}
-					<div class="sub-section">
-						<div class="sub-header">
-							<h3>Analyses <span class="count-badge">{analyses.length}</span></h3>
-							<a href="/evidence/analyses/new?subjectId={subjectId}" class="add-link"
-								>Add Analysis</a
+					<div class="mb-5 last:mb-0">
+						<div class="mb-2 flex items-center justify-between">
+							<h3 class="m-0 flex items-center gap-2 text-[0.8125rem] font-semibold text-slate-600">
+								Analyses
+								<span
+									class="inline-flex h-[1.125rem] min-w-[1.125rem] items-center justify-center rounded-full bg-blue-100 px-[0.3rem] text-[0.625rem] font-semibold text-blue-500"
+								>
+									{analyses.length}
+								</span>
+							</h3>
+							<a
+								href="/evidence/analyses/new?subjectId={subjectId}"
+								class="text-xs text-blue-500 no-underline hover:underline"
 							>
+								Add Analysis
+							</a>
 						</div>
 						{#each [...analysesByFactType.entries()] as [factType, items]}
-							<div class="fact-group">
-								<h4 class="fact-type-label">{formatFactType(factType)}</h4>
-								<ul class="analysis-list">
+							<div class="mb-3 last:mb-0">
+								<h4
+									class="m-0 mb-1 text-xs font-medium uppercase tracking-wide text-slate-400"
+								>
+									{formatFactType(factType)}
+								</h4>
+								<ul class="m-0 list-none p-0">
 									{#each items as analysis}
-										<li class="analysis-item">
-											<a href="/evidence/analyses/{analysis.id}" class="analysis-link">
-												<span class="analysis-conclusion">{analysis.conclusion}</span>
-												<span class="analysis-meta">
+										<li class="mb-1">
+											<a
+												href="/evidence/analyses/{analysis.id}"
+												class="flex items-center justify-between gap-3 rounded-md px-2.5 py-2 text-slate-800 no-underline transition-colors hover:bg-slate-100"
+											>
+												<span
+													class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[0.8125rem]"
+												>
+													{analysis.conclusion}
+												</span>
+												<span class="flex flex-shrink-0 items-center gap-2">
 													{#if analysis.research_status}
 														<UncertaintyBadge
 															status={analysis.research_status}
@@ -156,12 +199,10 @@
 														/>
 													{/if}
 													{#if analysis.citation_ids && analysis.citation_ids.length > 0}
-														<span class="citation-count"
-															>{analysis.citation_ids.length}
-															{analysis.citation_ids.length === 1
-																? 'citation'
-																: 'citations'}</span
-														>
+														<span class="text-[0.6875rem] text-slate-400">
+															{analysis.citation_ids.length}
+															{analysis.citation_ids.length === 1 ? 'citation' : 'citations'}
+														</span>
 													{/if}
 												</span>
 											</a>
@@ -175,20 +216,30 @@
 
 				<!-- Conflicts -->
 				{#if conflicts.length > 0}
-					<div class="sub-section">
-						<div class="sub-header">
-							<h3>Conflicts <span class="count-badge">{conflicts.length}</span></h3>
+					<div class="mb-5 last:mb-0">
+						<div class="mb-2 flex items-center justify-between">
+							<h3 class="m-0 flex items-center gap-2 text-[0.8125rem] font-semibold text-slate-600">
+								Conflicts
+								<span
+									class="inline-flex h-[1.125rem] min-w-[1.125rem] items-center justify-center rounded-full bg-blue-100 px-[0.3rem] text-[0.625rem] font-semibold text-blue-500"
+								>
+									{conflicts.length}
+								</span>
+							</h3>
 						</div>
-						<ul class="conflict-list">
+						<ul class="m-0 list-none p-0">
 							{#each conflicts as conflict}
 								<li
-									class="conflict-item"
-									class:conflict-open={conflict.status === 'open'}
-									class:conflict-resolved={conflict.status === 'resolved'}
+									class="mb-2 overflow-hidden rounded-md border {conflict.status === 'open'
+										? 'border-amber-200 bg-amber-50'
+										: 'border-slate-200 bg-slate-50'}"
 								>
-									<a href="/evidence/conflicts/{conflict.id}" class="conflict-link">
-										<div class="conflict-header-row">
-											<span class="conflict-description">{conflict.description}</span>
+									<a
+										href="/evidence/conflicts/{conflict.id}"
+										class="block px-3 py-2.5 text-slate-800 no-underline hover:opacity-85"
+									>
+										<div class="flex items-center justify-between gap-2">
+											<span class="flex-1 text-[0.8125rem]">{conflict.description}</span>
 											<Badge
 												variant={conflict.status === 'open' ? 'destructive' : 'secondary'}
 												class="text-[0.625rem] uppercase"
@@ -197,12 +248,10 @@
 											</Badge>
 										</div>
 										{#if conflict.analysis_ids && conflict.analysis_ids.length > 0}
-											<span class="conflict-analyses"
-												>{conflict.analysis_ids.length} linked
-												{conflict.analysis_ids.length === 1
-													? 'analysis'
-													: 'analyses'}</span
-											>
+											<span class="mt-1 block text-[0.6875rem] text-slate-400">
+												{conflict.analysis_ids.length} linked
+												{conflict.analysis_ids.length === 1 ? 'analysis' : 'analyses'}
+											</span>
 										{/if}
 									</a>
 								</li>
@@ -213,31 +262,39 @@
 
 				<!-- Research Logs -->
 				{#if researchLogs.length > 0}
-					<div class="sub-section">
-						<div class="sub-header">
-							<h3>
-								Research Logs <span class="count-badge">{researchLogs.length}</span>
+					<div class="mb-5 last:mb-0">
+						<div class="mb-2 flex items-center justify-between">
+							<h3 class="m-0 flex items-center gap-2 text-[0.8125rem] font-semibold text-slate-600">
+								Research Logs
+								<span
+									class="inline-flex h-[1.125rem] min-w-[1.125rem] items-center justify-center rounded-full bg-blue-100 px-[0.3rem] text-[0.625rem] font-semibold text-blue-500"
+								>
+									{researchLogs.length}
+								</span>
 							</h3>
 							<a
 								href="/evidence/research-logs/new?subjectId={subjectId}"
-								class="add-link">Log Research</a
+								class="text-xs text-blue-500 no-underline hover:underline"
 							>
+								Log Research
+							</a>
 						</div>
-						<ul class="log-list">
+						<ul class="m-0 list-none p-0">
 							{#each researchLogs as log}
-								<li class="log-item">
-									<div class="log-date">{formatDate(log.search_date)}</div>
-									<div class="log-body">
-										<div class="log-header-row">
-											<span class="log-repository">{log.repository}</span>
-											<Badge
-												variant="outline"
-												class={outcomeBadgeClass(log.outcome)}
-											>
+								<li class="flex gap-3 border-b border-slate-100 py-2 last:border-b-0">
+									<div class="min-w-20 flex-shrink-0 pt-0.5 text-[0.6875rem] text-slate-400">
+										{formatDate(log.search_date)}
+									</div>
+									<div class="min-w-0 flex-1">
+										<div class="mb-0.5 flex items-center gap-2">
+											<span class="text-[0.8125rem] font-medium text-slate-800">
+												{log.repository}
+											</span>
+											<Badge variant="outline" class={outcomeBadgeClass(log.outcome)}>
 												{log.outcome.replace('_', ' ')}
 											</Badge>
 										</div>
-										<span class="log-description">{log.search_description}</span>
+										<span class="block text-xs text-slate-500">{log.search_description}</span>
 									</div>
 								</li>
 							{/each}
@@ -248,300 +305,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.evidence-panel {
-		margin-top: 1.5rem;
-		padding-top: 1.5rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	.panel-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		width: 100%;
-		padding: 0;
-		border: none;
-		background: none;
-		cursor: pointer;
-		text-align: left;
-	}
-
-	.panel-header h2 {
-		display: flex;
-		align-items: center;
-		margin: 0;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #64748b;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.summary-text {
-		margin-left: 0.75rem;
-		font-size: 0.75rem;
-		font-weight: 400;
-		color: #94a3b8;
-		text-transform: none;
-		letter-spacing: 0;
-	}
-
-	.expand-icon {
-		font-size: 1.25rem;
-		font-weight: 600;
-		color: #64748b;
-	}
-
-	.panel-content {
-		margin-top: 1rem;
-	}
-
-	.loading-state,
-	.empty-state {
-		text-align: center;
-		padding: 1.5rem;
-		color: #64748b;
-		font-size: 0.875rem;
-	}
-
-	.empty-state p {
-		margin: 0 0 1rem;
-	}
-
-	.empty-actions {
-		display: flex;
-		gap: 1rem;
-		justify-content: center;
-	}
-
-	.error-state {
-		padding: 0.75rem;
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 6px;
-		color: #dc2626;
-		font-size: 0.875rem;
-	}
-
-	.sub-section {
-		margin-bottom: 1.25rem;
-	}
-
-	.sub-section:last-child {
-		margin-bottom: 0;
-	}
-
-	.sub-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.5rem;
-	}
-
-	.sub-header h3 {
-		margin: 0;
-		font-size: 0.8125rem;
-		font-weight: 600;
-		color: #475569;
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.count-badge {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		min-width: 1.125rem;
-		height: 1.125rem;
-		padding: 0 0.3rem;
-		background: #dbeafe;
-		border-radius: 9999px;
-		font-size: 0.625rem;
-		font-weight: 600;
-		color: #3b82f6;
-	}
-
-	.add-link {
-		font-size: 0.75rem;
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.add-link:hover {
-		text-decoration: underline;
-	}
-
-	.action-link {
-		font-size: 0.8125rem;
-		color: #3b82f6;
-		text-decoration: none;
-		padding: 0.375rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-	}
-
-	.action-link:hover {
-		background: #f1f5f9;
-	}
-
-	/* Analyses */
-	.fact-group {
-		margin-bottom: 0.75rem;
-	}
-
-	.fact-group:last-child {
-		margin-bottom: 0;
-	}
-
-	.fact-type-label {
-		margin: 0 0 0.25rem;
-		font-size: 0.75rem;
-		font-weight: 500;
-		color: #94a3b8;
-		text-transform: uppercase;
-		letter-spacing: 0.03em;
-	}
-
-	.analysis-list,
-	.conflict-list,
-	.log-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-
-	.analysis-item {
-		margin-bottom: 0.25rem;
-	}
-
-	.analysis-link {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.75rem;
-		padding: 0.5rem 0.625rem;
-		border-radius: 6px;
-		text-decoration: none;
-		color: #1e293b;
-		transition: background 0.15s;
-	}
-
-	.analysis-link:hover {
-		background: #f1f5f9;
-	}
-
-	.analysis-conclusion {
-		font-size: 0.8125rem;
-		flex: 1;
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.analysis-meta {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		flex-shrink: 0;
-	}
-
-	.citation-count {
-		font-size: 0.6875rem;
-		color: #94a3b8;
-	}
-
-	/* Conflicts */
-	.conflict-item {
-		margin-bottom: 0.5rem;
-		border-radius: 6px;
-		overflow: hidden;
-	}
-
-	.conflict-item.conflict-open {
-		background: #fffbeb;
-		border: 1px solid #fde68a;
-	}
-
-	.conflict-item.conflict-resolved {
-		background: #f8fafc;
-		border: 1px solid #e2e8f0;
-	}
-
-	.conflict-link {
-		display: block;
-		padding: 0.625rem 0.75rem;
-		text-decoration: none;
-		color: #1e293b;
-	}
-
-	.conflict-link:hover {
-		opacity: 0.85;
-	}
-
-	.conflict-header-row {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.5rem;
-	}
-
-	.conflict-description {
-		font-size: 0.8125rem;
-		flex: 1;
-	}
-
-	.conflict-analyses {
-		display: block;
-		font-size: 0.6875rem;
-		color: #94a3b8;
-		margin-top: 0.25rem;
-	}
-
-	/* Research Logs */
-	.log-item {
-		display: flex;
-		gap: 0.75rem;
-		padding: 0.5rem 0;
-		border-bottom: 1px solid #f1f5f9;
-	}
-
-	.log-item:last-child {
-		border-bottom: none;
-	}
-
-	.log-date {
-		flex-shrink: 0;
-		font-size: 0.6875rem;
-		color: #94a3b8;
-		min-width: 5rem;
-		padding-top: 0.125rem;
-	}
-
-	.log-body {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.log-header-row {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 0.125rem;
-	}
-
-	.log-repository {
-		font-size: 0.8125rem;
-		font-weight: 500;
-		color: #1e293b;
-	}
-
-	.log-description {
-		display: block;
-		font-size: 0.75rem;
-		color: #64748b;
-	}
-</style>

--- a/web/src/lib/utils/evidence.ts
+++ b/web/src/lib/utils/evidence.ts
@@ -45,3 +45,67 @@ export function toRFC3339(dateStr: string): string {
 	if (dateStr.includes('T')) return dateStr;
 	return dateStr + 'T00:00:00Z';
 }
+
+/**
+ * Props for rendering a research log's outcome as a <Badge>.
+ *
+ * Single source of truth so EvidencePanel, the evidence hub list, and any
+ * future surface share the same colour and label per outcome value.
+ */
+export interface BadgeProps {
+	variant: 'default' | 'secondary' | 'destructive' | 'outline';
+	class: string;
+	label: string;
+}
+
+export function outcomeBadgeProps(outcome: string): BadgeProps {
+	switch (outcome) {
+		case 'found':
+			return {
+				variant: 'secondary',
+				class:
+					'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400',
+				label: 'Found'
+			};
+		case 'not_found':
+			return { variant: 'destructive', class: '', label: 'Not Found' };
+		case 'inconclusive':
+			return {
+				variant: 'secondary',
+				class:
+					'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-400',
+				label: 'Inconclusive'
+			};
+		default:
+			return {
+				variant: 'secondary',
+				class:
+					'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-400',
+				label: outcome.replace(/_/g, ' ')
+			};
+	}
+}
+
+/**
+ * Props for rendering a conflict's status as a <Badge>.
+ *
+ * Single source of truth so EvidencePanel, the hub list, and the conflict
+ * detail page render the same colours for the same status.
+ */
+export function conflictBadgeProps(status: string): BadgeProps {
+	if (status === 'open') {
+		return { variant: 'destructive', class: '', label: 'Open' };
+	}
+	return {
+		variant: 'secondary',
+		class: 'border-green-200 bg-green-50 text-green-700',
+		label: 'Resolved'
+	};
+}
+
+/** Tailwind classes for an EvidencePanel conflict row's wrapper (open vs resolved). */
+export function conflictRowClass(status: string): string {
+	return status === 'open'
+		? 'border-amber-200 bg-amber-50'
+		: 'border-slate-200 bg-slate-50';
+}

--- a/web/src/lib/utils/forms.ts
+++ b/web/src/lib/utils/forms.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared styling tokens for form controls.
+ *
+ * The native <select> element doesn't have a shadcn-svelte primitive in this
+ * project, but we want it to look consistent with `<Input>`. This class string
+ * mirrors the shadcn Input signature so a native <select class={nativeSelectClass}>
+ * lines up visually with surrounding Input/Textarea controls.
+ */
+export const nativeSelectClass =
+	'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';

--- a/web/src/routes/evidence/+page.svelte
+++ b/web/src/routes/evidence/+page.svelte
@@ -165,11 +165,32 @@
 	<title>Evidence Analysis | My Family</title>
 </svelte:head>
 
-<div class="evidence-page">
-	<header class="page-header">
+{#snippet pagination(currentPage: number, totalPages: number, loading: boolean, onPrev: () => void, onNext: () => void)}
+	<div
+		class="mt-8 flex items-center justify-center gap-4 border-t border-slate-200 pt-4"
+	>
+		<Button variant="outline" size="sm" onclick={onPrev} disabled={currentPage === 1 || loading}>
+			Previous
+		</Button>
+		<span class="text-sm text-slate-500">Page {currentPage} of {totalPages}</span>
+		<Button
+			variant="outline"
+			size="sm"
+			onclick={onNext}
+			disabled={currentPage >= totalPages || loading}
+		>
+			Next
+		</Button>
+	</div>
+{/snippet}
+
+<div class="mx-auto max-w-screen-xl p-6">
+	<header class="mb-6">
 		<div>
-			<h1>Evidence Analysis</h1>
-			<p class="subtitle">GPS-compliant research tracking and proof management</p>
+			<h1 class="m-0 text-2xl text-slate-800">Evidence Analysis</h1>
+			<p class="mt-1 text-sm text-slate-500">
+				GPS-compliant research tracking and proof management
+			</p>
 		</div>
 	</header>
 
@@ -179,7 +200,9 @@
 			<Tabs.Trigger value="conflicts">
 				Conflicts
 				{#if openConflictsCount > 0}
-					<Badge variant="destructive" class="ml-1 h-5 min-w-5 px-1.5 text-xs">{openConflictsCount}</Badge>
+					<Badge variant="destructive" class="ml-1 h-5 min-w-5 px-1.5 text-xs">
+						{openConflictsCount}
+					</Badge>
 				{/if}
 			</Tabs.Trigger>
 			<Tabs.Trigger value="logs">Research Logs</Tabs.Trigger>
@@ -188,51 +211,80 @@
 
 		<!-- Analyses Tab -->
 		<Tabs.Content value="analyses">
-			<div class="tab-header">
-				<span class="tab-count">{analysesTotal} {analysesTotal === 1 ? 'analysis' : 'analyses'}</span>
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<span class="text-sm text-slate-500">
+					{analysesTotal} {analysesTotal === 1 ? 'analysis' : 'analyses'}
+				</span>
 				<Button href="/evidence/analyses/new">New Analysis</Button>
 			</div>
 
 			{#if analysesLoading}
-				<div class="loading">Loading analyses...</div>
+				<div class="p-12 text-center text-slate-500">Loading analyses...</div>
 			{:else if analysesError}
-				<div class="error-state">
-					<p>{analysesError}</p>
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{analysesError}</p>
 					<Button variant="outline" onclick={loadAnalyses}>Retry</Button>
 				</div>
 			{:else if analyses.length === 0}
-				<div class="empty">
-					<p>No evidence analyses yet.</p>
-					<p class="empty-hint">Create an analysis to evaluate evidence for a genealogical fact.</p>
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No evidence analyses yet.</p>
+					<p class="mb-4 text-[0.8125rem] text-slate-400">
+						Create an analysis to evaluate evidence for a genealogical fact.
+					</p>
 					<Button href="/evidence/analyses/new">New Analysis</Button>
 				</div>
 			{:else}
 				<!-- Desktop table -->
-				<div class="table-wrapper desktop-only">
-					<table>
+				<div class="hidden overflow-x-auto md:block">
+					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th>Fact Type</th>
-								<th>Subject</th>
-								<th>Conclusion</th>
-								<th>Status</th>
-								<th>Citations</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Conclusion</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Citations</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each analyses as analysis}
-								<tr class="clickable" tabindex="0" role="link" onclick={() => goto(`/evidence/analyses/${analysis.id}`)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/evidence/analyses/${analysis.id}`); } }}>
-									<td class="fact-type">{formatFactType(analysis.fact_type)}</td>
-									<td><a href="/{subjectRoute(analysis.fact_type)}/{analysis.subject_id}" onclick={(e) => e.stopPropagation()}>{analysis.subject_id.slice(0, 8)}...</a></td>
-									<td class="truncated">{truncate(analysis.conclusion)}</td>
-									<td>
+								<tr
+									class="cursor-pointer transition-colors hover:bg-slate-50"
+									tabindex="0"
+									role="link"
+									onclick={() => goto(`/evidence/analyses/${analysis.id}`)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											goto(`/evidence/analyses/${analysis.id}`);
+										}
+									}}
+								>
+									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
+										{formatFactType(analysis.fact_type)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+										<a
+											href="/{subjectRoute(analysis.fact_type)}/{analysis.subject_id}"
+											class="text-blue-500 no-underline hover:underline"
+											onclick={(e) => e.stopPropagation()}
+										>
+											{analysis.subject_id.slice(0, 8)}...
+										</a>
+									</td>
+									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+										{truncate(analysis.conclusion)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
 										{#if analysis.research_status}
 											<UncertaintyBadge status={analysis.research_status} showLabel />
 										{:else}
-											<span class="text-muted">--</span>
+											<span class="text-slate-400">--</span>
 										{/if}
 									</td>
-									<td class="count">{analysis.citation_ids?.length ?? 0}</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-center text-slate-800">
+										{analysis.citation_ids?.length ?? 0}
+									</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -240,17 +292,24 @@
 				</div>
 
 				<!-- Mobile cards -->
-				<div class="cards-wrapper mobile-only">
+				<div class="flex flex-col gap-3 md:hidden">
 					{#each analyses as analysis}
-						<a href="/evidence/analyses/{analysis.id}" class="card">
-							<div class="card-top">
-								<span class="card-fact-type">{formatFactType(analysis.fact_type)}</span>
+						<a
+							href="/evidence/analyses/{analysis.id}"
+							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
+						>
+							<div class="mb-2 flex items-center justify-between">
+								<span class="text-sm font-semibold text-slate-800">
+									{formatFactType(analysis.fact_type)}
+								</span>
 								{#if analysis.research_status}
 									<UncertaintyBadge status={analysis.research_status} showLabel size="small" />
 								{/if}
 							</div>
-							<p class="card-conclusion">{truncate(analysis.conclusion, 120)}</p>
-							<div class="card-meta">
+							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
+								{truncate(analysis.conclusion, 120)}
+							</p>
+							<div class="mt-2 text-xs text-slate-400">
 								<span>{analysis.citation_ids?.length ?? 0} citations</span>
 							</div>
 						</a>
@@ -258,61 +317,107 @@
 				</div>
 
 				{#if analysesTotalPages > 1}
-					<div class="pagination">
-						<button onclick={() => { analysesPage--; loadAnalyses(); }} disabled={analysesPage === 1 || analysesLoading}>Previous</button>
-						<span>Page {analysesPage} of {analysesTotalPages}</span>
-						<button onclick={() => { analysesPage++; loadAnalyses(); }} disabled={analysesPage >= analysesTotalPages || analysesLoading}>Next</button>
-					</div>
+					{@render pagination(
+						analysesPage,
+						analysesTotalPages,
+						analysesLoading,
+						() => {
+							analysesPage--;
+							loadAnalyses();
+						},
+						() => {
+							analysesPage++;
+							loadAnalyses();
+						}
+					)}
 				{/if}
 			{/if}
 		</Tabs.Content>
 
 		<!-- Conflicts Tab -->
 		<Tabs.Content value="conflicts">
-			<div class="tab-header">
-				<div class="filter-buttons">
-					<button class="filter-btn" class:active={conflictStatusFilter === 'all'} aria-pressed={conflictStatusFilter === 'all'} onclick={() => { conflictStatusFilter = 'all'; conflictsPage = 1; loadConflicts(); }}>All</button>
-					<button class="filter-btn" class:active={conflictStatusFilter === 'open'} aria-pressed={conflictStatusFilter === 'open'} onclick={() => { conflictStatusFilter = 'open'; conflictsPage = 1; loadConflicts(); }}>Open</button>
-					<button class="filter-btn" class:active={conflictStatusFilter === 'resolved'} aria-pressed={conflictStatusFilter === 'resolved'} onclick={() => { conflictStatusFilter = 'resolved'; conflictsPage = 1; loadConflicts(); }}>Resolved</button>
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<div class="flex gap-1">
+					{#each [{ key: 'all', label: 'All' }, { key: 'open', label: 'Open' }, { key: 'resolved', label: 'Resolved' }] as filter}
+						<Button
+							variant={conflictStatusFilter === filter.key ? 'default' : 'outline'}
+							size="sm"
+							aria-pressed={conflictStatusFilter === filter.key}
+							onclick={() => {
+								conflictStatusFilter = filter.key as 'all' | 'open' | 'resolved';
+								conflictsPage = 1;
+								loadConflicts();
+							}}
+						>
+							{filter.label}
+						</Button>
+					{/each}
 				</div>
-				<span class="tab-count">{conflictsTotal} {conflictsTotal === 1 ? 'conflict' : 'conflicts'}</span>
+				<span class="text-sm text-slate-500">
+					{conflictsTotal} {conflictsTotal === 1 ? 'conflict' : 'conflicts'}
+				</span>
 			</div>
 
 			{#if conflictsLoading}
-				<div class="loading">Loading conflicts...</div>
+				<div class="p-12 text-center text-slate-500">Loading conflicts...</div>
 			{:else if conflictsError}
-				<div class="error-state">
-					<p>{conflictsError}</p>
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{conflictsError}</p>
 					<Button variant="outline" onclick={loadConflicts}>Retry</Button>
 				</div>
 			{:else if conflicts.length === 0}
-				<div class="empty">
-					<p>No conflicts found.</p>
-					<p class="empty-hint">Conflicts are auto-detected when analyses for the same fact disagree.</p>
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No conflicts found.</p>
+					<p class="mb-4 text-[0.8125rem] text-slate-400">
+						Conflicts are auto-detected when analyses for the same fact disagree.
+					</p>
 				</div>
 			{:else}
 				<!-- Desktop table -->
-				<div class="table-wrapper desktop-only">
-					<table>
+				<div class="hidden overflow-x-auto md:block">
+					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th>Fact Type</th>
-								<th>Subject</th>
-								<th>Description</th>
-								<th>Status</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Description</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each conflicts as conflict}
-								<tr class="clickable" tabindex="0" role="link" onclick={() => goto(`/evidence/conflicts/${conflict.id}`)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/evidence/conflicts/${conflict.id}`); } }}>
-									<td class="fact-type">{formatFactType(conflict.fact_type)}</td>
-									<td><a href="/{subjectRoute(conflict.fact_type)}/{conflict.subject_id}" onclick={(e) => e.stopPropagation()}>{conflict.subject_id.slice(0, 8)}...</a></td>
-									<td class="truncated">{truncate(conflict.description)}</td>
-									<td>
+								<tr
+									class="cursor-pointer transition-colors hover:bg-slate-50"
+									tabindex="0"
+									role="link"
+									onclick={() => goto(`/evidence/conflicts/${conflict.id}`)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											goto(`/evidence/conflicts/${conflict.id}`);
+										}
+									}}
+								>
+									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
+										{formatFactType(conflict.fact_type)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+										<a
+											href="/{subjectRoute(conflict.fact_type)}/{conflict.subject_id}"
+											class="text-blue-500 no-underline hover:underline"
+											onclick={(e) => e.stopPropagation()}
+										>
+											{conflict.subject_id.slice(0, 8)}...
+										</a>
+									</td>
+									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+										{truncate(conflict.description)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
 										{#if conflict.status === 'open'}
 											<Badge variant="destructive">Open</Badge>
 										{:else}
-											<Badge class="bg-green-50 text-green-700 border-green-200">Resolved</Badge>
+											<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
 										{/if}
 									</td>
 								</tr>
@@ -322,81 +427,123 @@
 				</div>
 
 				<!-- Mobile cards -->
-				<div class="cards-wrapper mobile-only">
+				<div class="flex flex-col gap-3 md:hidden">
 					{#each conflicts as conflict}
-						<a href="/evidence/conflicts/{conflict.id}" class="card">
-							<div class="card-top">
-								<span class="card-fact-type">{formatFactType(conflict.fact_type)}</span>
+						<a
+							href="/evidence/conflicts/{conflict.id}"
+							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
+						>
+							<div class="mb-2 flex items-center justify-between">
+								<span class="text-sm font-semibold text-slate-800">
+									{formatFactType(conflict.fact_type)}
+								</span>
 								{#if conflict.status === 'open'}
 									<Badge variant="destructive">Open</Badge>
 								{:else}
-									<Badge class="bg-green-50 text-green-700 border-green-200">Resolved</Badge>
+									<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
 								{/if}
 							</div>
-							<p class="card-conclusion">{truncate(conflict.description, 120)}</p>
+							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
+								{truncate(conflict.description, 120)}
+							</p>
 						</a>
 					{/each}
 				</div>
 
 				{#if conflictsTotalPages > 1}
-					<div class="pagination">
-						<button onclick={() => { conflictsPage--; loadConflicts(); }} disabled={conflictsPage === 1 || conflictsLoading}>Previous</button>
-						<span>Page {conflictsPage} of {conflictsTotalPages}</span>
-						<button onclick={() => { conflictsPage++; loadConflicts(); }} disabled={conflictsPage >= conflictsTotalPages || conflictsLoading}>Next</button>
-					</div>
+					{@render pagination(
+						conflictsPage,
+						conflictsTotalPages,
+						conflictsLoading,
+						() => {
+							conflictsPage--;
+							loadConflicts();
+						},
+						() => {
+							conflictsPage++;
+							loadConflicts();
+						}
+					)}
 				{/if}
 			{/if}
 		</Tabs.Content>
 
 		<!-- Research Logs Tab -->
 		<Tabs.Content value="logs">
-			<div class="tab-header">
-				<span class="tab-count">{logsTotal} {logsTotal === 1 ? 'log entry' : 'log entries'}</span>
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<span class="text-sm text-slate-500">
+					{logsTotal} {logsTotal === 1 ? 'log entry' : 'log entries'}
+				</span>
 				<Button href="/evidence/research-logs/new">New Research Log</Button>
 			</div>
 
 			{#if logsLoading}
-				<div class="loading">Loading research logs...</div>
+				<div class="p-12 text-center text-slate-500">Loading research logs...</div>
 			{:else if logsError}
-				<div class="error-state">
-					<p>{logsError}</p>
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{logsError}</p>
 					<Button variant="outline" onclick={loadLogs}>Retry</Button>
 				</div>
 			{:else if logs.length === 0}
-				<div class="empty">
-					<p>No research logs yet.</p>
-					<p class="empty-hint">Log your research activities to track what repositories and records you have searched.</p>
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No research logs yet.</p>
+					<p class="mb-4 text-[0.8125rem] text-slate-400">
+						Log your research activities to track what repositories and records you have searched.
+					</p>
 					<Button href="/evidence/research-logs/new">New Research Log</Button>
 				</div>
 			{:else}
 				<!-- Desktop table -->
-				<div class="table-wrapper desktop-only">
-					<table>
+				<div class="hidden overflow-x-auto md:block">
+					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th>Subject</th>
-								<th>Repository</th>
-								<th>Search Description</th>
-								<th>Outcome</th>
-								<th>Date</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Repository</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Search Description</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Outcome</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Date</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each logs as log}
-								<tr class="clickable" tabindex="0" role="link" onclick={() => goto(`/evidence/research-logs/${log.id}`)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/evidence/research-logs/${log.id}`); } }}>
-									<td><a href="/{log.subject_type === 'family' ? 'families' : 'persons'}/{log.subject_id}" onclick={(e) => e.stopPropagation()}>{log.subject_id.slice(0, 8)}...</a></td>
-									<td>{log.repository}</td>
-									<td class="truncated">{truncate(log.search_description)}</td>
-									<td>
+								<tr
+									class="cursor-pointer transition-colors hover:bg-slate-50"
+									tabindex="0"
+									role="link"
+									onclick={() => goto(`/evidence/research-logs/${log.id}`)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											goto(`/evidence/research-logs/${log.id}`);
+										}
+									}}
+								>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+										<a
+											href="/{log.subject_type === 'family' ? 'families' : 'persons'}/{log.subject_id}"
+											class="text-blue-500 no-underline hover:underline"
+											onclick={(e) => e.stopPropagation()}
+										>
+											{log.subject_id.slice(0, 8)}...
+										</a>
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">{log.repository}</td>
+									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+										{truncate(log.search_description)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
 										{#if log.outcome === 'found'}
-											<Badge class="bg-green-50 text-green-700 border-green-200">Found</Badge>
+											<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
 										{:else if log.outcome === 'not_found'}
 											<Badge variant="destructive">Not Found</Badge>
 										{:else}
-											<Badge class="bg-yellow-50 text-yellow-700 border-yellow-200">Inconclusive</Badge>
+											<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
 										{/if}
 									</td>
-									<td class="date">{formatDate(log.search_date)}</td>
+									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+										{formatDate(log.search_date)}
+									</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -404,21 +551,26 @@
 				</div>
 
 				<!-- Mobile cards -->
-				<div class="cards-wrapper mobile-only">
+				<div class="flex flex-col gap-3 md:hidden">
 					{#each logs as log}
-						<a href="/evidence/research-logs/{log.id}" class="card">
-							<div class="card-top">
-								<span class="card-fact-type">{log.repository}</span>
+						<a
+							href="/evidence/research-logs/{log.id}"
+							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
+						>
+							<div class="mb-2 flex items-center justify-between">
+								<span class="text-sm font-semibold text-slate-800">{log.repository}</span>
 								{#if log.outcome === 'found'}
-									<Badge class="bg-green-50 text-green-700 border-green-200">Found</Badge>
+									<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
 								{:else if log.outcome === 'not_found'}
 									<Badge variant="destructive">Not Found</Badge>
 								{:else}
-									<Badge class="bg-yellow-50 text-yellow-700 border-yellow-200">Inconclusive</Badge>
+									<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
 								{/if}
 							</div>
-							<p class="card-conclusion">{truncate(log.search_description, 120)}</p>
-							<div class="card-meta">
+							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
+								{truncate(log.search_description, 120)}
+							</p>
+							<div class="mt-2 text-xs text-slate-400">
 								<span>{formatDate(log.search_date)}</span>
 							</div>
 						</a>
@@ -426,62 +578,99 @@
 				</div>
 
 				{#if logsTotalPages > 1}
-					<div class="pagination">
-						<button onclick={() => { logsPage--; loadLogs(); }} disabled={logsPage === 1 || logsLoading}>Previous</button>
-						<span>Page {logsPage} of {logsTotalPages}</span>
-						<button onclick={() => { logsPage++; loadLogs(); }} disabled={logsPage >= logsTotalPages || logsLoading}>Next</button>
-					</div>
+					{@render pagination(
+						logsPage,
+						logsTotalPages,
+						logsLoading,
+						() => {
+							logsPage--;
+							loadLogs();
+						},
+						() => {
+							logsPage++;
+							loadLogs();
+						}
+					)}
 				{/if}
 			{/if}
 		</Tabs.Content>
 
 		<!-- Proof Summaries Tab -->
 		<Tabs.Content value="summaries">
-			<div class="tab-header">
-				<span class="tab-count">{summariesTotal} {summariesTotal === 1 ? 'summary' : 'summaries'}</span>
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<span class="text-sm text-slate-500">
+					{summariesTotal} {summariesTotal === 1 ? 'summary' : 'summaries'}
+				</span>
 				<Button href="/evidence/proof-summaries/new">New Proof Summary</Button>
 			</div>
 
 			{#if summariesLoading}
-				<div class="loading">Loading proof summaries...</div>
+				<div class="p-12 text-center text-slate-500">Loading proof summaries...</div>
 			{:else if summariesError}
-				<div class="error-state">
-					<p>{summariesError}</p>
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{summariesError}</p>
 					<Button variant="outline" onclick={loadSummaries}>Retry</Button>
 				</div>
 			{:else if summaries.length === 0}
-				<div class="empty">
-					<p>No proof summaries yet.</p>
-					<p class="empty-hint">Create a proof summary to document your conclusions about a genealogical fact.</p>
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No proof summaries yet.</p>
+					<p class="mb-4 text-[0.8125rem] text-slate-400">
+						Create a proof summary to document your conclusions about a genealogical fact.
+					</p>
 					<Button href="/evidence/proof-summaries/new">New Proof Summary</Button>
 				</div>
 			{:else}
 				<!-- Desktop table -->
-				<div class="table-wrapper desktop-only">
-					<table>
+				<div class="hidden overflow-x-auto md:block">
+					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th>Fact Type</th>
-								<th>Subject</th>
-								<th>Conclusion</th>
-								<th>Status</th>
-								<th>Analyses</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Conclusion</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
+								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Analyses</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each summaries as summary}
-								<tr class="clickable" tabindex="0" role="link" onclick={() => goto(`/evidence/proof-summaries/${summary.id}`)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/evidence/proof-summaries/${summary.id}`); } }}>
-									<td class="fact-type">{formatFactType(summary.fact_type)}</td>
-									<td><a href="/{subjectRoute(summary.fact_type)}/{summary.subject_id}" onclick={(e) => e.stopPropagation()}>{summary.subject_id.slice(0, 8)}...</a></td>
-									<td class="truncated">{truncate(summary.conclusion)}</td>
-									<td>
+								<tr
+									class="cursor-pointer transition-colors hover:bg-slate-50"
+									tabindex="0"
+									role="link"
+									onclick={() => goto(`/evidence/proof-summaries/${summary.id}`)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											goto(`/evidence/proof-summaries/${summary.id}`);
+										}
+									}}
+								>
+									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
+										{formatFactType(summary.fact_type)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+										<a
+											href="/{subjectRoute(summary.fact_type)}/{summary.subject_id}"
+											class="text-blue-500 no-underline hover:underline"
+											onclick={(e) => e.stopPropagation()}
+										>
+											{summary.subject_id.slice(0, 8)}...
+										</a>
+									</td>
+									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+										{truncate(summary.conclusion)}
+									</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
 										{#if summary.research_status}
 											<UncertaintyBadge status={summary.research_status} showLabel />
 										{:else}
-											<span class="text-muted">--</span>
+											<span class="text-slate-400">--</span>
 										{/if}
 									</td>
-									<td class="count">{summary.analysis_ids?.length ?? 0}</td>
+									<td class="border-b border-slate-100 px-4 py-3 text-center text-slate-800">
+										{summary.analysis_ids?.length ?? 0}
+									</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -489,17 +678,24 @@
 				</div>
 
 				<!-- Mobile cards -->
-				<div class="cards-wrapper mobile-only">
+				<div class="flex flex-col gap-3 md:hidden">
 					{#each summaries as summary}
-						<a href="/evidence/proof-summaries/{summary.id}" class="card">
-							<div class="card-top">
-								<span class="card-fact-type">{formatFactType(summary.fact_type)}</span>
+						<a
+							href="/evidence/proof-summaries/{summary.id}"
+							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
+						>
+							<div class="mb-2 flex items-center justify-between">
+								<span class="text-sm font-semibold text-slate-800">
+									{formatFactType(summary.fact_type)}
+								</span>
 								{#if summary.research_status}
 									<UncertaintyBadge status={summary.research_status} showLabel size="small" />
 								{/if}
 							</div>
-							<p class="card-conclusion">{truncate(summary.conclusion, 120)}</p>
-							<div class="card-meta">
+							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
+								{truncate(summary.conclusion, 120)}
+							</p>
+							<div class="mt-2 text-xs text-slate-400">
 								<span>{summary.analysis_ids?.length ?? 0} linked analyses</span>
 							</div>
 						</a>
@@ -507,280 +703,21 @@
 				</div>
 
 				{#if summariesTotalPages > 1}
-					<div class="pagination">
-						<button onclick={() => { summariesPage--; loadSummaries(); }} disabled={summariesPage === 1 || summariesLoading}>Previous</button>
-						<span>Page {summariesPage} of {summariesTotalPages}</span>
-						<button onclick={() => { summariesPage++; loadSummaries(); }} disabled={summariesPage >= summariesTotalPages || summariesLoading}>Next</button>
-					</div>
+					{@render pagination(
+						summariesPage,
+						summariesTotalPages,
+						summariesLoading,
+						() => {
+							summariesPage--;
+							loadSummaries();
+						},
+						() => {
+							summariesPage++;
+							loadSummaries();
+						}
+					)}
 				{/if}
 			{/if}
 		</Tabs.Content>
 	</Tabs.Root>
 </div>
-
-<style>
-	.evidence-page {
-		max-width: 1200px;
-		margin: 0 auto;
-		padding: 1.5rem;
-	}
-
-	.page-header {
-		margin-bottom: 1.5rem;
-	}
-
-	.page-header h1 {
-		margin: 0;
-		font-size: 1.5rem;
-		color: #1e293b;
-	}
-
-	.subtitle {
-		margin: 0.25rem 0 0;
-		font-size: 0.875rem;
-		color: #64748b;
-	}
-
-	.tab-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1rem;
-		padding-top: 0.5rem;
-	}
-
-	.tab-count {
-		font-size: 0.875rem;
-		color: #64748b;
-	}
-
-	.filter-buttons {
-		display: flex;
-		gap: 0.25rem;
-	}
-
-	.filter-btn {
-		padding: 0.375rem 0.75rem;
-		border: 1px solid #cbd5e1;
-		border-radius: 6px;
-		background: white;
-		font-size: 0.8125rem;
-		color: #64748b;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.filter-btn:hover {
-		background: #f1f5f9;
-		color: #1e293b;
-	}
-
-	.filter-btn.active {
-		background: #eff6ff;
-		color: #3b82f6;
-		border-color: #3b82f6;
-	}
-
-	/* Table styles */
-	.table-wrapper {
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		font-size: 0.875rem;
-	}
-
-	th {
-		text-align: left;
-		padding: 0.75rem 1rem;
-		border-bottom: 2px solid #e2e8f0;
-		color: #475569;
-		font-weight: 600;
-		white-space: nowrap;
-	}
-
-	td {
-		padding: 0.75rem 1rem;
-		border-bottom: 1px solid #f1f5f9;
-		color: #1e293b;
-	}
-
-	tr.clickable {
-		cursor: pointer;
-		transition: background 0.1s;
-	}
-
-	tr.clickable:hover {
-		background: #f8fafc;
-	}
-
-	.fact-type {
-		font-weight: 500;
-		white-space: nowrap;
-	}
-
-	.truncated {
-		max-width: 300px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.count {
-		text-align: center;
-	}
-
-	.date {
-		white-space: nowrap;
-	}
-
-	td a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	td a:hover {
-		text-decoration: underline;
-	}
-
-	.text-muted {
-		color: #94a3b8;
-	}
-
-	/* Card styles (mobile) */
-	.cards-wrapper {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.card {
-		display: block;
-		background: white;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
-		padding: 1rem;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.15s, box-shadow 0.15s;
-	}
-
-	.card:hover {
-		border-color: #cbd5e1;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-	}
-
-	.card-top {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.5rem;
-	}
-
-	.card-fact-type {
-		font-weight: 600;
-		font-size: 0.875rem;
-		color: #1e293b;
-	}
-
-	.card-conclusion {
-		margin: 0;
-		font-size: 0.8125rem;
-		color: #475569;
-		line-height: 1.4;
-	}
-
-	.card-meta {
-		margin-top: 0.5rem;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	/* Responsive: show table on desktop, cards on mobile */
-	.desktop-only {
-		display: block;
-	}
-
-	.mobile-only {
-		display: none;
-	}
-
-	@media (max-width: 768px) {
-		.desktop-only {
-			display: none;
-		}
-
-		.mobile-only {
-			display: flex;
-		}
-
-		.tab-header {
-			flex-wrap: wrap;
-			gap: 0.5rem;
-		}
-	}
-
-	/* Loading / empty / error states */
-	.loading,
-	.empty {
-		text-align: center;
-		padding: 3rem;
-		color: #64748b;
-	}
-
-	.empty p {
-		margin: 0 0 0.5rem;
-	}
-
-	.empty-hint {
-		font-size: 0.8125rem;
-		color: #94a3b8;
-		margin-bottom: 1rem !important;
-	}
-
-	.error-state {
-		text-align: center;
-		padding: 3rem;
-		color: #dc2626;
-	}
-
-	.error-state p {
-		margin: 0 0 1rem;
-	}
-
-	/* Pagination */
-	.pagination {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		gap: 1rem;
-		margin-top: 2rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	.pagination button {
-		padding: 0.5rem 1rem;
-		border: 1px solid #cbd5e1;
-		border-radius: 6px;
-		background: white;
-		font-size: 0.875rem;
-		cursor: pointer;
-	}
-
-	.pagination button:hover:not(:disabled) {
-		background: #f1f5f9;
-	}
-
-	.pagination button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.pagination span {
-		font-size: 0.875rem;
-		color: #64748b;
-	}
-</style>

--- a/web/src/routes/evidence/+page.svelte
+++ b/web/src/routes/evidence/+page.svelte
@@ -12,9 +12,27 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
-	import { formatFactType, subjectRoute, formatDate } from '$lib/utils/evidence';
+	import {
+		formatFactType,
+		subjectRoute,
+		formatDate,
+		outcomeBadgeProps,
+		conflictBadgeProps
+	} from '$lib/utils/evidence';
 
 	const pageSize = 20;
+
+	// Shared class strings for the desktop tables. Same pattern as the
+	// {#snippet pagination} below — single place to change when the table styling
+	// evolves, rather than 20+ <th>/<td> sites.
+	const TH_CLASS =
+		'whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600';
+	const TD_CLASS = 'border-b border-slate-100 px-4 py-3 text-slate-800';
+	const TD_NOWRAP = `${TD_CLASS} whitespace-nowrap font-medium`;
+	const TD_TRUNCATE = `${TD_CLASS} max-w-xs overflow-hidden text-ellipsis whitespace-nowrap`;
+	const TD_CENTER = `${TD_CLASS} text-center`;
+	const ROW_CLICKABLE = 'cursor-pointer transition-colors hover:bg-slate-50';
+	const SUBJECT_LINK = 'text-blue-500 no-underline hover:underline';
 
 	// Active tab
 	let activeTab = $state('analyses');
@@ -169,19 +187,44 @@
 	<div
 		class="mt-8 flex items-center justify-center gap-4 border-t border-slate-200 pt-4"
 	>
-		<Button variant="outline" size="sm" onclick={onPrev} disabled={currentPage === 1 || loading}>
+		<Button
+			variant="outline"
+			size="sm"
+			onclick={() => {
+				if (currentPage > 1) onPrev();
+			}}
+			disabled={currentPage === 1 || loading}
+		>
 			Previous
 		</Button>
 		<span class="text-sm text-slate-500">Page {currentPage} of {totalPages}</span>
 		<Button
 			variant="outline"
 			size="sm"
-			onclick={onNext}
+			onclick={() => {
+				if (currentPage < totalPages) onNext();
+			}}
 			disabled={currentPage >= totalPages || loading}
 		>
 			Next
 		</Button>
 	</div>
+{/snippet}
+
+{#snippet mobileCard(href: string, topLeft: string, body: string, meta: string | null, badge: import('svelte').Snippet)}
+	<a
+		href={href}
+		class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
+	>
+		<div class="mb-2 flex items-center justify-between">
+			<span class="text-sm font-semibold text-slate-800">{topLeft}</span>
+			{@render badge()}
+		</div>
+		<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">{body}</p>
+		{#if meta}
+			<div class="mt-2 text-xs text-slate-400">{meta}</div>
+		{/if}
+	</a>
 {/snippet}
 
 <div class="mx-auto max-w-screen-xl p-6">
@@ -239,17 +282,17 @@
 					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Conclusion</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Citations</th>
+								<th class={TH_CLASS}>Fact Type</th>
+								<th class={TH_CLASS}>Subject</th>
+								<th class={TH_CLASS}>Conclusion</th>
+								<th class={TH_CLASS}>Status</th>
+								<th class={TH_CLASS}>Citations</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each analyses as analysis}
 								<tr
-									class="cursor-pointer transition-colors hover:bg-slate-50"
+									class={ROW_CLICKABLE}
 									tabindex="0"
 									role="link"
 									onclick={() => goto(`/evidence/analyses/${analysis.id}`)}
@@ -260,31 +303,25 @@
 										}
 									}}
 								>
-									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
-										{formatFactType(analysis.fact_type)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_NOWRAP}>{formatFactType(analysis.fact_type)}</td>
+									<td class={TD_CLASS}>
 										<a
 											href="/{subjectRoute(analysis.fact_type)}/{analysis.subject_id}"
-											class="text-blue-500 no-underline hover:underline"
+											class={SUBJECT_LINK}
 											onclick={(e) => e.stopPropagation()}
 										>
 											{analysis.subject_id.slice(0, 8)}...
 										</a>
 									</td>
-									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
-										{truncate(analysis.conclusion)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_TRUNCATE}>{truncate(analysis.conclusion)}</td>
+									<td class={TD_CLASS}>
 										{#if analysis.research_status}
 											<UncertaintyBadge status={analysis.research_status} showLabel />
 										{:else}
 											<span class="text-slate-400">--</span>
 										{/if}
 									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-center text-slate-800">
-										{analysis.citation_ids?.length ?? 0}
-									</td>
+									<td class={TD_CENTER}>{analysis.citation_ids?.length ?? 0}</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -294,25 +331,22 @@
 				<!-- Mobile cards -->
 				<div class="flex flex-col gap-3 md:hidden">
 					{#each analyses as analysis}
-						<a
-							href="/evidence/analyses/{analysis.id}"
-							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
-						>
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-semibold text-slate-800">
-									{formatFactType(analysis.fact_type)}
-								</span>
-								{#if analysis.research_status}
-									<UncertaintyBadge status={analysis.research_status} showLabel size="small" />
-								{/if}
-							</div>
-							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
-								{truncate(analysis.conclusion, 120)}
-							</p>
-							<div class="mt-2 text-xs text-slate-400">
-								<span>{analysis.citation_ids?.length ?? 0} citations</span>
-							</div>
-						</a>
+						{#snippet analysisBadge()}
+							{#if analysis.research_status}
+								<UncertaintyBadge
+									status={analysis.research_status}
+									showLabel
+									size="small"
+								/>
+							{/if}
+						{/snippet}
+						{@render mobileCard(
+							`/evidence/analyses/${analysis.id}`,
+							formatFactType(analysis.fact_type),
+							truncate(analysis.conclusion, 120),
+							`${analysis.citation_ids?.length ?? 0} citations`,
+							analysisBadge
+						)}
 					{/each}
 				</div>
 
@@ -378,16 +412,17 @@
 					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Description</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
+								<th class={TH_CLASS}>Fact Type</th>
+								<th class={TH_CLASS}>Subject</th>
+								<th class={TH_CLASS}>Description</th>
+								<th class={TH_CLASS}>Status</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each conflicts as conflict}
+								{@const statusBadge = conflictBadgeProps(conflict.status)}
 								<tr
-									class="cursor-pointer transition-colors hover:bg-slate-50"
+									class={ROW_CLICKABLE}
 									tabindex="0"
 									role="link"
 									onclick={() => goto(`/evidence/conflicts/${conflict.id}`)}
@@ -398,27 +433,21 @@
 										}
 									}}
 								>
-									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
-										{formatFactType(conflict.fact_type)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_NOWRAP}>{formatFactType(conflict.fact_type)}</td>
+									<td class={TD_CLASS}>
 										<a
 											href="/{subjectRoute(conflict.fact_type)}/{conflict.subject_id}"
-											class="text-blue-500 no-underline hover:underline"
+											class={SUBJECT_LINK}
 											onclick={(e) => e.stopPropagation()}
 										>
 											{conflict.subject_id.slice(0, 8)}...
 										</a>
 									</td>
-									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
-										{truncate(conflict.description)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
-										{#if conflict.status === 'open'}
-											<Badge variant="destructive">Open</Badge>
-										{:else}
-											<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
-										{/if}
+									<td class={TD_TRUNCATE}>{truncate(conflict.description)}</td>
+									<td class={TD_CLASS}>
+										<Badge variant={statusBadge.variant} class={statusBadge.class}>
+											{statusBadge.label}
+										</Badge>
 									</td>
 								</tr>
 							{/each}
@@ -429,24 +458,19 @@
 				<!-- Mobile cards -->
 				<div class="flex flex-col gap-3 md:hidden">
 					{#each conflicts as conflict}
-						<a
-							href="/evidence/conflicts/{conflict.id}"
-							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
-						>
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-semibold text-slate-800">
-									{formatFactType(conflict.fact_type)}
-								</span>
-								{#if conflict.status === 'open'}
-									<Badge variant="destructive">Open</Badge>
-								{:else}
-									<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
-								{/if}
-							</div>
-							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
-								{truncate(conflict.description, 120)}
-							</p>
-						</a>
+						{@const statusBadge = conflictBadgeProps(conflict.status)}
+						{#snippet conflictMobileBadge()}
+							<Badge variant={statusBadge.variant} class={statusBadge.class}>
+								{statusBadge.label}
+							</Badge>
+						{/snippet}
+						{@render mobileCard(
+							`/evidence/conflicts/${conflict.id}`,
+							formatFactType(conflict.fact_type),
+							truncate(conflict.description, 120),
+							null,
+							conflictMobileBadge
+						)}
 					{/each}
 				</div>
 
@@ -498,17 +522,18 @@
 					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Repository</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Search Description</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Outcome</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Date</th>
+								<th class={TH_CLASS}>Subject</th>
+								<th class={TH_CLASS}>Repository</th>
+								<th class={TH_CLASS}>Search Description</th>
+								<th class={TH_CLASS}>Outcome</th>
+								<th class={TH_CLASS}>Date</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each logs as log}
+								{@const outcomeBadge = outcomeBadgeProps(log.outcome)}
 								<tr
-									class="cursor-pointer transition-colors hover:bg-slate-50"
+									class={ROW_CLICKABLE}
 									tabindex="0"
 									role="link"
 									onclick={() => goto(`/evidence/research-logs/${log.id}`)}
@@ -519,29 +544,23 @@
 										}
 									}}
 								>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_CLASS}>
 										<a
 											href="/{log.subject_type === 'family' ? 'families' : 'persons'}/{log.subject_id}"
-											class="text-blue-500 no-underline hover:underline"
+											class={SUBJECT_LINK}
 											onclick={(e) => e.stopPropagation()}
 										>
 											{log.subject_id.slice(0, 8)}...
 										</a>
 									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">{log.repository}</td>
-									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
-										{truncate(log.search_description)}
+									<td class={TD_CLASS}>{log.repository}</td>
+									<td class={TD_TRUNCATE}>{truncate(log.search_description)}</td>
+									<td class={TD_CLASS}>
+										<Badge variant={outcomeBadge.variant} class={outcomeBadge.class}>
+											{outcomeBadge.label}
+										</Badge>
 									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
-										{#if log.outcome === 'found'}
-											<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
-										{:else if log.outcome === 'not_found'}
-											<Badge variant="destructive">Not Found</Badge>
-										{:else}
-											<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
-										{/if}
-									</td>
-									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={`${TD_CLASS} whitespace-nowrap`}>
 										{formatDate(log.search_date)}
 									</td>
 								</tr>
@@ -553,27 +572,19 @@
 				<!-- Mobile cards -->
 				<div class="flex flex-col gap-3 md:hidden">
 					{#each logs as log}
-						<a
-							href="/evidence/research-logs/{log.id}"
-							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
-						>
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-semibold text-slate-800">{log.repository}</span>
-								{#if log.outcome === 'found'}
-									<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
-								{:else if log.outcome === 'not_found'}
-									<Badge variant="destructive">Not Found</Badge>
-								{:else}
-									<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
-								{/if}
-							</div>
-							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
-								{truncate(log.search_description, 120)}
-							</p>
-							<div class="mt-2 text-xs text-slate-400">
-								<span>{formatDate(log.search_date)}</span>
-							</div>
-						</a>
+						{@const outcomeBadge = outcomeBadgeProps(log.outcome)}
+						{#snippet logMobileBadge()}
+							<Badge variant={outcomeBadge.variant} class={outcomeBadge.class}>
+								{outcomeBadge.label}
+							</Badge>
+						{/snippet}
+						{@render mobileCard(
+							`/evidence/research-logs/${log.id}`,
+							log.repository,
+							truncate(log.search_description, 120),
+							formatDate(log.search_date),
+							logMobileBadge
+						)}
 					{/each}
 				</div>
 
@@ -625,17 +636,17 @@
 					<table class="w-full border-collapse text-sm">
 						<thead>
 							<tr>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Fact Type</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Subject</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Conclusion</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Status</th>
-								<th class="whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600">Analyses</th>
+								<th class={TH_CLASS}>Fact Type</th>
+								<th class={TH_CLASS}>Subject</th>
+								<th class={TH_CLASS}>Conclusion</th>
+								<th class={TH_CLASS}>Status</th>
+								<th class={TH_CLASS}>Analyses</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each summaries as summary}
 								<tr
-									class="cursor-pointer transition-colors hover:bg-slate-50"
+									class={ROW_CLICKABLE}
 									tabindex="0"
 									role="link"
 									onclick={() => goto(`/evidence/proof-summaries/${summary.id}`)}
@@ -646,31 +657,25 @@
 										}
 									}}
 								>
-									<td class="whitespace-nowrap border-b border-slate-100 px-4 py-3 font-medium text-slate-800">
-										{formatFactType(summary.fact_type)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_NOWRAP}>{formatFactType(summary.fact_type)}</td>
+									<td class={TD_CLASS}>
 										<a
 											href="/{subjectRoute(summary.fact_type)}/{summary.subject_id}"
-											class="text-blue-500 no-underline hover:underline"
+											class={SUBJECT_LINK}
 											onclick={(e) => e.stopPropagation()}
 										>
 											{summary.subject_id.slice(0, 8)}...
 										</a>
 									</td>
-									<td class="max-w-xs overflow-hidden text-ellipsis whitespace-nowrap border-b border-slate-100 px-4 py-3 text-slate-800">
-										{truncate(summary.conclusion)}
-									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-slate-800">
+									<td class={TD_TRUNCATE}>{truncate(summary.conclusion)}</td>
+									<td class={TD_CLASS}>
 										{#if summary.research_status}
 											<UncertaintyBadge status={summary.research_status} showLabel />
 										{:else}
 											<span class="text-slate-400">--</span>
 										{/if}
 									</td>
-									<td class="border-b border-slate-100 px-4 py-3 text-center text-slate-800">
-										{summary.analysis_ids?.length ?? 0}
-									</td>
+									<td class={TD_CENTER}>{summary.analysis_ids?.length ?? 0}</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -680,25 +685,22 @@
 				<!-- Mobile cards -->
 				<div class="flex flex-col gap-3 md:hidden">
 					{#each summaries as summary}
-						<a
-							href="/evidence/proof-summaries/{summary.id}"
-							class="block rounded-lg border border-slate-200 bg-white p-4 text-inherit no-underline transition-shadow hover:border-slate-300 hover:shadow-sm"
-						>
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-semibold text-slate-800">
-									{formatFactType(summary.fact_type)}
-								</span>
-								{#if summary.research_status}
-									<UncertaintyBadge status={summary.research_status} showLabel size="small" />
-								{/if}
-							</div>
-							<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">
-								{truncate(summary.conclusion, 120)}
-							</p>
-							<div class="mt-2 text-xs text-slate-400">
-								<span>{summary.analysis_ids?.length ?? 0} linked analyses</span>
-							</div>
-						</a>
+						{#snippet summaryBadge()}
+							{#if summary.research_status}
+								<UncertaintyBadge
+									status={summary.research_status}
+									showLabel
+									size="small"
+								/>
+							{/if}
+						{/snippet}
+						{@render mobileCard(
+							`/evidence/proof-summaries/${summary.id}`,
+							formatFactType(summary.fact_type),
+							truncate(summary.conclusion, 120),
+							`${summary.analysis_ids?.length ?? 0} linked analyses`,
+							summaryBadge
+						)}
 					{/each}
 				</div>
 

--- a/web/src/routes/evidence/analyses/[id]/+page.svelte
+++ b/web/src/routes/evidence/analyses/[id]/+page.svelte
@@ -9,6 +9,9 @@
 	} from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
 	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
 
@@ -22,6 +25,11 @@
 	];
 
 	const researchStatuses = ['certain', 'probable', 'possible', 'unknown'] as const;
+
+	// Native <select> styled to match shadcn Input. Matches Input class signature so
+	// focus ring, border, and disabled state stay consistent with other form controls.
+	const nativeSelectClass =
+		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let analysis: EvidenceAnalysisResponse | null = $state(null);
 	let loading = $state(true);
@@ -198,11 +206,13 @@
 	<title>{isNew ? 'New Analysis' : analysis ? 'Analysis' : 'Evidence Analysis'} | My Family</title>
 </svelte:head>
 
-<div class="detail-page">
-	<header class="page-header">
-		<a href="/evidence" class="back-link">&larr; Evidence</a>
+<div class="mx-auto max-w-3xl p-6">
+	<header class="mb-6 flex items-center justify-between">
+		<a href="/evidence" class="text-sm text-slate-500 no-underline hover:text-blue-500">
+			&larr; Evidence
+		</a>
 		{#if analysis && !editing}
-			<div class="actions">
+			<div class="flex gap-2">
 				<Button variant="outline" onclick={startEdit}>Edit</Button>
 				<Button variant="destructive" onclick={deleteAnalysis} disabled={deleting}>
 					{deleting ? 'Deleting...' : 'Delete'}
@@ -212,75 +222,130 @@
 	</header>
 
 	{#if loading}
-		<div class="loading">Loading...</div>
+		<div class="p-12 text-center text-slate-500">Loading...</div>
 	{:else if error && !analysis && !isNew}
-		<div class="error">
-			<p>{error}</p>
+		<div class="p-12 text-center text-red-600">
+			<p class="m-0 mb-4">{error}</p>
 			<Button variant="outline" onclick={() => loadAnalysis($page.params.id!)}>Retry</Button>
 		</div>
 	{:else if editing}
-		<form class="edit-form" onsubmit={(e) => { e.preventDefault(); saveAnalysis(); }}>
-			<h1>{isNew ? 'New Evidence Analysis' : 'Edit Analysis'}</h1>
+		<form
+			class="rounded-xl border border-slate-200 bg-white p-6"
+			onsubmit={(e) => {
+				e.preventDefault();
+				saveAnalysis();
+			}}
+		>
+			<h1 class="m-0 mb-6 text-xl text-slate-800">
+				{isNew ? 'New Evidence Analysis' : 'Edit Analysis'}
+			</h1>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="form-row">
-				<label>
-					Fact Type <span class="required">*</span>
-					<select bind:value={formData.fact_type} aria-label="Fact Type">
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="fact-type" class="text-sm text-slate-600">
+						Fact Type <span class="text-red-600">*</span>
+					</Label>
+					<select
+						id="fact-type"
+						bind:value={formData.fact_type}
+						aria-label="Fact Type"
+						class={nativeSelectClass}
+					>
 						{#each factTypes as ft}
 							<option value={ft}>{formatFactType(ft)}</option>
 						{/each}
 					</select>
-				</label>
-				<label>
-					Subject ID <span class="required">*</span>
-					<input type="text" bind:value={formData.subject_id} required placeholder="Person or family UUID" aria-label="Subject ID" />
-				</label>
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<Label for="subject-id" class="text-sm text-slate-600">
+						Subject ID <span class="text-red-600">*</span>
+					</Label>
+					<Input
+						id="subject-id"
+						type="text"
+						bind:value={formData.subject_id}
+						required
+						placeholder="Person or family UUID"
+						aria-label="Subject ID"
+					/>
+				</div>
 			</div>
 
-			<label>
-				Conclusion <span class="required">*</span>
-				<textarea bind:value={formData.conclusion} rows="3" required aria-label="Conclusion"></textarea>
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="conclusion" class="text-sm text-slate-600">
+					Conclusion <span class="text-red-600">*</span>
+				</Label>
+				<Textarea
+					id="conclusion"
+					bind:value={formData.conclusion}
+					rows={3}
+					required
+					aria-label="Conclusion"
+				/>
+			</div>
 
-			<div class="form-row">
-				<label>
-					Research Status
-					<select bind:value={formData.research_status} aria-label="Research Status">
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="research-status" class="text-sm text-slate-600">Research Status</Label>
+					<select
+						id="research-status"
+						bind:value={formData.research_status}
+						aria-label="Research Status"
+						class={nativeSelectClass}
+					>
 						{#each researchStatuses as s}
 							<option value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
 						{/each}
 					</select>
-				</label>
+				</div>
 			</div>
 
-			<label>
-				Notes
-				<textarea bind:value={formData.notes} rows="3" aria-label="Notes"></textarea>
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="notes" class="text-sm text-slate-600">Notes</Label>
+				<Textarea id="notes" bind:value={formData.notes} rows={3} aria-label="Notes" />
+			</div>
 
-			<div class="list-field">
-				<h3>Citation IDs</h3>
+			<div class="mb-4">
+				<h3 class="m-0 mb-2 text-sm text-slate-600">Citation IDs</h3>
 				{#if formData.citation_ids.length > 0}
-					<ul class="id-list">
+					<ul class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
 						{#each formData.citation_ids as cid}
-							<li>
-								<code>{cid}</code>
-								<button type="button" class="remove-btn" onclick={() => removeCitation(cid)} aria-label="Remove citation {cid}">x</button>
+							<li class="flex items-center gap-2">
+								<code class="rounded bg-slate-100 px-2 py-1 text-[0.8125rem]">{cid}</code>
+								<button
+									type="button"
+									class="rounded border-none bg-transparent px-1.5 py-0.5 text-sm text-red-600 hover:bg-red-50"
+									onclick={() => removeCitation(cid)}
+									aria-label="Remove citation {cid}"
+								>
+									x
+								</button>
 							</li>
 						{/each}
 					</ul>
 				{/if}
-				<div class="add-id-row">
-					<input type="text" bind:value={newCitationId} placeholder="Citation UUID" aria-label="New citation ID" />
+				<div class="flex items-center gap-2">
+					<Input
+						type="text"
+						bind:value={newCitationId}
+						placeholder="Citation UUID"
+						aria-label="New citation ID"
+						class="flex-1"
+					/>
 					<Button type="button" variant="outline" onclick={addCitation}>Add</Button>
 				</div>
 			</div>
 
-			<div class="form-actions">
+			<div class="mt-6 flex justify-end gap-3 border-t border-slate-200 pt-4">
 				<Button variant="outline" onclick={cancelEdit} disabled={saving}>Cancel</Button>
 				<Button type="submit" disabled={saving}>
 					{saving ? 'Saving...' : isNew ? 'Create Analysis' : 'Save Changes'}
@@ -288,10 +353,10 @@
 			</div>
 		</form>
 	{:else if analysis}
-		<div class="detail-card">
-			<div class="detail-header">
-				<h1>Evidence Analysis</h1>
-				<div class="header-badges">
+		<div class="rounded-xl border border-slate-200 bg-white p-6">
+			<div class="mb-6 border-b border-slate-200 pb-4">
+				<h1 class="m-0 mb-2 text-2xl text-slate-800">Evidence Analysis</h1>
+				<div class="flex items-center gap-2">
 					<Badge variant="secondary">{formatFactType(analysis.fact_type)}</Badge>
 					{#if analysis.research_status}
 						<UncertaintyBadge status={analysis.research_status} showLabel />
@@ -300,49 +365,88 @@
 			</div>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="info-grid">
-				<div class="info-section">
-					<h2>Details</h2>
-					<dl>
-						<dt>Subject</dt>
-						<dd><a href="/{subjectRoute(analysis.fact_type)}/{analysis.subject_id}">{analysis.subject_id}</a></dd>
-						<dt>Fact Type</dt>
-						<dd>{formatFactType(analysis.fact_type)}</dd>
+			<div
+				class="mb-6 grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-6"
+			>
+				<div class="mb-6">
+					<h2
+						class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500"
+					>
+						Details
+					</h2>
+					<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+						<dt class="text-[0.8125rem] text-slate-400">Subject</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							<a
+								href="/{subjectRoute(analysis.fact_type)}/{analysis.subject_id}"
+								class="text-blue-500 no-underline hover:underline"
+							>
+								{analysis.subject_id}
+							</a>
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Fact Type</dt>
+						<dd class="m-0 text-sm text-slate-800">{formatFactType(analysis.fact_type)}</dd>
 						{#if analysis.conflict_id}
-							<dt>Conflict</dt>
-							<dd><a href="/evidence/conflicts/{analysis.conflict_id}">{analysis.conflict_id.slice(0, 8)}...</a></dd>
+							<dt class="text-[0.8125rem] text-slate-400">Conflict</dt>
+							<dd class="m-0 text-sm text-slate-800">
+								<a
+									href="/evidence/conflicts/{analysis.conflict_id}"
+									class="text-blue-500 no-underline hover:underline"
+								>
+									{analysis.conflict_id.slice(0, 8)}...
+								</a>
+							</dd>
 						{/if}
 					</dl>
 				</div>
 			</div>
 
-			<div class="info-section">
-				<h2>Conclusion</h2>
-				<p class="text-content">{analysis.conclusion}</p>
+			<div class="mb-6">
+				<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+					Conclusion
+				</h2>
+				<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+					{analysis.conclusion}
+				</p>
 			</div>
 
 			{#if analysis.notes}
-				<div class="info-section">
-					<h2>Notes</h2>
-					<p class="text-content">{analysis.notes}</p>
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Notes
+					</h2>
+					<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+						{analysis.notes}
+					</p>
 				</div>
 			{/if}
 
 			{#if analysis.citation_ids && analysis.citation_ids.length > 0}
-				<div class="info-section">
-					<h2>Citations ({analysis.citation_ids.length})</h2>
-					<ul class="linked-ids">
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Citations ({analysis.citation_ids.length})
+					</h2>
+					<ul class="m-0 flex list-none flex-col gap-1.5 p-0">
 						{#each analysis.citation_ids as cid}
-							<li><code>{cid}</code></li>
+							<li>
+								<code class="rounded bg-slate-100 px-2 py-1 text-[0.8125rem]">{cid}</code>
+							</li>
 						{/each}
 					</ul>
 				</div>
 			{/if}
 
-			<div class="meta-footer">
+			<div
+				class="mt-6 flex flex-wrap gap-6 border-t border-slate-200 pt-4 text-xs text-slate-400"
+			>
 				{#if analysis.created_at}
 					<span>Created: {new Date(analysis.created_at).toLocaleDateString()}</span>
 				{/if}
@@ -354,296 +458,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.detail-page {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 1.5rem;
-	}
-
-	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1.5rem;
-	}
-
-	.back-link {
-		color: #64748b;
-		text-decoration: none;
-		font-size: 0.875rem;
-	}
-
-	.back-link:hover {
-		color: #3b82f6;
-	}
-
-	.actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.loading {
-		text-align: center;
-		padding: 3rem;
-		color: #64748b;
-	}
-
-	.error {
-		text-align: center;
-		padding: 3rem;
-		color: #dc2626;
-	}
-
-	.error p {
-		margin: 0 0 1rem;
-	}
-
-	.detail-card {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.detail-header {
-		margin-bottom: 1.5rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid #e2e8f0;
-	}
-
-	.detail-header h1 {
-		margin: 0 0 0.5rem;
-		font-size: 1.5rem;
-		color: #1e293b;
-	}
-
-	.header-badges {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.info-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 1.5rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section {
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section h2 {
-		margin: 0 0 0.75rem;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #64748b;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.info-section dl {
-		margin: 0;
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.25rem 1rem;
-	}
-
-	.info-section dt {
-		color: #94a3b8;
-		font-size: 0.8125rem;
-	}
-
-	.info-section dd {
-		margin: 0;
-		color: #1e293b;
-		font-size: 0.875rem;
-	}
-
-	.info-section dd a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.info-section dd a:hover {
-		text-decoration: underline;
-	}
-
-	.text-content {
-		margin: 0;
-		color: #475569;
-		font-size: 0.875rem;
-		white-space: pre-wrap;
-		line-height: 1.6;
-	}
-
-	.linked-ids {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-	}
-
-	.linked-ids code {
-		font-size: 0.8125rem;
-		background: #f1f5f9;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.meta-footer {
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-		display: flex;
-		gap: 1.5rem;
-		flex-wrap: wrap;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	/* Edit form styles */
-	.edit-form {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.edit-form h1 {
-		margin: 0 0 1.5rem;
-		font-size: 1.25rem;
-		color: #1e293b;
-	}
-
-	.form-error {
-		padding: 0.75rem;
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 6px;
-		color: #dc2626;
-		font-size: 0.875rem;
-		margin-bottom: 1rem;
-	}
-
-	.form-row {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.edit-form label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		font-size: 0.875rem;
-		color: #475569;
-		margin-bottom: 1rem;
-	}
-
-	.required {
-		color: #dc2626;
-	}
-
-	.edit-form input,
-	.edit-form select,
-	.edit-form textarea {
-		padding: 0.625rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-	}
-
-	.edit-form input:focus,
-	.edit-form select:focus,
-	.edit-form textarea:focus {
-		outline: none;
-		border-color: #3b82f6;
-		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-	}
-
-	.edit-form textarea {
-		resize: vertical;
-	}
-
-	.list-field {
-		margin-bottom: 1rem;
-	}
-
-	.list-field h3 {
-		margin: 0 0 0.5rem;
-		font-size: 0.875rem;
-		color: #475569;
-	}
-
-	.id-list {
-		list-style: none;
-		padding: 0;
-		margin: 0 0 0.5rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.id-list li {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.id-list code {
-		font-size: 0.8125rem;
-		background: #f1f5f9;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.remove-btn {
-		background: none;
-		border: none;
-		color: #dc2626;
-		cursor: pointer;
-		font-size: 0.875rem;
-		padding: 0.125rem 0.375rem;
-		border-radius: 4px;
-	}
-
-	.remove-btn:hover {
-		background: #fef2f2;
-	}
-
-	.add-id-row {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.add-id-row input {
-		flex: 1;
-		padding: 0.5rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-	}
-
-	.form-actions {
-		display: flex;
-		justify-content: flex-end;
-		gap: 0.75rem;
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	@media (max-width: 640px) {
-		.form-row {
-			grid-template-columns: 1fr;
-		}
-	}
-</style>

--- a/web/src/routes/evidence/analyses/[id]/+page.svelte
+++ b/web/src/routes/evidence/analyses/[id]/+page.svelte
@@ -14,6 +14,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
 	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
+	import { nativeSelectClass } from '$lib/utils/forms';
 
 	const factTypes = [
 		'person_birth', 'person_death', 'person_name', 'person_gender',
@@ -25,11 +26,6 @@
 	];
 
 	const researchStatuses = ['certain', 'probable', 'possible', 'unknown'] as const;
-
-	// Native <select> styled to match shadcn Input. Matches Input class signature so
-	// focus ring, border, and disabled state stay consistent with other form controls.
-	const nativeSelectClass =
-		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let analysis: EvidenceAnalysisResponse | null = $state(null);
 	let loading = $state(true);

--- a/web/src/routes/evidence/conflicts/[id]/+page.svelte
+++ b/web/src/routes/evidence/conflicts/[id]/+page.svelte
@@ -11,7 +11,11 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
-	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
+	import {
+		formatFactType,
+		subjectRoute,
+		conflictBadgeProps
+	} from '$lib/utils/evidence';
 
 	let conflict: EvidenceConflictResponse | null = $state(null);
 	let linkedAnalyses: EvidenceAnalysisResponse[] = $state([]);
@@ -98,16 +102,15 @@
 			<Button variant="outline" onclick={() => loadConflict($page.params.id!)}>Retry</Button>
 		</div>
 	{:else if conflict}
+		{@const statusBadge = conflictBadgeProps(conflict.status)}
 		<div class="rounded-xl border border-slate-200 bg-white p-6">
 			<div class="mb-6 border-b border-slate-200 pb-4">
 				<h1 class="m-0 mb-2 text-2xl text-slate-800">Evidence Conflict</h1>
 				<div class="flex items-center gap-2">
 					<Badge variant="secondary">{formatFactType(conflict.fact_type)}</Badge>
-					{#if conflict.status === 'open'}
-						<Badge variant="destructive">Open</Badge>
-					{:else}
-						<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
-					{/if}
+					<Badge variant={statusBadge.variant} class={statusBadge.class}>
+						{statusBadge.label}
+					</Badge>
 				</div>
 			</div>
 

--- a/web/src/routes/evidence/conflicts/[id]/+page.svelte
+++ b/web/src/routes/evidence/conflicts/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
 	import {
 		api,
 		type EvidenceConflictResponse,
@@ -9,6 +8,8 @@
 	} from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Label } from '$lib/components/ui/label';
+	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
 	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
 
@@ -82,102 +83,166 @@
 	<title>Evidence Conflict | My Family</title>
 </svelte:head>
 
-<div class="detail-page">
-	<header class="page-header">
-		<a href="/evidence" class="back-link">&larr; Evidence</a>
+<div class="mx-auto max-w-3xl p-6">
+	<header class="mb-6 flex items-center justify-between">
+		<a href="/evidence" class="text-sm text-slate-500 no-underline hover:text-blue-500">
+			&larr; Evidence
+		</a>
 	</header>
 
 	{#if loading}
-		<div class="loading">Loading...</div>
+		<div class="p-12 text-center text-slate-500">Loading...</div>
 	{:else if error && !conflict}
-		<div class="error">
-			<p>{error}</p>
+		<div class="p-12 text-center text-red-600">
+			<p class="m-0 mb-4">{error}</p>
 			<Button variant="outline" onclick={() => loadConflict($page.params.id!)}>Retry</Button>
 		</div>
 	{:else if conflict}
-		<div class="detail-card">
-			<div class="detail-header">
-				<h1>Evidence Conflict</h1>
-				<div class="header-badges">
+		<div class="rounded-xl border border-slate-200 bg-white p-6">
+			<div class="mb-6 border-b border-slate-200 pb-4">
+				<h1 class="m-0 mb-2 text-2xl text-slate-800">Evidence Conflict</h1>
+				<div class="flex items-center gap-2">
 					<Badge variant="secondary">{formatFactType(conflict.fact_type)}</Badge>
 					{#if conflict.status === 'open'}
 						<Badge variant="destructive">Open</Badge>
 					{:else}
-						<Badge class="bg-green-50 text-green-700 border-green-200">Resolved</Badge>
+						<Badge class="border-green-200 bg-green-50 text-green-700">Resolved</Badge>
 					{/if}
 				</div>
 			</div>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="info-grid">
-				<div class="info-section">
-					<h2>Details</h2>
-					<dl>
-						<dt>Subject</dt>
-						<dd><a href="/{subjectRoute(conflict.fact_type)}/{conflict.subject_id}">{conflict.subject_id}</a></dd>
-						<dt>Fact Type</dt>
-						<dd>{formatFactType(conflict.fact_type)}</dd>
-						<dt>Status</dt>
-						<dd class="status-{conflict.status}">{conflict.status.charAt(0).toUpperCase() + conflict.status.slice(1)}</dd>
+			<div
+				class="mb-6 grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-6"
+			>
+				<div class="mb-6">
+					<h2
+						class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500"
+					>
+						Details
+					</h2>
+					<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+						<dt class="text-[0.8125rem] text-slate-400">Subject</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							<a
+								href="/{subjectRoute(conflict.fact_type)}/{conflict.subject_id}"
+								class="text-blue-500 no-underline hover:underline"
+							>
+								{conflict.subject_id}
+							</a>
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Fact Type</dt>
+						<dd class="m-0 text-sm text-slate-800">{formatFactType(conflict.fact_type)}</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Status</dt>
+						<dd
+							class="m-0 text-sm font-medium {conflict.status === 'open'
+								? 'text-red-600'
+								: 'text-green-600'}"
+						>
+							{conflict.status.charAt(0).toUpperCase() + conflict.status.slice(1)}
+						</dd>
 					</dl>
 				</div>
 			</div>
 
-			<div class="info-section">
-				<h2>Description</h2>
-				<p class="text-content">{conflict.description}</p>
+			<div class="mb-6">
+				<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+					Description
+				</h2>
+				<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+					{conflict.description}
+				</p>
 			</div>
 
 			{#if conflict.resolution}
-				<div class="info-section resolution-section">
-					<h2>Resolution</h2>
-					<p class="text-content">{conflict.resolution}</p>
+				<div class="mb-6 rounded-lg border border-green-200 bg-green-50 p-4">
+					<h2
+						class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500"
+					>
+						Resolution
+					</h2>
+					<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+						{conflict.resolution}
+					</p>
 				</div>
 			{/if}
 
 			{#if linkedAnalyses.length > 0}
-				<div class="info-section">
-					<h2>Linked Analyses ({linkedAnalyses.length})</h2>
-					<div class="analysis-cards">
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Linked Analyses ({linkedAnalyses.length})
+					</h2>
+					<div class="flex flex-col gap-3">
 						{#each linkedAnalyses as la}
-							<a href="/evidence/analyses/{la.id}" class="analysis-card">
-								<div class="analysis-card-header">
-									<span class="analysis-fact-type">{formatFactType(la.fact_type)}</span>
+							<a
+								href="/evidence/analyses/{la.id}"
+								class="block rounded-lg border border-slate-200 p-4 text-inherit no-underline transition-colors hover:border-blue-500"
+							>
+								<div class="mb-2 flex items-center justify-between">
+									<span class="text-sm font-semibold text-slate-800">
+										{formatFactType(la.fact_type)}
+									</span>
 									{#if la.research_status}
 										<UncertaintyBadge status={la.research_status} showLabel size="small" />
 									{/if}
 								</div>
-								<p class="analysis-conclusion">{la.conclusion}</p>
+								<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">{la.conclusion}</p>
 								{#if la.citation_ids && la.citation_ids.length > 0}
-									<span class="analysis-meta">{la.citation_ids.length} citations</span>
+									<span class="mt-2 inline-block text-xs text-slate-400">
+										{la.citation_ids.length} citations
+									</span>
 								{/if}
 							</a>
 						{/each}
 					</div>
 				</div>
 			{:else if conflict.analysis_ids && conflict.analysis_ids.length > 0}
-				<div class="info-section">
-					<h2>Linked Analysis IDs ({conflict.analysis_ids.length})</h2>
-					<ul class="linked-ids">
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Linked Analysis IDs ({conflict.analysis_ids.length})
+					</h2>
+					<ul class="m-0 flex list-none flex-col gap-1.5 p-0">
 						{#each conflict.analysis_ids as aid}
-							<li><a href="/evidence/analyses/{aid}"><code>{aid}</code></a></li>
+							<li>
+								<a
+									href="/evidence/analyses/{aid}"
+									class="text-blue-500 no-underline hover:underline"
+								>
+									<code class="rounded bg-slate-100 px-2 py-1 text-[0.8125rem]">{aid}</code>
+								</a>
+							</li>
 						{/each}
 					</ul>
 				</div>
 			{/if}
 
 			{#if conflict.status === 'open'}
-				<div class="resolve-section">
-					<h2>Resolve Conflict</h2>
-					<p class="resolve-hint">Provide a resolution explaining how this conflict was addressed.</p>
-					<label>
-						Resolution <span class="required">*</span>
-						<textarea bind:value={resolutionText} rows="4" placeholder="Describe how this conflict was resolved..." aria-label="Resolution text"></textarea>
-					</label>
-					<div class="resolve-actions">
+				<div class="mt-6 border-t-2 border-red-200 pt-6">
+					<h2 class="m-0 mb-2 text-base font-semibold text-slate-800">Resolve Conflict</h2>
+					<p class="m-0 mb-4 text-[0.8125rem] text-slate-500">
+						Provide a resolution explaining how this conflict was addressed.
+					</p>
+					<div class="flex flex-col gap-1.5">
+						<Label for="resolution" class="text-sm text-slate-600">
+							Resolution <span class="text-red-600">*</span>
+						</Label>
+						<Textarea
+							id="resolution"
+							bind:value={resolutionText}
+							rows={4}
+							placeholder="Describe how this conflict was resolved..."
+							aria-label="Resolution text"
+						/>
+					</div>
+					<div class="mt-4 flex justify-end">
 						<Button onclick={resolveConflict} disabled={resolving}>
 							{resolving ? 'Resolving...' : 'Resolve Conflict'}
 						</Button>
@@ -185,7 +250,9 @@
 				</div>
 			{/if}
 
-			<div class="meta-footer">
+			<div
+				class="mt-6 flex flex-wrap gap-6 border-t border-slate-200 pt-4 text-xs text-slate-400"
+			>
 				{#if conflict.created_at}
 					<span>Created: {new Date(conflict.created_at).toLocaleDateString()}</span>
 				{/if}
@@ -197,285 +264,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.detail-page {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 1.5rem;
-	}
-
-	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1.5rem;
-	}
-
-	.back-link {
-		color: #64748b;
-		text-decoration: none;
-		font-size: 0.875rem;
-	}
-
-	.back-link:hover {
-		color: #3b82f6;
-	}
-
-	.loading {
-		text-align: center;
-		padding: 3rem;
-		color: #64748b;
-	}
-
-	.error {
-		text-align: center;
-		padding: 3rem;
-		color: #dc2626;
-	}
-
-	.error p {
-		margin: 0 0 1rem;
-	}
-
-	.detail-card {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.detail-header {
-		margin-bottom: 1.5rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid #e2e8f0;
-	}
-
-	.detail-header h1 {
-		margin: 0 0 0.5rem;
-		font-size: 1.5rem;
-		color: #1e293b;
-	}
-
-	.header-badges {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.form-error {
-		padding: 0.75rem;
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 6px;
-		color: #dc2626;
-		font-size: 0.875rem;
-		margin-bottom: 1rem;
-	}
-
-	.info-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 1.5rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section {
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section h2 {
-		margin: 0 0 0.75rem;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #64748b;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.info-section dl {
-		margin: 0;
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.25rem 1rem;
-	}
-
-	.info-section dt {
-		color: #94a3b8;
-		font-size: 0.8125rem;
-	}
-
-	.info-section dd {
-		margin: 0;
-		color: #1e293b;
-		font-size: 0.875rem;
-	}
-
-	.info-section dd a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.info-section dd a:hover {
-		text-decoration: underline;
-	}
-
-	.status-open {
-		color: #dc2626;
-		font-weight: 500;
-	}
-
-	.status-resolved {
-		color: #16a34a;
-		font-weight: 500;
-	}
-
-	.text-content {
-		margin: 0;
-		color: #475569;
-		font-size: 0.875rem;
-		white-space: pre-wrap;
-		line-height: 1.6;
-	}
-
-	.resolution-section {
-		background: #f0fdf4;
-		border: 1px solid #bbf7d0;
-		border-radius: 8px;
-		padding: 1rem;
-	}
-
-	.linked-ids {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-	}
-
-	.linked-ids a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.linked-ids a:hover {
-		text-decoration: underline;
-	}
-
-	.linked-ids code {
-		font-size: 0.8125rem;
-		background: #f1f5f9;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.analysis-cards {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.analysis-card {
-		display: block;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
-		padding: 1rem;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.15s;
-	}
-
-	.analysis-card:hover {
-		border-color: #3b82f6;
-	}
-
-	.analysis-card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.5rem;
-	}
-
-	.analysis-fact-type {
-		font-weight: 600;
-		font-size: 0.875rem;
-		color: #1e293b;
-	}
-
-	.analysis-conclusion {
-		margin: 0;
-		font-size: 0.8125rem;
-		color: #475569;
-		line-height: 1.4;
-	}
-
-	.analysis-meta {
-		display: inline-block;
-		margin-top: 0.5rem;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	.resolve-section {
-		margin-top: 1.5rem;
-		padding-top: 1.5rem;
-		border-top: 2px solid #fecaca;
-	}
-
-	.resolve-section h2 {
-		margin: 0 0 0.5rem;
-		font-size: 1rem;
-		font-weight: 600;
-		color: #1e293b;
-	}
-
-	.resolve-hint {
-		margin: 0 0 1rem;
-		font-size: 0.8125rem;
-		color: #64748b;
-	}
-
-	.resolve-section label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		font-size: 0.875rem;
-		color: #475569;
-	}
-
-	.required {
-		color: #dc2626;
-	}
-
-	.resolve-section textarea {
-		padding: 0.625rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-		resize: vertical;
-	}
-
-	.resolve-section textarea:focus {
-		outline: none;
-		border-color: #3b82f6;
-		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-	}
-
-	.resolve-actions {
-		display: flex;
-		justify-content: flex-end;
-		margin-top: 1rem;
-	}
-
-	.meta-footer {
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-		display: flex;
-		gap: 1.5rem;
-		flex-wrap: wrap;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-</style>

--- a/web/src/routes/evidence/proof-summaries/[id]/+page.svelte
+++ b/web/src/routes/evidence/proof-summaries/[id]/+page.svelte
@@ -15,6 +15,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
 	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
+	import { nativeSelectClass } from '$lib/utils/forms';
 
 	const factTypes = [
 		'person_birth', 'person_death', 'person_name', 'person_gender',
@@ -26,10 +27,6 @@
 	];
 
 	const researchStatuses = ['certain', 'probable', 'possible', 'unknown'] as const;
-
-	// Native <select> styled to match shadcn Input for visual consistency.
-	const nativeSelectClass =
-		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let summary: ProofSummaryResponse | null = $state(null);
 	let linkedAnalyses: EvidenceAnalysisResponse[] = $state([]);

--- a/web/src/routes/evidence/proof-summaries/[id]/+page.svelte
+++ b/web/src/routes/evidence/proof-summaries/[id]/+page.svelte
@@ -10,6 +10,9 @@
 	} from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Textarea } from '$lib/components/ui/textarea';
 	import UncertaintyBadge from '$lib/components/UncertaintyBadge.svelte';
 	import { formatFactType, subjectRoute } from '$lib/utils/evidence';
 
@@ -23,6 +26,10 @@
 	];
 
 	const researchStatuses = ['certain', 'probable', 'possible', 'unknown'] as const;
+
+	// Native <select> styled to match shadcn Input for visual consistency.
+	const nativeSelectClass =
+		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let summary: ProofSummaryResponse | null = $state(null);
 	let linkedAnalyses: EvidenceAnalysisResponse[] = $state([]);
@@ -230,11 +237,13 @@
 	<title>{isNew ? 'New Proof Summary' : 'Proof Summary'} | My Family</title>
 </svelte:head>
 
-<div class="detail-page">
-	<header class="page-header">
-		<a href="/evidence" class="back-link">&larr; Evidence</a>
+<div class="mx-auto max-w-3xl p-6">
+	<header class="mb-6 flex items-center justify-between">
+		<a href="/evidence" class="text-sm text-slate-500 no-underline hover:text-blue-500">
+			&larr; Evidence
+		</a>
 		{#if summary && !editing}
-			<div class="actions">
+			<div class="flex gap-2">
 				<Button variant="outline" onclick={startEdit}>Edit</Button>
 				<Button variant="destructive" onclick={deleteSummary} disabled={deleting}>
 					{deleting ? 'Deleting...' : 'Delete'}
@@ -244,75 +253,139 @@
 	</header>
 
 	{#if loading}
-		<div class="loading">Loading...</div>
+		<div class="p-12 text-center text-slate-500">Loading...</div>
 	{:else if error && !summary && !isNew}
-		<div class="error">
-			<p>{error}</p>
+		<div class="p-12 text-center text-red-600">
+			<p class="m-0 mb-4">{error}</p>
 			<Button variant="outline" onclick={() => loadSummary($page.params.id!)}>Retry</Button>
 		</div>
 	{:else if editing}
-		<form class="edit-form" onsubmit={(e) => { e.preventDefault(); saveSummary(); }}>
-			<h1>{isNew ? 'New Proof Summary' : 'Edit Proof Summary'}</h1>
+		<form
+			class="rounded-xl border border-slate-200 bg-white p-6"
+			onsubmit={(e) => {
+				e.preventDefault();
+				saveSummary();
+			}}
+		>
+			<h1 class="m-0 mb-6 text-xl text-slate-800">
+				{isNew ? 'New Proof Summary' : 'Edit Proof Summary'}
+			</h1>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="form-row">
-				<label>
-					Fact Type <span class="required">*</span>
-					<select bind:value={formData.fact_type} aria-label="Fact Type">
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="fact-type" class="text-sm text-slate-600">
+						Fact Type <span class="text-red-600">*</span>
+					</Label>
+					<select
+						id="fact-type"
+						bind:value={formData.fact_type}
+						aria-label="Fact Type"
+						class={nativeSelectClass}
+					>
 						{#each factTypes as ft}
 							<option value={ft}>{formatFactType(ft)}</option>
 						{/each}
 					</select>
-				</label>
-				<label>
-					Subject ID <span class="required">*</span>
-					<input type="text" bind:value={formData.subject_id} required placeholder="Person or family UUID" aria-label="Subject ID" />
-				</label>
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<Label for="subject-id" class="text-sm text-slate-600">
+						Subject ID <span class="text-red-600">*</span>
+					</Label>
+					<Input
+						id="subject-id"
+						type="text"
+						bind:value={formData.subject_id}
+						required
+						placeholder="Person or family UUID"
+						aria-label="Subject ID"
+					/>
+				</div>
 			</div>
 
-			<label>
-				Conclusion <span class="required">*</span>
-				<input type="text" bind:value={formData.conclusion} required aria-label="Conclusion" />
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="conclusion" class="text-sm text-slate-600">
+					Conclusion <span class="text-red-600">*</span>
+				</Label>
+				<Input
+					id="conclusion"
+					type="text"
+					bind:value={formData.conclusion}
+					required
+					aria-label="Conclusion"
+				/>
+			</div>
 
-			<label>
-				Argument <span class="required">*</span>
-				<textarea bind:value={formData.argument} rows="10" required placeholder="Present the full proof argument, evaluating each piece of evidence..." aria-label="Argument"></textarea>
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="argument" class="text-sm text-slate-600">
+					Argument <span class="text-red-600">*</span>
+				</Label>
+				<Textarea
+					id="argument"
+					bind:value={formData.argument}
+					rows={10}
+					required
+					placeholder="Present the full proof argument, evaluating each piece of evidence..."
+					aria-label="Argument"
+				/>
+			</div>
 
-			<div class="form-row">
-				<label>
-					Research Status
-					<select bind:value={formData.research_status} aria-label="Research Status">
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="research-status" class="text-sm text-slate-600">Research Status</Label>
+					<select
+						id="research-status"
+						bind:value={formData.research_status}
+						aria-label="Research Status"
+						class={nativeSelectClass}
+					>
 						{#each researchStatuses as s}
 							<option value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
 						{/each}
 					</select>
-				</label>
+				</div>
 			</div>
 
-			<div class="list-field">
-				<h3>Linked Analysis IDs</h3>
+			<div class="mb-4">
+				<h3 class="m-0 mb-2 text-sm text-slate-600">Linked Analysis IDs</h3>
 				{#if formData.analysis_ids.length > 0}
-					<ul class="id-list">
+					<ul class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
 						{#each formData.analysis_ids as aid}
-							<li>
-								<code>{aid}</code>
-								<button type="button" class="remove-btn" onclick={() => removeAnalysis(aid)} aria-label="Remove analysis {aid}">x</button>
+							<li class="flex items-center gap-2">
+								<code class="rounded bg-slate-100 px-2 py-1 text-[0.8125rem]">{aid}</code>
+								<button
+									type="button"
+									class="rounded border-none bg-transparent px-1.5 py-0.5 text-sm text-red-600 hover:bg-red-50"
+									onclick={() => removeAnalysis(aid)}
+									aria-label="Remove analysis {aid}"
+								>
+									x
+								</button>
 							</li>
 						{/each}
 					</ul>
 				{/if}
-				<div class="add-id-row">
-					<input type="text" bind:value={newAnalysisId} placeholder="Analysis UUID" aria-label="New analysis ID" />
+				<div class="flex items-center gap-2">
+					<Input
+						type="text"
+						bind:value={newAnalysisId}
+						placeholder="Analysis UUID"
+						aria-label="New analysis ID"
+						class="flex-1"
+					/>
 					<Button type="button" variant="outline" onclick={addAnalysis}>Add</Button>
 				</div>
 			</div>
 
-			<div class="form-actions">
+			<div class="mt-6 flex justify-end gap-3 border-t border-slate-200 pt-4">
 				<Button variant="outline" onclick={cancelEdit} disabled={saving}>Cancel</Button>
 				<Button type="submit" disabled={saving}>
 					{saving ? 'Saving...' : isNew ? 'Create Proof Summary' : 'Save Changes'}
@@ -320,10 +393,10 @@
 			</div>
 		</form>
 	{:else if summary}
-		<div class="detail-card">
-			<div class="detail-header">
-				<h1>Proof Summary</h1>
-				<div class="header-badges">
+		<div class="rounded-xl border border-slate-200 bg-white p-6">
+			<div class="mb-6 border-b border-slate-200 pb-4">
+				<h1 class="m-0 mb-2 text-2xl text-slate-800">Proof Summary</h1>
+				<div class="flex items-center gap-2">
 					<Badge variant="secondary">{formatFactType(summary.fact_type)}</Badge>
 					{#if summary.research_status}
 						<UncertaintyBadge status={summary.research_status} showLabel />
@@ -332,63 +405,111 @@
 			</div>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="info-grid">
-				<div class="info-section">
-					<h2>Details</h2>
-					<dl>
-						<dt>Subject</dt>
-						<dd><a href="/{subjectRoute(summary.fact_type)}/{summary.subject_id}">{summary.subject_id}</a></dd>
-						<dt>Fact Type</dt>
-						<dd>{formatFactType(summary.fact_type)}</dd>
+			<div
+				class="mb-6 grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-6"
+			>
+				<div class="mb-6">
+					<h2
+						class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500"
+					>
+						Details
+					</h2>
+					<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+						<dt class="text-[0.8125rem] text-slate-400">Subject</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							<a
+								href="/{subjectRoute(summary.fact_type)}/{summary.subject_id}"
+								class="text-blue-500 no-underline hover:underline"
+							>
+								{summary.subject_id}
+							</a>
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Fact Type</dt>
+						<dd class="m-0 text-sm text-slate-800">{formatFactType(summary.fact_type)}</dd>
 					</dl>
 				</div>
 			</div>
 
-			<div class="info-section">
-				<h2>Conclusion</h2>
-				<p class="text-content conclusion-text">{summary.conclusion}</p>
+			<div class="mb-6">
+				<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+					Conclusion
+				</h2>
+				<p
+					class="m-0 whitespace-pre-wrap text-base font-medium leading-relaxed text-slate-800"
+				>
+					{summary.conclusion}
+				</p>
 			</div>
 
-			<div class="info-section argument-section">
-				<h2>Argument</h2>
-				<div class="argument-text">{summary.argument}</div>
+			<div class="mb-6 rounded-lg border border-slate-200 bg-slate-50 p-5">
+				<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+					Argument
+				</h2>
+				<div class="m-0 whitespace-pre-wrap text-[0.9375rem] leading-loose text-slate-700">
+					{summary.argument}
+				</div>
 			</div>
 
 			{#if linkedAnalyses.length > 0}
-				<div class="info-section">
-					<h2>Supporting Analyses ({linkedAnalyses.length})</h2>
-					<div class="analysis-cards">
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Supporting Analyses ({linkedAnalyses.length})
+					</h2>
+					<div class="flex flex-col gap-3">
 						{#each linkedAnalyses as la}
-							<a href="/evidence/analyses/{la.id}" class="analysis-card">
-								<div class="analysis-card-header">
-									<span class="analysis-fact-type">{formatFactType(la.fact_type)}</span>
+							<a
+								href="/evidence/analyses/{la.id}"
+								class="block rounded-lg border border-slate-200 p-4 text-inherit no-underline transition-colors hover:border-blue-500"
+							>
+								<div class="mb-2 flex items-center justify-between">
+									<span class="text-sm font-semibold text-slate-800">
+										{formatFactType(la.fact_type)}
+									</span>
 									{#if la.research_status}
 										<UncertaintyBadge status={la.research_status} showLabel size="small" />
 									{/if}
 								</div>
-								<p class="analysis-conclusion">{la.conclusion}</p>
+								<p class="m-0 text-[0.8125rem] leading-snug text-slate-600">{la.conclusion}</p>
 								{#if la.citation_ids && la.citation_ids.length > 0}
-									<span class="analysis-meta">{la.citation_ids.length} citations</span>
+									<span class="mt-2 inline-block text-xs text-slate-400">
+										{la.citation_ids.length} citations
+									</span>
 								{/if}
 							</a>
 						{/each}
 					</div>
 				</div>
 			{:else if summary.analysis_ids && summary.analysis_ids.length > 0}
-				<div class="info-section">
-					<h2>Linked Analysis IDs ({summary.analysis_ids.length})</h2>
-					<ul class="linked-ids">
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Linked Analysis IDs ({summary.analysis_ids.length})
+					</h2>
+					<ul class="m-0 flex list-none flex-col gap-1.5 p-0">
 						{#each summary.analysis_ids as aid}
-							<li><a href="/evidence/analyses/{aid}"><code>{aid}</code></a></li>
+							<li>
+								<a
+									href="/evidence/analyses/{aid}"
+									class="text-blue-500 no-underline hover:underline"
+								>
+									<code class="rounded bg-slate-100 px-2 py-1 text-[0.8125rem]">{aid}</code>
+								</a>
+							</li>
 						{/each}
 					</ul>
 				</div>
 			{/if}
 
-			<div class="meta-footer">
+			<div
+				class="mt-6 flex flex-wrap gap-6 border-t border-slate-200 pt-4 text-xs text-slate-400"
+			>
 				{#if summary.created_at}
 					<span>Created: {new Date(summary.created_at).toLocaleDateString()}</span>
 				{/if}
@@ -400,373 +521,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.detail-page {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 1.5rem;
-	}
-
-	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1.5rem;
-	}
-
-	.back-link {
-		color: #64748b;
-		text-decoration: none;
-		font-size: 0.875rem;
-	}
-
-	.back-link:hover {
-		color: #3b82f6;
-	}
-
-	.actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.loading {
-		text-align: center;
-		padding: 3rem;
-		color: #64748b;
-	}
-
-	.error {
-		text-align: center;
-		padding: 3rem;
-		color: #dc2626;
-	}
-
-	.error p {
-		margin: 0 0 1rem;
-	}
-
-	.detail-card {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.detail-header {
-		margin-bottom: 1.5rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid #e2e8f0;
-	}
-
-	.detail-header h1 {
-		margin: 0 0 0.5rem;
-		font-size: 1.5rem;
-		color: #1e293b;
-	}
-
-	.header-badges {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.info-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 1.5rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section {
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section h2 {
-		margin: 0 0 0.75rem;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #64748b;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.info-section dl {
-		margin: 0;
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.25rem 1rem;
-	}
-
-	.info-section dt {
-		color: #94a3b8;
-		font-size: 0.8125rem;
-	}
-
-	.info-section dd {
-		margin: 0;
-		color: #1e293b;
-		font-size: 0.875rem;
-	}
-
-	.info-section dd a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.info-section dd a:hover {
-		text-decoration: underline;
-	}
-
-	.text-content {
-		margin: 0;
-		color: #475569;
-		font-size: 0.875rem;
-		white-space: pre-wrap;
-		line-height: 1.6;
-	}
-
-	.conclusion-text {
-		font-weight: 500;
-		font-size: 1rem;
-		color: #1e293b;
-	}
-
-	.argument-section {
-		background: #f8fafc;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
-		padding: 1.25rem;
-	}
-
-	.argument-text {
-		margin: 0;
-		color: #334155;
-		font-size: 0.9375rem;
-		white-space: pre-wrap;
-		line-height: 1.8;
-	}
-
-	.linked-ids {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-	}
-
-	.linked-ids a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.linked-ids a:hover {
-		text-decoration: underline;
-	}
-
-	.linked-ids code {
-		font-size: 0.8125rem;
-		background: #f1f5f9;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.analysis-cards {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.analysis-card {
-		display: block;
-		border: 1px solid #e2e8f0;
-		border-radius: 8px;
-		padding: 1rem;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.15s;
-	}
-
-	.analysis-card:hover {
-		border-color: #3b82f6;
-	}
-
-	.analysis-card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.5rem;
-	}
-
-	.analysis-fact-type {
-		font-weight: 600;
-		font-size: 0.875rem;
-		color: #1e293b;
-	}
-
-	.analysis-conclusion {
-		margin: 0;
-		font-size: 0.8125rem;
-		color: #475569;
-		line-height: 1.4;
-	}
-
-	.analysis-meta {
-		display: inline-block;
-		margin-top: 0.5rem;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	.meta-footer {
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-		display: flex;
-		gap: 1.5rem;
-		flex-wrap: wrap;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	/* Edit form styles */
-	.edit-form {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.edit-form h1 {
-		margin: 0 0 1.5rem;
-		font-size: 1.25rem;
-		color: #1e293b;
-	}
-
-	.form-error {
-		padding: 0.75rem;
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 6px;
-		color: #dc2626;
-		font-size: 0.875rem;
-		margin-bottom: 1rem;
-	}
-
-	.form-row {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.edit-form label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		font-size: 0.875rem;
-		color: #475569;
-		margin-bottom: 1rem;
-	}
-
-	.required {
-		color: #dc2626;
-	}
-
-	.edit-form input,
-	.edit-form select,
-	.edit-form textarea {
-		padding: 0.625rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-	}
-
-	.edit-form input:focus,
-	.edit-form select:focus,
-	.edit-form textarea:focus {
-		outline: none;
-		border-color: #3b82f6;
-		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-	}
-
-	.edit-form textarea {
-		resize: vertical;
-	}
-
-	.list-field {
-		margin-bottom: 1rem;
-	}
-
-	.list-field h3 {
-		margin: 0 0 0.5rem;
-		font-size: 0.875rem;
-		color: #475569;
-	}
-
-	.id-list {
-		list-style: none;
-		padding: 0;
-		margin: 0 0 0.5rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.id-list li {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.id-list code {
-		font-size: 0.8125rem;
-		background: #f1f5f9;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.remove-btn {
-		background: none;
-		border: none;
-		color: #dc2626;
-		cursor: pointer;
-		font-size: 0.875rem;
-		padding: 0.125rem 0.375rem;
-		border-radius: 4px;
-	}
-
-	.remove-btn:hover {
-		background: #fef2f2;
-	}
-
-	.add-id-row {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.add-id-row input {
-		flex: 1;
-		padding: 0.5rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-	}
-
-	.form-actions {
-		display: flex;
-		justify-content: flex-end;
-		gap: 0.75rem;
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	@media (max-width: 640px) {
-		.form-row {
-			grid-template-columns: 1fr;
-		}
-	}
-</style>

--- a/web/src/routes/evidence/research-logs/[id]/+page.svelte
+++ b/web/src/routes/evidence/research-logs/[id]/+page.svelte
@@ -12,13 +12,10 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
-	import { toRFC3339 } from '$lib/utils/evidence';
+	import { toRFC3339, outcomeBadgeProps } from '$lib/utils/evidence';
+	import { nativeSelectClass } from '$lib/utils/forms';
 
 	const outcomes = ['found', 'not_found', 'inconclusive'] as const;
-
-	// Native <select> styled to match shadcn Input for visual consistency.
-	const nativeSelectClass =
-		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let log: ResearchLogResponse | null = $state(null);
 	let loading = $state(true);
@@ -311,17 +308,14 @@
 			</div>
 		</form>
 	{:else if log}
+		{@const outcomeBadge = outcomeBadgeProps(log.outcome)}
 		<div class="rounded-xl border border-slate-200 bg-white p-6">
 			<div class="mb-6 border-b border-slate-200 pb-4">
 				<h1 class="m-0 mb-2 text-2xl text-slate-800">Research Log</h1>
 				<div class="flex items-center gap-2">
-					{#if log.outcome === 'found'}
-						<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
-					{:else if log.outcome === 'not_found'}
-						<Badge variant="destructive">Not Found</Badge>
-					{:else}
-						<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
-					{/if}
+					<Badge variant={outcomeBadge.variant} class={outcomeBadge.class}>
+						{outcomeBadge.label}
+					</Badge>
 				</div>
 			</div>
 

--- a/web/src/routes/evidence/research-logs/[id]/+page.svelte
+++ b/web/src/routes/evidence/research-logs/[id]/+page.svelte
@@ -9,9 +9,16 @@
 	} from '$lib/api/client';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Textarea } from '$lib/components/ui/textarea';
 	import { toRFC3339 } from '$lib/utils/evidence';
 
 	const outcomes = ['found', 'not_found', 'inconclusive'] as const;
+
+	// Native <select> styled to match shadcn Input for visual consistency.
+	const nativeSelectClass =
+		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
 
 	let log: ResearchLogResponse | null = $state(null);
 	let loading = $state(true);
@@ -178,11 +185,13 @@
 	<title>{isNew ? 'New Research Log' : 'Research Log'} | My Family</title>
 </svelte:head>
 
-<div class="detail-page">
-	<header class="page-header">
-		<a href="/evidence" class="back-link">&larr; Evidence</a>
+<div class="mx-auto max-w-3xl p-6">
+	<header class="mb-6 flex items-center justify-between">
+		<a href="/evidence" class="text-sm text-slate-500 no-underline hover:text-blue-500">
+			&larr; Evidence
+		</a>
 		{#if log && !editing}
-			<div class="actions">
+			<div class="flex gap-2">
 				<Button variant="outline" onclick={startEdit}>Edit</Button>
 				<Button variant="destructive" onclick={deleteLog} disabled={deleting}>
 					{deleting ? 'Deleting...' : 'Delete'}
@@ -192,67 +201,109 @@
 	</header>
 
 	{#if loading}
-		<div class="loading">Loading...</div>
+		<div class="p-12 text-center text-slate-500">Loading...</div>
 	{:else if error && !log && !isNew}
-		<div class="error">
-			<p>{error}</p>
+		<div class="p-12 text-center text-red-600">
+			<p class="m-0 mb-4">{error}</p>
 			<Button variant="outline" onclick={() => loadLog($page.params.id!)}>Retry</Button>
 		</div>
 	{:else if editing}
-		<form class="edit-form" onsubmit={(e) => { e.preventDefault(); saveLog(); }}>
-			<h1>{isNew ? 'New Research Log' : 'Edit Research Log'}</h1>
+		<form
+			class="rounded-xl border border-slate-200 bg-white p-6"
+			onsubmit={(e) => {
+				e.preventDefault();
+				saveLog();
+			}}
+		>
+			<h1 class="m-0 mb-6 text-xl text-slate-800">
+				{isNew ? 'New Research Log' : 'Edit Research Log'}
+			</h1>
 
 			{#if error}
-				<div class="form-error" role="alert">{error}</div>
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600"
+					role="alert"
+				>
+					{error}
+				</div>
 			{/if}
 
-			<div class="form-row">
-				<label>
-					Subject ID <span class="required">*</span>
-					<input type="text" bind:value={formData.subject_id} required placeholder="Person or family UUID" />
-				</label>
-				<label>
-					Subject Type
-					<select bind:value={formData.subject_type}>
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="subject-id" class="text-sm text-slate-600">
+						Subject ID <span class="text-red-600">*</span>
+					</Label>
+					<Input
+						id="subject-id"
+						type="text"
+						bind:value={formData.subject_id}
+						required
+						placeholder="Person or family UUID"
+					/>
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<Label for="subject-type" class="text-sm text-slate-600">Subject Type</Label>
+					<select
+						id="subject-type"
+						bind:value={formData.subject_type}
+						class={nativeSelectClass}
+					>
 						<option value="person">Person</option>
 						<option value="family">Family</option>
 					</select>
-				</label>
+				</div>
 			</div>
 
-			<div class="form-row">
-				<label>
-					Repository <span class="required">*</span>
-					<input type="text" bind:value={formData.repository} required placeholder="e.g., National Archives" />
-				</label>
-				<label>
-					Search Date <span class="required">*</span>
-					<input type="date" bind:value={formData.search_date} required />
-				</label>
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="repository" class="text-sm text-slate-600">
+						Repository <span class="text-red-600">*</span>
+					</Label>
+					<Input
+						id="repository"
+						type="text"
+						bind:value={formData.repository}
+						required
+						placeholder="e.g., National Archives"
+					/>
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<Label for="search-date" class="text-sm text-slate-600">
+						Search Date <span class="text-red-600">*</span>
+					</Label>
+					<Input id="search-date" type="date" bind:value={formData.search_date} required />
+				</div>
 			</div>
 
-			<label>
-				Search Description <span class="required">*</span>
-				<textarea bind:value={formData.search_description} rows="3" required></textarea>
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="search-description" class="text-sm text-slate-600">
+					Search Description <span class="text-red-600">*</span>
+				</Label>
+				<Textarea
+					id="search-description"
+					bind:value={formData.search_description}
+					rows={3}
+					required
+				/>
+			</div>
 
-			<div class="form-row">
-				<label>
-					Outcome
-					<select bind:value={formData.outcome}>
+			<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<div class="flex flex-col gap-1.5">
+					<Label for="outcome" class="text-sm text-slate-600">Outcome</Label>
+					<select id="outcome" bind:value={formData.outcome} class={nativeSelectClass}>
 						{#each outcomes as o}
 							<option value={o}>{formatOutcome(o)}</option>
 						{/each}
 					</select>
-				</label>
+				</div>
 			</div>
 
-			<label>
-				Notes
-				<textarea bind:value={formData.notes} rows="3"></textarea>
-			</label>
+			<div class="mb-4 flex flex-col gap-1.5">
+				<Label for="notes" class="text-sm text-slate-600">Notes</Label>
+				<Textarea id="notes" bind:value={formData.notes} rows={3} />
+			</div>
 
-			<div class="form-actions">
+			<div class="mt-6 flex justify-end gap-3 border-t border-slate-200 pt-4">
 				<Button variant="outline" onclick={cancelEdit} disabled={saving}>Cancel</Button>
 				<Button type="submit" disabled={saving}>
 					{saving ? 'Saving...' : isNew ? 'Create Research Log' : 'Save Changes'}
@@ -260,51 +311,78 @@
 			</div>
 		</form>
 	{:else if log}
-		<div class="detail-card">
-			<div class="detail-header">
-				<h1>Research Log</h1>
-				<div class="header-badges">
+		<div class="rounded-xl border border-slate-200 bg-white p-6">
+			<div class="mb-6 border-b border-slate-200 pb-4">
+				<h1 class="m-0 mb-2 text-2xl text-slate-800">Research Log</h1>
+				<div class="flex items-center gap-2">
 					{#if log.outcome === 'found'}
-						<Badge class="bg-green-50 text-green-700 border-green-200">Found</Badge>
+						<Badge class="border-green-200 bg-green-50 text-green-700">Found</Badge>
 					{:else if log.outcome === 'not_found'}
 						<Badge variant="destructive">Not Found</Badge>
 					{:else}
-						<Badge class="bg-yellow-50 text-yellow-700 border-yellow-200">Inconclusive</Badge>
+						<Badge class="border-yellow-200 bg-yellow-50 text-yellow-700">Inconclusive</Badge>
 					{/if}
 				</div>
 			</div>
 
-			<div class="info-grid">
-				<div class="info-section">
-					<h2>Details</h2>
-					<dl>
-						<dt>Subject</dt>
-						<dd><a href="/{log.subject_type === 'family' ? 'families' : 'persons'}/{log.subject_id}">{log.subject_id}</a></dd>
-						<dt>Subject Type</dt>
-						<dd>{log.subject_type.charAt(0).toUpperCase() + log.subject_type.slice(1)}</dd>
-						<dt>Repository</dt>
-						<dd>{log.repository}</dd>
-						<dt>Search Date</dt>
-						<dd>{new Date(log.search_date).toLocaleDateString()}</dd>
-						<dt>Outcome</dt>
-						<dd>{formatOutcome(log.outcome)}</dd>
+			<div
+				class="mb-6 grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-6"
+			>
+				<div class="mb-6">
+					<h2
+						class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500"
+					>
+						Details
+					</h2>
+					<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+						<dt class="text-[0.8125rem] text-slate-400">Subject</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							<a
+								href="/{log.subject_type === 'family' ? 'families' : 'persons'}/{log.subject_id}"
+								class="text-blue-500 no-underline hover:underline"
+							>
+								{log.subject_id}
+							</a>
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Subject Type</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							{log.subject_type.charAt(0).toUpperCase() + log.subject_type.slice(1)}
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Repository</dt>
+						<dd class="m-0 text-sm text-slate-800">{log.repository}</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Search Date</dt>
+						<dd class="m-0 text-sm text-slate-800">
+							{new Date(log.search_date).toLocaleDateString()}
+						</dd>
+						<dt class="text-[0.8125rem] text-slate-400">Outcome</dt>
+						<dd class="m-0 text-sm text-slate-800">{formatOutcome(log.outcome)}</dd>
 					</dl>
 				</div>
 			</div>
 
-			<div class="info-section">
-				<h2>Search Description</h2>
-				<p class="text-content">{log.search_description}</p>
+			<div class="mb-6">
+				<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+					Search Description
+				</h2>
+				<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+					{log.search_description}
+				</p>
 			</div>
 
 			{#if log.notes}
-				<div class="info-section">
-					<h2>Notes</h2>
-					<p class="text-content">{log.notes}</p>
+				<div class="mb-6">
+					<h2 class="m-0 mb-3 text-sm font-semibold uppercase tracking-wider text-slate-500">
+						Notes
+					</h2>
+					<p class="m-0 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">
+						{log.notes}
+					</p>
 				</div>
 			{/if}
 
-			<div class="meta-footer">
+			<div
+				class="mt-6 flex flex-wrap gap-6 border-t border-slate-200 pt-4 text-xs text-slate-400"
+			>
 				{#if log.created_at}
 					<span>Created: {new Date(log.created_at).toLocaleDateString()}</span>
 				{/if}
@@ -316,220 +394,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.detail-page {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 1.5rem;
-	}
-
-	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1.5rem;
-	}
-
-	.back-link {
-		color: #64748b;
-		text-decoration: none;
-		font-size: 0.875rem;
-	}
-
-	.back-link:hover {
-		color: #3b82f6;
-	}
-
-	.actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.loading {
-		text-align: center;
-		padding: 3rem;
-		color: #64748b;
-	}
-
-	.error {
-		text-align: center;
-		padding: 3rem;
-		color: #dc2626;
-	}
-
-	.error p {
-		margin: 0 0 1rem;
-	}
-
-	.detail-card {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.detail-header {
-		margin-bottom: 1.5rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid #e2e8f0;
-	}
-
-	.detail-header h1 {
-		margin: 0 0 0.5rem;
-		font-size: 1.5rem;
-		color: #1e293b;
-	}
-
-	.header-badges {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-	}
-
-	.info-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 1.5rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section {
-		margin-bottom: 1.5rem;
-	}
-
-	.info-section h2 {
-		margin: 0 0 0.75rem;
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: #64748b;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.info-section dl {
-		margin: 0;
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.25rem 1rem;
-	}
-
-	.info-section dt {
-		color: #94a3b8;
-		font-size: 0.8125rem;
-	}
-
-	.info-section dd {
-		margin: 0;
-		color: #1e293b;
-		font-size: 0.875rem;
-	}
-
-	.info-section dd a {
-		color: #3b82f6;
-		text-decoration: none;
-	}
-
-	.info-section dd a:hover {
-		text-decoration: underline;
-	}
-
-	.text-content {
-		margin: 0;
-		color: #475569;
-		font-size: 0.875rem;
-		white-space: pre-wrap;
-		line-height: 1.6;
-	}
-
-	.meta-footer {
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-		display: flex;
-		gap: 1.5rem;
-		flex-wrap: wrap;
-		font-size: 0.75rem;
-		color: #94a3b8;
-	}
-
-	/* Edit form styles */
-	.edit-form {
-		background: white;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		padding: 1.5rem;
-	}
-
-	.edit-form h1 {
-		margin: 0 0 1.5rem;
-		font-size: 1.25rem;
-		color: #1e293b;
-	}
-
-	.form-error {
-		padding: 0.75rem;
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 6px;
-		color: #dc2626;
-		font-size: 0.875rem;
-		margin-bottom: 1rem;
-	}
-
-	.form-row {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.edit-form label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		font-size: 0.875rem;
-		color: #475569;
-		margin-bottom: 1rem;
-	}
-
-	.required {
-		color: #dc2626;
-	}
-
-	.edit-form input,
-	.edit-form select,
-	.edit-form textarea {
-		padding: 0.625rem 0.75rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-size: 0.875rem;
-	}
-
-	.edit-form input:focus,
-	.edit-form select:focus,
-	.edit-form textarea:focus {
-		outline: none;
-		border-color: #3b82f6;
-		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-	}
-
-	.edit-form textarea {
-		resize: vertical;
-	}
-
-	.form-actions {
-		display: flex;
-		justify-content: flex-end;
-		gap: 0.75rem;
-		margin-top: 1.5rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	@media (max-width: 640px) {
-		.form-row {
-			grid-template-columns: 1fr;
-		}
-	}
-</style>


### PR DESCRIPTION
## Summary

Refactor all 6 evidence UI surfaces to replace large custom `<style>` blocks with Tailwind utility classes + shadcn-svelte form primitives (`Input`, `Label`, `Textarea`). CodeRabbit flagged this during PR #388. Net diff is **−1,930 lines** across the two commits, almost entirely deleted CSS.

## Commits

1. **`refactor(ui): replace custom CSS in evidence pages with Tailwind + shadcn`** — initial 6-file conversion. Forms use shadcn primitives; native `<select>` kept and styled to match. Responsive table↔card switching preserved via `md:` prefixes.
2. **`refactor(ui): address panel review findings for #392 evidence refactor`** — follow-up addressing a multi-persona panel review:
   - New `$lib/utils/forms.ts` exports `nativeSelectClass` (was duplicated 3×)
   - New `outcomeBadgeProps`, `conflictBadgeProps`, `conflictRowClass` in `$lib/utils/evidence.ts` (replaces local `outcomeBadgeClass` and unifies 3 divergent inline conflict-status renders)
   - `evidence/+page.svelte`: extract `TH_CLASS`/`TD_*`/`ROW_CLICKABLE`/`SUBJECT_LINK` constants for the 4 tab tables; extract `{#snippet mobileCard}` for the 4 mobile card layouts
   - Pagination snippet now guards `currentPage > 1` / `currentPage < totalPages` inside Previous/Next handlers, closing a latent double-click race

## Test plan

- [x] `npx svelte-check --threshold error` — 0 errors
- [x] `make test` — 230/230 frontend tests pass (67 evidence-specific), all Go packages pass
- [x] `make lint` — 0 issues
- [x] Browser visual check at 1280px and 375px viewports confirms layout, form rendering, and responsive switching

## Notes

- `<select>` was intentionally kept native (styled to match shadcn `Input`) rather than swapped to shadcn `Select`. The shadcn Select uses bits-ui custom triggers that would have meant rewriting tests using `getByLabelText` and `bind:value` semantics. Same visual consistency, zero test churn.
- Existing `text-[0.8125rem]`/`text-[0.6875rem]` arbitrary values were transliterated from the old CSS as-is; they now live mostly in the shared `mobileCard` snippet and panel-internal styling so a single edit changes them everywhere. Promoting them to a Tailwind theme extension is a project-wide decision deferred.

Closes #392
