### PR TITLE
Add data validation and cleanup UI for #156

### DIFF
--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -3713,18 +3713,24 @@ type ValidationIssue struct {
 // ValidationIssueSeverity Severity level of the issue
 type ValidationIssueSeverity string
 
-// ValidationIssuesResponse Response containing validation issues categorized by severity
+// ValidationIssuesResponse Response containing validation issues categorized by severity.
+// Counts always cover the full unfiltered, unpaginated issue set;
+// `total` is the count of issues after the severity filter (if any)
+// but before pagination, suitable for driving page navigation.
 type ValidationIssuesResponse struct {
-	// ErrorCount Total number of error-level issues
+	// ErrorCount Total number of error-level issues (unfiltered)
 	ErrorCount int `json:"error_count"`
 
-	// InfoCount Total number of info-level issues
+	// InfoCount Total number of info-level issues (unfiltered)
 	InfoCount int `json:"info_count"`
 
-	// Issues List of validation issues
+	// Issues List of validation issues (paginated slice)
 	Issues []ValidationIssue `json:"issues"`
 
-	// WarningCount Total number of warning-level issues
+	// Total Total number of issues matching the severity filter (pre-pagination)
+	Total int `json:"total"`
+
+	// WarningCount Total number of warning-level issues (unfiltered)
 	WarningCount int `json:"warning_count"`
 }
 
@@ -4109,6 +4115,12 @@ type DeleteProofSummaryParams struct {
 type GetValidationIssuesParams struct {
 	// Severity Filter by severity level
 	Severity *GetValidationIssuesParamsSeverity `form:"severity,omitempty" json:"severity,omitempty"`
+
+	// Limit Maximum number of issues to return (post-severity-filter)
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of issues to skip (post-severity-filter)
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
 // GetValidationIssuesParamsSeverity defines parameters for GetValidationIssues.
@@ -6849,6 +6861,20 @@ func (w *ServerInterfaceWrapper) GetValidationIssues(ctx echo.Context) error {
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "severity", ctx.QueryParams(), &params.Severity, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter severity: %s", err))
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", ctx.QueryParams(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", ctx.QueryParams(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter offset: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2017,7 +2017,11 @@ paths:
     get:
       operationId: getValidationIssues
       summary: Get validation issues
-      description: Returns date logic and reference validation issues categorized by severity
+      description: |
+        Returns date logic and reference validation issues categorized by
+        severity. Supports pagination so a large tree does not produce an
+        unbounded response. The error/warning/info counts always reflect the
+        full unfiltered, unpaginated issue set.
       tags: [quality]
       parameters:
         - name: severity
@@ -2026,6 +2030,21 @@ paths:
           schema:
             type: string
             enum: [error, warning, info]
+        - name: limit
+          in: query
+          description: Maximum number of issues to return (post-severity-filter)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: Number of issues to skip (post-severity-filter)
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
       responses:
         '200':
           description: Validation issues
@@ -5591,23 +5610,30 @@ components:
 
     ValidationIssuesResponse:
       type: object
-      description: Response containing validation issues categorized by severity
-      required: [issues, error_count, warning_count, info_count]
+      description: |
+        Response containing validation issues categorized by severity.
+        Counts always cover the full unfiltered, unpaginated issue set;
+        `total` is the count of issues after the severity filter (if any)
+        but before pagination, suitable for driving page navigation.
+      required: [issues, total, error_count, warning_count, info_count]
       properties:
         issues:
           type: array
           items:
             $ref: '#/components/schemas/ValidationIssue'
-          description: List of validation issues
+          description: List of validation issues (paginated slice)
+        total:
+          type: integer
+          description: Total number of issues matching the severity filter (pre-pagination)
         error_count:
           type: integer
-          description: Total number of error-level issues
+          description: Total number of error-level issues (unfiltered)
         warning_count:
           type: integer
-          description: Total number of warning-level issues
+          description: Total number of warning-level issues (unfiltered)
         info_count:
           type: integer
-          description: Total number of info-level issues
+          description: Total number of info-level issues (unfiltered)
 
     Statistics:
       type: object

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -2497,15 +2497,24 @@ func (ss *StrictServer) GetValidationIssues(ctx context.Context, request GetVali
 		severityFilter = string(*request.Params.Severity)
 	}
 
-	results, err := ss.server.validationService.GetValidationIssues(ctx, severityFilter)
+	// Extract limit/offset with defaults matching the OpenAPI spec.
+	limit := 100
+	offset := 0
+	if request.Params.Limit != nil {
+		limit = *request.Params.Limit
+	}
+	if request.Params.Offset != nil {
+		offset = *request.Params.Offset
+	}
+
+	page, err := ss.server.validationService.GetValidationIssues(ctx, severityFilter, limit, offset)
 	if err != nil {
 		return nil, err
 	}
 
-	// Map to API types and count issues by severity
-	issues := make([]ValidationIssue, len(results))
-	errorCount, warningCount, infoCount := 0, 0, 0
-	for i, r := range results {
+	// Map to API types
+	issues := make([]ValidationIssue, len(page.Issues))
+	for i, r := range page.Issues {
 		issues[i] = ValidationIssue{
 			Severity: ValidationIssueSeverity(r.Severity),
 			Code:     r.Code,
@@ -2515,23 +2524,14 @@ func (ss *StrictServer) GetValidationIssues(ctx context.Context, request GetVali
 		if r.RelatedRecordID != nil {
 			issues[i].RelatedRecordId = r.RelatedRecordID
 		}
-
-		// Count by severity
-		switch r.Severity {
-		case "error":
-			errorCount++
-		case "warning":
-			warningCount++
-		case "info":
-			infoCount++
-		}
 	}
 
 	return GetValidationIssues200JSONResponse{
 		Issues:       issues,
-		ErrorCount:   errorCount,
-		WarningCount: warningCount,
-		InfoCount:    infoCount,
+		Total:        page.Total,
+		ErrorCount:   page.ErrorCount,
+		WarningCount: page.WarningCount,
+		InfoCount:    page.InfoCount,
 	}, nil
 }
 

--- a/internal/api/validation_handlers_test.go
+++ b/internal/api/validation_handlers_test.go
@@ -441,7 +441,7 @@ func TestGetValidationIssues_ResponseSchema(t *testing.T) {
 	}
 
 	// Check required fields
-	requiredFields := []string{"issues", "error_count", "warning_count", "info_count"}
+	requiredFields := []string{"issues", "total", "error_count", "warning_count", "info_count"}
 	for _, field := range requiredFields {
 		if _, ok := raw[field]; !ok {
 			t.Errorf("Missing required field: %s", field)

--- a/internal/query/validation_service.go
+++ b/internal/query/validation_service.go
@@ -162,8 +162,21 @@ func (s *ValidationService) FindDuplicates(ctx context.Context, limit, offset in
 	return results, total, nil
 }
 
-// GetValidationIssues returns validation issues, optionally filtered by severity.
-func (s *ValidationService) GetValidationIssues(ctx context.Context, severityFilter string) ([]ValidationIssueResult, error) {
+// ValidationIssuesPage is the result of a paginated validation-issues query.
+// Counts always reflect the full unfiltered issue set; Total reflects the
+// post-severity-filter, pre-pagination count.
+type ValidationIssuesPage struct {
+	Issues       []ValidationIssueResult
+	Total        int
+	ErrorCount   int
+	WarningCount int
+	InfoCount    int
+}
+
+// GetValidationIssues returns validation issues, optionally filtered by
+// severity and paginated. limit <= 0 means "no limit"; offset < 0 is treated
+// as 0.
+func (s *ValidationService) GetValidationIssues(ctx context.Context, severityFilter string, limit, offset int) (*ValidationIssuesPage, error) {
 	// Build gedcom document from read model
 	doc, xrefMap, err := s.buildGedcomDocument(ctx)
 	if err != nil {
@@ -175,14 +188,30 @@ func (s *ValidationService) GetValidationIssues(ctx context.Context, severityFil
 		Strictness: validator.StrictnessStrict,
 	})
 
-	// Get all validation issues
-	issues := v.ValidateAll(doc)
+	// Get all validation issues (unfiltered) so we can compute global counts
+	// even when a severity filter is applied.
+	allIssues := v.ValidateAll(doc)
+
+	page := &ValidationIssuesPage{
+		Issues: []ValidationIssueResult{},
+	}
+	for _, issue := range allIssues {
+		switch issue.Severity {
+		case validator.SeverityError:
+			page.ErrorCount++
+		case validator.SeverityWarning:
+			page.WarningCount++
+		case validator.SeverityInfo:
+			page.InfoCount++
+		}
+	}
 
 	// Filter by severity if specified
+	issues := allIssues
 	if severityFilter != "" {
-		var filtered []validator.Issue
+		filtered := make([]validator.Issue, 0, len(allIssues))
 		targetSeverity := severityStringToConst(severityFilter)
-		for _, issue := range issues {
+		for _, issue := range allIssues {
 			if issue.Severity == targetSeverity {
 				filtered = append(filtered, issue)
 			}
@@ -190,9 +219,27 @@ func (s *ValidationService) GetValidationIssues(ctx context.Context, severityFil
 		issues = filtered
 	}
 
+	page.Total = len(issues)
+
+	// Apply pagination. Defensive bounds: clamp offset/limit to [0, len].
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(issues) {
+		return page, nil
+	}
+	end := len(issues)
+	if limit > 0 {
+		end = offset + limit
+		if end > len(issues) {
+			end = len(issues)
+		}
+	}
+	pageIssues := issues[offset:end]
+
 	// Convert to ValidationIssueResult
-	results := make([]ValidationIssueResult, 0, len(issues))
-	for _, issue := range issues {
+	results := make([]ValidationIssueResult, 0, len(pageIssues))
+	for _, issue := range pageIssues {
 		result := ValidationIssueResult{
 			Severity: severityConstToString(issue.Severity),
 			Code:     issue.Code,
@@ -214,7 +261,8 @@ func (s *ValidationService) GetValidationIssues(ctx context.Context, severityFil
 		results = append(results, result)
 	}
 
-	return results, nil
+	page.Issues = results
+	return page, nil
 }
 
 // buildGedcomDocument reconstructs a gedcom.Document from read model data.

--- a/internal/query/validation_service_test.go
+++ b/internal/query/validation_service_test.go
@@ -358,13 +358,16 @@ func TestValidationService_GetValidationIssues_Empty(t *testing.T) {
 	service, _ := setupValidationService()
 	ctx := context.Background()
 
-	issues, err := service.GetValidationIssues(ctx, "")
+	page, err := service.GetValidationIssues(ctx, "", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues returned error: %v", err)
 	}
 
-	if len(issues) != 0 {
-		t.Errorf("Issues = %d, want 0", len(issues))
+	if len(page.Issues) != 0 {
+		t.Errorf("Issues = %d, want 0", len(page.Issues))
+	}
+	if page.Total != 0 {
+		t.Errorf("Total = %d, want 0", page.Total)
 	}
 }
 
@@ -375,19 +378,19 @@ func TestValidationService_GetValidationIssues_DateLogicIssues(t *testing.T) {
 	// Add a person with death before birth (invalid)
 	addPersonWithDeath(store, "Invalid", "Dates", "2000", "1950")
 
-	issues, err := service.GetValidationIssues(ctx, "")
+	page, err := service.GetValidationIssues(ctx, "", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues returned error: %v", err)
 	}
 
 	// Should have at least one issue
-	if len(issues) == 0 {
+	if len(page.Issues) == 0 {
 		t.Error("Expected issues for person with death before birth")
 	}
 
 	// At least one issue should relate to date logic
 	hasDateIssue := false
-	for _, issue := range issues {
+	for _, issue := range page.Issues {
 		if issue.Code != "" {
 			hasDateIssue = true
 			break
@@ -406,14 +409,14 @@ func TestValidationService_GetValidationIssues_SeverityLevels(t *testing.T) {
 	addPerson(store, "John", "Doe", "")                           // Missing birth date
 	addPersonWithDeath(store, "Invalid", "Dates", "2000", "1900") // Death before birth
 
-	issues, err := service.GetValidationIssues(ctx, "")
+	page, err := service.GetValidationIssues(ctx, "", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues returned error: %v", err)
 	}
 
 	// Verify severity levels are valid
 	validSeverities := map[string]bool{"error": true, "warning": true, "info": true}
-	for _, issue := range issues {
+	for _, issue := range page.Issues {
 		if !validSeverities[issue.Severity] {
 			t.Errorf("Invalid severity: %s", issue.Severity)
 		}
@@ -429,41 +432,51 @@ func TestValidationService_GetValidationIssues_SeverityFilter(t *testing.T) {
 	addPerson(store, "Missing", "Data", "")
 
 	// Get all issues first
-	allIssues, err := service.GetValidationIssues(ctx, "")
+	allPage, err := service.GetValidationIssues(ctx, "", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues returned error: %v", err)
 	}
 
 	// Filter by error
-	errorIssues, err := service.GetValidationIssues(ctx, "error")
+	errorPage, err := service.GetValidationIssues(ctx, "error", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues (error filter) returned error: %v", err)
 	}
 
 	// All filtered issues should have error severity
-	for _, issue := range errorIssues {
+	for _, issue := range errorPage.Issues {
 		if issue.Severity != "error" {
 			t.Errorf("Issue severity = %s, want error", issue.Severity)
 		}
 	}
 
 	// Filter by warning
-	warningIssues, err := service.GetValidationIssues(ctx, "warning")
+	warningPage, err := service.GetValidationIssues(ctx, "warning", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues (warning filter) returned error: %v", err)
 	}
 
 	// All filtered issues should have warning severity
-	for _, issue := range warningIssues {
+	for _, issue := range warningPage.Issues {
 		if issue.Severity != "warning" {
 			t.Errorf("Issue severity = %s, want warning", issue.Severity)
 		}
 	}
 
 	// Filtered counts should not exceed total
-	if len(errorIssues)+len(warningIssues) > len(allIssues) {
+	if len(errorPage.Issues)+len(warningPage.Issues) > len(allPage.Issues) {
 		// This could happen if there are info issues too
 		t.Log("Filtered counts may include info issues")
+	}
+
+	// Global counts should be stable across filters.
+	if errorPage.ErrorCount != allPage.ErrorCount {
+		t.Errorf("ErrorCount across filters differs: error-filtered=%d, all=%d",
+			errorPage.ErrorCount, allPage.ErrorCount)
+	}
+	if warningPage.WarningCount != allPage.WarningCount {
+		t.Errorf("WarningCount across filters differs: warning-filtered=%d, all=%d",
+			warningPage.WarningCount, allPage.WarningCount)
 	}
 }
 
@@ -474,13 +487,13 @@ func TestValidationService_GetValidationIssues_RecordMapping(t *testing.T) {
 	// Add a person with issues
 	personID := addPersonWithDeath(store, "Invalid", "Person", "2000", "1900")
 
-	issues, err := service.GetValidationIssues(ctx, "")
+	page, err := service.GetValidationIssues(ctx, "", 0, 0)
 	if err != nil {
 		t.Fatalf("GetValidationIssues returned error: %v", err)
 	}
 
 	// If there are issues related to our person, the RecordID should be mapped
-	for _, issue := range issues {
+	for _, issue := range page.Issues {
 		if issue.RecordID != nil {
 			// Verify it's a valid UUID (not nil)
 			if *issue.RecordID == uuid.Nil {
@@ -491,6 +504,61 @@ func TestValidationService_GetValidationIssues_RecordMapping(t *testing.T) {
 				t.Log("Successfully mapped issue to person ID")
 			}
 		}
+	}
+}
+
+func TestValidationService_GetValidationIssues_Pagination(t *testing.T) {
+	service, store := setupValidationService()
+	ctx := context.Background()
+
+	// Seed enough issue-producing persons that the issue list exceeds a small page.
+	for i := 0; i < 5; i++ {
+		addPersonWithDeath(store, "Bad", "Dates", "2000", "1900")
+	}
+
+	// All issues at once for a baseline.
+	all, err := service.GetValidationIssues(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatalf("GetValidationIssues (all) returned error: %v", err)
+	}
+	if all.Total != len(all.Issues) {
+		t.Errorf("Total=%d should equal len(Issues)=%d when no pagination", all.Total, len(all.Issues))
+	}
+	if all.Total < 2 {
+		t.Skipf("Need at least 2 issues to exercise pagination; got %d", all.Total)
+	}
+
+	// First page of 1.
+	first, err := service.GetValidationIssues(ctx, "", 1, 0)
+	if err != nil {
+		t.Fatalf("GetValidationIssues (first page) returned error: %v", err)
+	}
+	if len(first.Issues) != 1 {
+		t.Errorf("First page Issues = %d, want 1", len(first.Issues))
+	}
+	if first.Total != all.Total {
+		t.Errorf("First page Total = %d, want %d (matches unfiltered total)", first.Total, all.Total)
+	}
+
+	// Second page of 1.
+	second, err := service.GetValidationIssues(ctx, "", 1, 1)
+	if err != nil {
+		t.Fatalf("GetValidationIssues (second page) returned error: %v", err)
+	}
+	if len(second.Issues) != 1 {
+		t.Errorf("Second page Issues = %d, want 1", len(second.Issues))
+	}
+
+	// Offset beyond available issues yields an empty page but the same Total.
+	beyond, err := service.GetValidationIssues(ctx, "", 10, all.Total+100)
+	if err != nil {
+		t.Fatalf("GetValidationIssues (beyond) returned error: %v", err)
+	}
+	if len(beyond.Issues) != 0 {
+		t.Errorf("Beyond-end page Issues = %d, want 0", len(beyond.Issues))
+	}
+	if beyond.Total != all.Total {
+		t.Errorf("Beyond-end page Total = %d, want %d", beyond.Total, all.Total)
 	}
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,7 @@
 			"devDependencies": {
 				"@fontsource-variable/inter": "^5.2.8",
 				"@internationalized/date": "^3.12.1",
-				"@lucide/svelte": "^1.14.0",
+				"@lucide/svelte": "^1.16.0",
 				"@sveltejs/adapter-auto": "^7.0.1",
 				"@sveltejs/adapter-static": "^3.0.0",
 				"@sveltejs/kit": "^2.59.1",
@@ -432,9 +432,9 @@
 			}
 		},
 		"node_modules/@lucide/svelte": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.14.0.tgz",
-			"integrity": "sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.16.0.tgz",
+			"integrity": "sha512-AvvPJnaWxeiNkAljI5MsSEc84yHPLMaWQIAJOcbX7k9au/f9ITS7cxTTQiautDiOFKVOXiYdZ+d6mtl88J+Kbg==",
 			"dev": true,
 			"license": "ISC",
 			"peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
 	"devDependencies": {
 		"@fontsource-variable/inter": "^5.2.8",
 		"@internationalized/date": "^3.12.1",
-		"@lucide/svelte": "^1.14.0",
+		"@lucide/svelte": "^1.16.0",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.59.1",

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -24,6 +24,25 @@ export type RestorePointsResponse = components['schemas']['RestorePointsResponse
 export type RollbackRequest = components['schemas']['RollbackRequest'];
 export type RollbackResponse = components['schemas']['RollbackResponse'];
 
+// Re-export Quality/Validation types from generated file
+export type ValidationIssue = components['schemas']['ValidationIssue'];
+export type ValidationIssuesResponse = components['schemas']['ValidationIssuesResponse'];
+
+// Re-export Duplicate detection & merge types from generated file
+export type DuplicatePair = components['schemas']['DuplicatePair'];
+export type DuplicatesResponse = components['schemas']['DuplicatesResponse'];
+export type MergePersonsRequest = components['schemas']['MergePersonsRequest'];
+export type MergePersonsResponse = components['schemas']['MergePersonsResponse'];
+export type MergeSummary = components['schemas']['MergeSummary'];
+export type DismissDuplicateRequest = components['schemas']['DismissDuplicateRequest'];
+export type DuplicatePairRef = components['schemas']['DuplicatePairRef'];
+export type BatchMergeRequest = components['schemas']['BatchMergeRequest'];
+export type BatchMergeResponse = components['schemas']['BatchMergeResponse'];
+export type BatchMergeResult = components['schemas']['BatchMergeResult'];
+export type BatchDismissRequest = components['schemas']['BatchDismissRequest'];
+export type BatchDismissResponse = components['schemas']['BatchDismissResponse'];
+export type BatchDismissResult = components['schemas']['BatchDismissResult'];
+
 const API_BASE = '/api/v1';
 
 // Types based on OpenAPI schemas
@@ -1770,6 +1789,73 @@ class ApiClient {
 		return this.request<ProofSummaryResponse[]>(
 			'GET',
 			`/proof-summaries/by-fact?${params.toString()}`
+		);
+	}
+
+	// Quality / validation endpoints
+	async getValidationIssues(params?: {
+		severity?: 'error' | 'warning' | 'info';
+		limit?: number;
+		offset?: number;
+	}): Promise<ValidationIssuesResponse> {
+		const searchParams = new URLSearchParams();
+		if (params?.severity) searchParams.set('severity', params.severity);
+		if (params?.limit != null) searchParams.set('limit', params.limit.toString());
+		if (params?.offset != null) searchParams.set('offset', params.offset.toString());
+
+		const query = searchParams.toString();
+		return this.request<ValidationIssuesResponse>(
+			'GET',
+			`/quality/validation${query ? `?${query}` : ''}`
+		);
+	}
+
+	// Duplicate detection endpoints
+	async getPersonsDuplicates(params?: {
+		limit?: number;
+		offset?: number;
+	}): Promise<DuplicatesResponse> {
+		const searchParams = new URLSearchParams();
+		if (params?.limit != null) searchParams.set('limit', params.limit.toString());
+		if (params?.offset != null) searchParams.set('offset', params.offset.toString());
+
+		const query = searchParams.toString();
+		return this.request<DuplicatesResponse>(
+			'GET',
+			`/persons/duplicates${query ? `?${query}` : ''}`
+		);
+	}
+
+	async dismissDuplicate(
+		person1Id: string,
+		person2Id: string,
+		req?: DismissDuplicateRequest
+	): Promise<void> {
+		return this.request<void>(
+			'POST',
+			`/persons/duplicates/${encodeURIComponent(person1Id)}/${encodeURIComponent(person2Id)}/dismiss`,
+			req
+		);
+	}
+
+	// Merge endpoints
+	async mergePersons(req: MergePersonsRequest): Promise<MergePersonsResponse> {
+		return this.requestWithConflictRetry<MergePersonsResponse>(
+			'POST',
+			'/persons/merge',
+			req
+		);
+	}
+
+	async batchMergePersons(req: BatchMergeRequest): Promise<BatchMergeResponse> {
+		return this.request<BatchMergeResponse>('POST', '/persons/merge/batch', req);
+	}
+
+	async batchDismissDuplicates(req: BatchDismissRequest): Promise<BatchDismissResponse> {
+		return this.request<BatchDismissResponse>(
+			'POST',
+			'/persons/duplicates/dismiss/batch',
+			req
 		);
 	}
 }

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -1278,7 +1278,10 @@ export interface paths {
         };
         /**
          * Get validation issues
-         * @description Returns date logic and reference validation issues categorized by severity
+         * @description Returns date logic and reference validation issues categorized by
+         *     severity. Supports pagination so a large tree does not produce an
+         *     unbounded response. The error/warning/info counts always reflect the
+         *     full unfiltered, unpaginated issue set.
          */
         get: operations["getValidationIssues"];
         put?: never;
@@ -3305,15 +3308,22 @@ export interface components {
              */
             related_record_id?: string;
         };
-        /** @description Response containing validation issues categorized by severity */
+        /**
+         * @description Response containing validation issues categorized by severity.
+         *     Counts always cover the full unfiltered, unpaginated issue set;
+         *     `total` is the count of issues after the severity filter (if any)
+         *     but before pagination, suitable for driving page navigation.
+         */
         ValidationIssuesResponse: {
-            /** @description List of validation issues */
+            /** @description List of validation issues (paginated slice) */
             issues: components["schemas"]["ValidationIssue"][];
-            /** @description Total number of error-level issues */
+            /** @description Total number of issues matching the severity filter (pre-pagination) */
+            total: number;
+            /** @description Total number of error-level issues (unfiltered) */
             error_count: number;
-            /** @description Total number of warning-level issues */
+            /** @description Total number of warning-level issues (unfiltered) */
             warning_count: number;
-            /** @description Total number of info-level issues */
+            /** @description Total number of info-level issues (unfiltered) */
             info_count: number;
         };
         Statistics: {
@@ -6158,6 +6168,10 @@ export interface operations {
             query?: {
                 /** @description Filter by severity level */
                 severity?: "error" | "warning" | "info";
+                /** @description Maximum number of issues to return (post-severity-filter) */
+                limit?: number;
+                /** @description Number of issues to skip (post-severity-filter) */
+                offset?: number;
             };
             header?: never;
             path?: never;

--- a/web/src/lib/components/SeverityBadge.svelte
+++ b/web/src/lib/components/SeverityBadge.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+
+	interface Props {
+		severity: 'error' | 'warning' | 'info';
+	}
+
+	let { severity }: Props = $props();
+
+	const config = $derived.by(() => {
+		switch (severity) {
+			case 'error':
+				return {
+					label: 'Error',
+					class: 'bg-red-100 text-red-700 border-red-200'
+				};
+			case 'warning':
+				return {
+					label: 'Warning',
+					class: 'bg-amber-100 text-amber-700 border-amber-200'
+				};
+			case 'info':
+			default:
+				return {
+					label: 'Info',
+					class: 'bg-blue-100 text-blue-700 border-blue-200'
+				};
+		}
+	});
+</script>
+
+<Badge variant="outline" class={config.class}>{config.label}</Badge>

--- a/web/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/web/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import MinusIcon from '@lucide/svelte/icons/minus';
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border shadow-xs transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-3 aria-invalid:ring-3 peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div
+			data-slot="checkbox-indicator"
+			class="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+		>
+			{#if checked}
+				<CheckIcon  />
+			{:else if indeterminate}
+				<MinusIcon  />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/web/src/lib/components/ui/checkbox/index.ts
+++ b/web/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,6 @@
+import Root from "./checkbox.svelte";
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/web/src/lib/components/ui/progress/index.ts
+++ b/web/src/lib/components/ui/progress/index.ts
@@ -1,0 +1,7 @@
+import Root from "./progress.svelte";
+
+export {
+	Root,
+	//
+	Root as Progress,
+};

--- a/web/src/lib/components/ui/progress/progress.svelte
+++ b/web/src/lib/components/ui/progress/progress.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Progress as ProgressPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		max = 100,
+		value,
+		...restProps
+	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> = $props();
+</script>
+
+<ProgressPrimitive.Root
+	bind:ref
+	data-slot="progress"
+	class={cn("bg-muted h-1.5 rounded-full relative flex w-full items-center overflow-x-hidden", className)}
+	{value}
+	{max}
+	{...restProps}
+>
+	<div
+		data-slot="progress-indicator"
+		class="bg-primary size-full flex-1 transition-all"
+		style="transform: translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
+	></div>
+</ProgressPrimitive.Root>

--- a/web/src/lib/components/ui/progress/progress.svelte
+++ b/web/src/lib/components/ui/progress/progress.svelte
@@ -9,6 +9,13 @@
 		value,
 		...restProps
 	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> = $props();
+
+	// Guard the indicator transform: a caller passing max=0 (or a negative value)
+	// would otherwise produce Infinity/NaN in the translateX expression, leaving
+	// the bar visually broken.
+	const safeMax = $derived(max > 0 ? max : 1);
+	const clampedValue = $derived(Math.min(Math.max(value ?? 0, 0), safeMax));
+	const offsetPercent = $derived(100 - (100 * clampedValue) / safeMax);
 </script>
 
 <ProgressPrimitive.Root
@@ -22,6 +29,6 @@
 	<div
 		data-slot="progress-indicator"
 		class="bg-primary size-full flex-1 transition-all"
-		style="transform: translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
+		style="transform: translateX(-{offsetPercent}%)"
 	></div>
 </ProgressPrimitive.Root>

--- a/web/src/lib/components/ui/radio-group/index.ts
+++ b/web/src/lib/components/ui/radio-group/index.ts
@@ -1,0 +1,10 @@
+import Root from "./radio-group.svelte";
+import Item from "./radio-group-item.svelte";
+
+export {
+	Root,
+	Item,
+	//
+	Root as RadioGroup,
+	Item as RadioGroupItem,
+};

--- a/web/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/web/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from "bits-ui";
+	import CircleIcon from '@lucide/svelte/icons/circle';
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> = $props();
+</script>
+
+<RadioGroupPrimitive.Item
+	bind:ref
+	data-slot="radio-group-item"
+	class={cn(
+		"border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-3 aria-invalid:ring-3 group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<div data-slot="radio-group-indicator" class="flex size-4 items-center justify-center">
+			{#if checked}
+				<CircleIcon class="bg-primary-foreground absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full" />
+			{/if}
+		</div>
+	{/snippet}
+</RadioGroupPrimitive.Item>

--- a/web/src/lib/components/ui/radio-group/radio-group.svelte
+++ b/web/src/lib/components/ui/radio-group/radio-group.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value = $bindable(""),
+		...restProps
+	}: RadioGroupPrimitive.RootProps = $props();
+</script>
+
+<RadioGroupPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="radio-group"
+	class={cn("grid gap-3 w-full", className)}
+	{...restProps}
+/>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -105,6 +105,7 @@
 			<a href="/history" class:active={$page.url.pathname.startsWith('/history')}>History</a>
 			<a href="/map" class:active={$page.url.pathname.startsWith('/map')}>Map</a>
 			<a href="/analytics" class:active={$page.url.pathname.startsWith('/analytics')}>Analytics</a>
+			<a href="/quality" class:active={$page.url.pathname.startsWith('/quality')}>Quality</a>
 			<a href="/relationship" class:active={$page.url.pathname.startsWith('/relationship')}>Relationship</a>
 			<a href="/import" class:active={$page.url.pathname === '/import'}>Import</a>
 			<a href="/search" class:active={$page.url.pathname.startsWith('/search')}>Search</a>

--- a/web/src/routes/quality/+page.svelte
+++ b/web/src/routes/quality/+page.svelte
@@ -1,0 +1,548 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+	import {
+		api,
+		type ValidationIssue,
+		type DuplicatePair
+	} from '$lib/api/client';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Checkbox } from '$lib/components/ui/checkbox';
+	import * as Tabs from '$lib/components/ui/tabs';
+	import SeverityBadge from '$lib/components/SeverityBadge.svelte';
+
+	const pageSize = 20;
+	const ERROR_MESSAGE_MAX_LEN = 200;
+	// Separator for serializing (person1_id, person2_id) into a single Set key.
+	// `::` is illegal in a UUID, so the round-trip is unambiguous and parsePairKey
+	// can hard-assert exactly two segments.
+	const PAIR_KEY_SEPARATOR = '::';
+
+	// Shared class strings for the desktop tables. Adapted from the evidence
+	// page (post-#392 pattern). A future refactor can lift these into a shared
+	// module — kept inline here to limit PR scope.
+	const TH_CLASS =
+		'whitespace-nowrap border-b-2 border-slate-200 px-4 py-3 text-left font-semibold text-slate-600';
+	const TD_CLASS = 'border-b border-slate-100 px-4 py-3 text-slate-800';
+	const TD_NOWRAP = `${TD_CLASS} whitespace-nowrap font-medium`;
+	const TD_CENTER = `${TD_CLASS} text-center`;
+	const ROW_CLICKABLE = 'cursor-pointer transition-colors hover:bg-slate-50';
+	const SUBJECT_LINK = 'text-blue-500 no-underline hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
+
+	// Active tab
+	let activeTab = $state('validation');
+
+	// --- Validation tab state ---
+	let issues: ValidationIssue[] = $state([]);
+	let validationTotal = $state(0); // total matching the active severity filter
+	let validationPage = $state(1);
+	let errorCount = $state(0);
+	let warningCount = $state(0);
+	let infoCount = $state(0);
+	let validationLoading = $state(false);
+	let validationError: string | null = $state(null);
+	let severityFilter = $state<'all' | 'error' | 'warning' | 'info'>('all');
+
+	// --- Duplicates tab state ---
+	let duplicates: DuplicatePair[] = $state([]);
+	let duplicatesTotal = $state(0);
+	let duplicatesPage = $state(1);
+	let duplicatesLoading = $state(false);
+	let duplicatesError: string | null = $state(null);
+	let dismissError: string | null = $state(null);
+	let dismissBusy = $state(false);
+	// Per-row "Dismissing…" label target. dismissBusy gates ALL dismiss buttons
+	// (per-row + bulk) to prevent overlapping calls; dismissingKey just tells us
+	// which row to relabel.
+	let dismissingKey: string | null = $state(null);
+	const selectedKeys: SvelteSet<string> = new SvelteSet();
+
+	// --- Helpers ---
+	function pairKey(p1: string, p2: string): string {
+		return `${p1}${PAIR_KEY_SEPARATOR}${p2}`;
+	}
+
+	function parsePairKey(k: string): [string, string] {
+		const parts = k.split(PAIR_KEY_SEPARATOR);
+		if (parts.length !== 2 || !parts[0] || !parts[1]) {
+			throw new Error(`malformed pair key: ${k}`);
+		}
+		return [parts[0], parts[1]];
+	}
+
+	function truncateError(msg: unknown, fallback: string): string {
+		const raw =
+			typeof msg === 'string' && msg
+				? msg
+				: (msg as { message?: string } | null | undefined)?.message || fallback;
+		return raw.length > ERROR_MESSAGE_MAX_LEN
+			? `${raw.slice(0, ERROR_MESSAGE_MAX_LEN)}…`
+			: raw;
+	}
+
+	function toggleRowSelection(p1: string, p2: string) {
+		const k = pairKey(p1, p2);
+		if (selectedKeys.has(k)) {
+			selectedKeys.delete(k);
+		} else {
+			selectedKeys.add(k);
+		}
+	}
+
+	function togglePageSelection() {
+		const pageKeys = duplicates.map((d) => pairKey(d.person1_id, d.person2_id));
+		const allSelected = pageKeys.length > 0 && pageKeys.every((k) => selectedKeys.has(k));
+		if (allSelected) {
+			for (const k of pageKeys) selectedKeys.delete(k);
+		} else {
+			for (const k of pageKeys) selectedKeys.add(k);
+		}
+	}
+
+	function clearSelection() {
+		selectedKeys.clear();
+	}
+
+	// --- Data loading ---
+
+	async function loadValidationIssues() {
+		validationLoading = true;
+		validationError = null;
+		try {
+			const result = await api.getValidationIssues({
+				severity: severityFilter === 'all' ? undefined : severityFilter,
+				limit: pageSize,
+				offset: (validationPage - 1) * pageSize
+			});
+			issues = result.issues;
+			validationTotal = result.total;
+			// Counts always reflect the full unfiltered set from the backend, so
+			// they remain stable regardless of the active filter or page.
+			errorCount = result.error_count;
+			warningCount = result.warning_count;
+			infoCount = result.info_count;
+		} catch (e) {
+			validationError = truncateError(e, 'Failed to load validation issues');
+		} finally {
+			validationLoading = false;
+		}
+	}
+
+	async function loadDuplicates() {
+		duplicatesLoading = true;
+		duplicatesError = null;
+		try {
+			const result = await api.getPersonsDuplicates({
+				limit: pageSize,
+				offset: (duplicatesPage - 1) * pageSize
+			});
+			duplicates = result.duplicates;
+			duplicatesTotal = result.total;
+		} catch (e) {
+			duplicatesError = truncateError(e, 'Failed to load duplicates');
+		} finally {
+			duplicatesLoading = false;
+		}
+	}
+
+	async function dismissOne(p1: string, p2: string) {
+		if (dismissBusy) return;
+		dismissError = null;
+		dismissBusy = true;
+		dismissingKey = pairKey(p1, p2);
+		try {
+			await api.dismissDuplicate(p1, p2);
+			selectedKeys.delete(pairKey(p1, p2));
+			await loadDuplicates();
+		} catch (e) {
+			dismissError = truncateError(e, 'Failed to dismiss duplicate');
+		} finally {
+			dismissBusy = false;
+			dismissingKey = null;
+		}
+	}
+
+	async function dismissSelected() {
+		if (selectedKeys.size === 0 || dismissBusy) return;
+		dismissError = null;
+		dismissBusy = true;
+		try {
+			const dismissals = [...selectedKeys].map((k) => {
+				const [person1_id, person2_id] = parsePairKey(k);
+				return { person1_id, person2_id };
+			});
+			await api.batchDismissDuplicates({ dismissals });
+			clearSelection();
+			await loadDuplicates();
+		} catch (e) {
+			dismissError = truncateError(e, 'Failed to dismiss selected duplicates');
+		} finally {
+			dismissBusy = false;
+		}
+	}
+
+	// Load data when active tab changes. Switching tabs resets the active
+	// pagination so a stale page number from a previous visit doesn't render
+	// an empty list.
+	$effect(() => {
+		const tab = activeTab;
+		untrack(() => {
+			if (tab === 'validation') {
+				validationPage = 1;
+				loadValidationIssues();
+			} else if (tab === 'duplicates') {
+				duplicatesPage = 1;
+				loadDuplicates();
+			}
+		});
+	});
+
+	// Derived values
+	const totalIssuesCount = $derived(errorCount + warningCount + infoCount);
+	const validationTotalPages = $derived(Math.max(1, Math.ceil(validationTotal / pageSize)));
+	const duplicatesTotalPages = $derived(Math.ceil(duplicatesTotal / pageSize));
+
+	const filterPills = $derived([
+		{ key: 'all' as const, label: 'All', count: totalIssuesCount },
+		{ key: 'error' as const, label: 'Errors', count: errorCount },
+		{ key: 'warning' as const, label: 'Warnings', count: warningCount },
+		{ key: 'info' as const, label: 'Info', count: infoCount }
+	]);
+
+	const pageAllSelected = $derived(
+		duplicates.length > 0 &&
+			duplicates.every((d) => selectedKeys.has(pairKey(d.person1_id, d.person2_id)))
+	);
+</script>
+
+<svelte:head>
+	<title>Quality | My Family</title>
+</svelte:head>
+
+<div class="mx-auto max-w-screen-xl p-6">
+	<header class="mb-6">
+		<div>
+			<h1 class="m-0 text-2xl text-slate-800">Quality</h1>
+			<p class="mt-1 text-sm text-slate-500">
+				Find and fix data quality issues and potential duplicate persons.
+			</p>
+		</div>
+	</header>
+
+	<Tabs.Root bind:value={activeTab}>
+		<Tabs.List>
+			<Tabs.Trigger value="validation">
+				Validation Issues
+				{#if totalIssuesCount > 0}
+					<span class="ml-1 text-xs text-slate-500">({totalIssuesCount})</span>
+				{/if}
+			</Tabs.Trigger>
+			<Tabs.Trigger value="duplicates">
+				Duplicates
+				{#if duplicatesTotal > 0}
+					<span class="ml-1 text-xs text-slate-500">({duplicatesTotal})</span>
+				{/if}
+			</Tabs.Trigger>
+		</Tabs.List>
+
+		<!-- Validation Issues Tab -->
+		<Tabs.Content value="validation">
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<div class="flex flex-wrap gap-1">
+					{#each filterPills as filter}
+						<Button
+							variant={severityFilter === filter.key ? 'default' : 'outline'}
+							size="sm"
+							aria-pressed={severityFilter === filter.key}
+							onclick={() => {
+								severityFilter = filter.key;
+								validationPage = 1;
+								loadValidationIssues();
+							}}
+						>
+							{filter.label} ({filter.count})
+						</Button>
+					{/each}
+				</div>
+				<div class="flex items-center gap-3">
+					{#if validationLoading}
+						<div class="flex items-center gap-2" role="status" aria-live="polite">
+							<svg
+								class="size-4 animate-spin text-slate-500"
+								viewBox="0 0 24 24"
+								fill="none"
+								aria-hidden="true"
+							>
+								<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-opacity="0.25" />
+								<path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+							</svg>
+							<span class="text-sm text-slate-500">Scanning…</span>
+						</div>
+					{/if}
+					<Button variant="outline" size="sm" onclick={loadValidationIssues} disabled={validationLoading}>
+						Scan now
+					</Button>
+				</div>
+			</div>
+
+			{#if validationLoading}
+				<div class="p-12 text-center text-slate-500">Loading validation issues...</div>
+			{:else if validationError}
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{validationError}</p>
+					<Button variant="outline" onclick={loadValidationIssues}>Retry</Button>
+				</div>
+			{:else if issues.length === 0}
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No issues found at this severity.</p>
+					<p class="text-[0.8125rem] text-slate-400">
+						Try a different severity filter or run a fresh scan.
+					</p>
+				</div>
+			{:else}
+				<div class="overflow-x-auto">
+					<table class="w-full border-collapse text-sm">
+						<thead>
+							<tr>
+								<th class={TH_CLASS}>Severity</th>
+								<th class="{TH_CLASS} hidden sm:table-cell">Code</th>
+								<th class={TH_CLASS}>Message</th>
+								<th class={TH_CLASS}>Record</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each issues as issue}
+								<tr>
+									<td class={TD_NOWRAP}>
+										<SeverityBadge severity={issue.severity} />
+									</td>
+									<td class="{TD_CLASS} hidden font-mono text-xs text-slate-500 sm:table-cell">
+										{issue.code}
+									</td>
+									<td class={TD_CLASS}>{issue.message}</td>
+									<td class={TD_CLASS}>
+										{#if issue.record_id}
+											<a href="/persons/{issue.record_id}" class={SUBJECT_LINK}>
+												{issue.record_id.slice(0, 8)}...
+											</a>
+										{:else}
+											<span class="text-slate-400">—</span>
+										{/if}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+
+				{#if validationTotalPages > 1}
+					<div
+						class="mt-8 flex items-center justify-center gap-4 border-t border-slate-200 pt-4"
+					>
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => {
+								if (validationPage > 1) {
+									validationPage--;
+									loadValidationIssues();
+								}
+							}}
+							disabled={validationPage === 1 || validationLoading}
+						>
+							Previous
+						</Button>
+						<span class="text-sm text-slate-500">
+							Page {validationPage} of {validationTotalPages}
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => {
+								if (validationPage < validationTotalPages) {
+									validationPage++;
+									loadValidationIssues();
+								}
+							}}
+							disabled={validationPage >= validationTotalPages || validationLoading}
+						>
+							Next
+						</Button>
+					</div>
+				{/if}
+			{/if}
+		</Tabs.Content>
+
+		<!-- Duplicates Tab -->
+		<Tabs.Content value="duplicates">
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2 pt-2">
+				<span class="text-sm text-slate-500">
+					{duplicatesTotal}
+					{duplicatesTotal === 1 ? 'potential duplicate' : 'potential duplicates'}
+				</span>
+			</div>
+
+			{#if selectedKeys.size > 0}
+				<div
+					class="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-slate-200 bg-slate-50 px-4 py-3"
+				>
+					<span class="text-sm font-medium text-slate-700">
+						{selectedKeys.size} selected
+					</span>
+					<div class="flex gap-2">
+						<Button variant="outline" size="sm" onclick={clearSelection} disabled={dismissBusy}>
+							Clear
+						</Button>
+						<Button size="sm" onclick={dismissSelected} disabled={dismissBusy}>
+							{dismissBusy ? 'Dismissing…' : 'Dismiss selected'}
+						</Button>
+					</div>
+				</div>
+			{/if}
+
+			{#if dismissError}
+				<div
+					class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+				>
+					{dismissError}
+				</div>
+			{/if}
+
+			{#if duplicatesLoading}
+				<div class="p-12 text-center text-slate-500">Loading duplicates...</div>
+			{:else if duplicatesError}
+				<div class="p-12 text-center text-red-600">
+					<p class="m-0 mb-4">{duplicatesError}</p>
+					<Button variant="outline" onclick={loadDuplicates}>Retry</Button>
+				</div>
+			{:else if duplicates.length === 0}
+				<div class="p-12 text-center text-slate-500">
+					<p class="m-0 mb-2">No potential duplicates detected.</p>
+					<p class="text-[0.8125rem] text-slate-400">
+						The duplicate detector compares persons by name, dates, and places.
+					</p>
+				</div>
+			{:else}
+				<div class="overflow-x-auto">
+					<table class="w-full border-collapse text-sm">
+						<thead>
+							<tr>
+								<th class="{TH_CLASS} w-10">
+									<Checkbox
+										aria-label="Select all duplicates on this page"
+										checked={pageAllSelected}
+										onCheckedChange={() => togglePageSelection()}
+									/>
+								</th>
+								<th class={TH_CLASS}>Person 1</th>
+								<th class={TH_CLASS}>Person 2</th>
+								<th class={TH_CLASS}>Confidence</th>
+								<th class="{TH_CLASS} hidden sm:table-cell">Match Reasons</th>
+								<th class={TH_CLASS}>Actions</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each duplicates as pair}
+								{@const key = pairKey(pair.person1_id, pair.person2_id)}
+								{@const isSelected = selectedKeys.has(key)}
+								{@const reasons = pair.match_reasons ?? []}
+								{@const visibleReasons = reasons.slice(0, 3)}
+								{@const extraReasonCount = Math.max(0, reasons.length - visibleReasons.length)}
+								<tr class={ROW_CLICKABLE}>
+									<td class={TD_CENTER}>
+										<Checkbox
+											aria-label="Select duplicate pair {pair.person1_name} and {pair.person2_name}"
+											checked={isSelected}
+											onCheckedChange={() => toggleRowSelection(pair.person1_id, pair.person2_id)}
+										/>
+									</td>
+									<td class={TD_CLASS}>
+										<a href="/persons/{pair.person1_id}" class={SUBJECT_LINK}>
+											{pair.person1_name}
+										</a>
+									</td>
+									<td class={TD_CLASS}>
+										<a href="/persons/{pair.person2_id}" class={SUBJECT_LINK}>
+											{pair.person2_name}
+										</a>
+									</td>
+									<td class={TD_NOWRAP}>
+										{(pair.confidence * 100).toFixed(0)}%
+									</td>
+									<td class="{TD_CLASS} hidden sm:table-cell">
+										<div class="flex flex-wrap gap-1">
+											{#each visibleReasons as reason}
+												<Badge variant="secondary" class="text-[0.6875rem]">{reason}</Badge>
+											{/each}
+											{#if extraReasonCount > 0}
+												<Badge variant="outline" class="text-[0.6875rem]">
+													+{extraReasonCount} more
+												</Badge>
+											{/if}
+										</div>
+									</td>
+									<td class={TD_NOWRAP}>
+										<div class="flex gap-2">
+											<Button
+												variant="outline"
+												size="sm"
+												href="/quality/merge/{pair.person1_id}/{pair.person2_id}"
+											>
+												Compare / Merge
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												onclick={() => dismissOne(pair.person1_id, pair.person2_id)}
+												disabled={dismissBusy}
+											>
+												{dismissingKey === key ? 'Dismissing…' : 'Dismiss'}
+											</Button>
+										</div>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+
+				{#if duplicatesTotalPages > 1}
+					<div
+						class="mt-8 flex items-center justify-center gap-4 border-t border-slate-200 pt-4"
+					>
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => {
+								if (duplicatesPage > 1) {
+									duplicatesPage--;
+									loadDuplicates();
+								}
+							}}
+							disabled={duplicatesPage === 1 || duplicatesLoading}
+						>
+							Previous
+						</Button>
+						<span class="text-sm text-slate-500">
+							Page {duplicatesPage} of {duplicatesTotalPages}
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => {
+								if (duplicatesPage < duplicatesTotalPages) {
+									duplicatesPage++;
+									loadDuplicates();
+								}
+							}}
+							disabled={duplicatesPage >= duplicatesTotalPages || duplicatesLoading}
+						>
+							Next
+						</Button>
+					</div>
+				{/if}
+			{/if}
+		</Tabs.Content>
+	</Tabs.Root>
+</div>

--- a/web/src/routes/quality/+page.svelte
+++ b/web/src/routes/quality/+page.svelte
@@ -106,15 +106,36 @@
 
 	// --- Data loading ---
 
+	// Returns the page actually fetched. When the requested page was beyond the
+	// post-mutation total (e.g. user dismissed the last items on page 3), the
+	// caller can re-issue with the returned page or update local state.
+	function clampPage(requested: number, total: number): number {
+		const maxPage = Math.max(1, Math.ceil(total / pageSize));
+		return Math.min(Math.max(1, requested), maxPage);
+	}
+
 	async function loadValidationIssues() {
 		validationLoading = true;
 		validationError = null;
 		try {
-			const result = await api.getValidationIssues({
-				severity: severityFilter === 'all' ? undefined : severityFilter,
+			const severityParam = severityFilter === 'all' ? undefined : severityFilter;
+			const requestedPage = validationPage;
+			let result = await api.getValidationIssues({
+				severity: severityParam,
 				limit: pageSize,
-				offset: (validationPage - 1) * pageSize
+				offset: (requestedPage - 1) * pageSize
 			});
+			// If a previous fetch / filter switch / external mutation left
+			// validationPage past the new total, clamp and refetch the valid page.
+			const target = clampPage(requestedPage, result.total);
+			if (target !== requestedPage && result.total > 0) {
+				validationPage = target;
+				result = await api.getValidationIssues({
+					severity: severityParam,
+					limit: pageSize,
+					offset: (target - 1) * pageSize
+				});
+			}
 			issues = result.issues;
 			validationTotal = result.total;
 			// Counts always reflect the full unfiltered set from the backend, so
@@ -133,10 +154,22 @@
 		duplicatesLoading = true;
 		duplicatesError = null;
 		try {
-			const result = await api.getPersonsDuplicates({
+			const requestedPage = duplicatesPage;
+			let result = await api.getPersonsDuplicates({
 				limit: pageSize,
-				offset: (duplicatesPage - 1) * pageSize
+				offset: (requestedPage - 1) * pageSize
 			});
+			// If a dismiss reduced the total below the active page (e.g. user
+			// dismissed the last items on page 3), clamp and refetch so the UI
+			// shows the correct page rather than an empty out-of-range slice.
+			const target = clampPage(requestedPage, result.total);
+			if (target !== requestedPage && result.total > 0) {
+				duplicatesPage = target;
+				result = await api.getPersonsDuplicates({
+					limit: pageSize,
+					offset: (target - 1) * pageSize
+				});
+			}
 			duplicates = result.duplicates;
 			duplicatesTotal = result.total;
 		} catch (e) {
@@ -201,7 +234,7 @@
 	// Derived values
 	const totalIssuesCount = $derived(errorCount + warningCount + infoCount);
 	const validationTotalPages = $derived(Math.max(1, Math.ceil(validationTotal / pageSize)));
-	const duplicatesTotalPages = $derived(Math.ceil(duplicatesTotal / pageSize));
+	const duplicatesTotalPages = $derived(Math.max(1, Math.ceil(duplicatesTotal / pageSize)));
 
 	const filterPills = $derived([
 		{ key: 'all' as const, label: 'All', count: totalIssuesCount },

--- a/web/src/routes/quality/merge/[survivorId]/[mergedId]/+page.svelte
+++ b/web/src/routes/quality/merge/[survivorId]/[mergedId]/+page.svelte
@@ -57,10 +57,11 @@
 	let submitting = $state(false);
 	let result = $state<MergePersonsResponse | null>(null);
 	let resolution = $state<Record<string, Side>>({});
-	// Captured at load time so the post-merge redirect uses the trusted route
-	// param, not survivor.id from the API response (which could be tampered with
-	// upstream).
+	// Captured at load time so both the merge request payload and the post-merge
+	// redirect bind to the trusted route params, not the IDs in the API response
+	// body (which could be tampered with upstream).
 	let routeSurvivorId = $state<string | null>(null);
+	let routeMergedId = $state<string | null>(null);
 
 	$effect(() => {
 		const params = $page.params as Record<string, string | undefined>;
@@ -88,6 +89,7 @@
 		merged = null;
 		result = null;
 		routeSurvivorId = null;
+		routeMergedId = null;
 
 		if (!SAFE_ID_PATTERN.test(survivorId) || !SAFE_ID_PATTERN.test(mergedId)) {
 			error = 'Invalid person ID in URL.';
@@ -106,6 +108,7 @@
 			survivor = s;
 			merged = m;
 			routeSurvivorId = survivorId;
+			routeMergedId = mergedId;
 			resolution = buildInitialResolution(s, m);
 		} catch (e) {
 			error = truncateError(e, 'Failed to load one or both persons.');
@@ -193,21 +196,24 @@
 	}
 
 	async function handleMerge() {
-		if (!survivor || !merged || !routeSurvivorId) return;
-		const redirectTarget = routeSurvivorId;
+		if (!survivor || !merged || !routeSurvivorId || !routeMergedId) return;
+		const survivorTarget = routeSurvivorId;
+		const mergedTarget = routeMergedId;
 		submitting = true;
 		error = null;
 		try {
 			const req: MergePersonsRequest = {
-				survivor_id: survivor.id,
-				merged_id: merged.id,
+				// IDs come from the trusted route params, not the API response body
+				// — defence-in-depth in case the response was tampered with.
+				survivor_id: survivorTarget,
+				merged_id: mergedTarget,
 				survivor_version: survivor.version,
 				merged_version: merged.version,
 				field_resolution: { ...resolution }
 			};
 			result = await api.mergePersons(req);
 			setTimeout(() => {
-				goto(`/persons/${encodeURIComponent(redirectTarget)}`);
+				goto(`/persons/${encodeURIComponent(survivorTarget)}`);
 			}, MERGE_REDIRECT_DELAY_MS);
 		} catch (e) {
 			error = truncateError(e, 'Merge failed');

--- a/web/src/routes/quality/merge/[survivorId]/[mergedId]/+page.svelte
+++ b/web/src/routes/quality/merge/[survivorId]/[mergedId]/+page.svelte
@@ -1,0 +1,428 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import {
+		api,
+		formatGenDate,
+		formatPersonName,
+		type GenDate,
+		type MergePersonsRequest,
+		type MergePersonsResponse,
+		type PersonDetail
+	} from '$lib/api/client';
+	import { Button } from '$lib/components/ui/button';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card';
+	import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group';
+	import { Label } from '$lib/components/ui/label';
+
+	const MERGEABLE_FIELDS = [
+		'given_name',
+		'surname',
+		'gender',
+		'birth_date',
+		'birth_place',
+		'death_date',
+		'death_place',
+		'notes',
+		'research_status'
+	] as const;
+	type MergeableField = (typeof MERGEABLE_FIELDS)[number];
+	type Side = 'survivor' | 'merged';
+
+	const DATE_FIELDS: ReadonlySet<MergeableField> = new Set<MergeableField>([
+		'birth_date',
+		'death_date'
+	]);
+
+	// Pause after the success card lands before redirecting to the survivor page.
+	// Long enough for the user to register the summary, short enough to feel snappy.
+	const MERGE_REDIRECT_DELAY_MS = 1500;
+	const ERROR_MESSAGE_MAX_LEN = 200;
+	// Defense-in-depth: route params come from SvelteKit's matcher (which rejects
+	// `/`), but we still constrain to a safe character set so a crafted ID can't
+	// reshape the URL we hand to goto() or the API client. Permissive enough to
+	// accept UUIDs, opaque IDs, and test fixtures like "p-survivor".
+	const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+	let survivor = $state<PersonDetail | null>(null);
+	let merged = $state<PersonDetail | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let submitting = $state(false);
+	let result = $state<MergePersonsResponse | null>(null);
+	let resolution = $state<Record<string, Side>>({});
+	// Captured at load time so the post-merge redirect uses the trusted route
+	// param, not survivor.id from the API response (which could be tampered with
+	// upstream).
+	let routeSurvivorId = $state<string | null>(null);
+
+	$effect(() => {
+		const params = $page.params as Record<string, string | undefined>;
+		const survivorId = params.survivorId;
+		const mergedId = params.mergedId;
+		if (survivorId && mergedId) {
+			loadPersons(survivorId, mergedId);
+		}
+	});
+
+	function truncateError(msg: unknown, fallback: string): string {
+		const raw =
+			typeof msg === 'string' && msg
+				? msg
+				: (msg as { message?: string } | null | undefined)?.message || fallback;
+		return raw.length > ERROR_MESSAGE_MAX_LEN
+			? `${raw.slice(0, ERROR_MESSAGE_MAX_LEN)}…`
+			: raw;
+	}
+
+	async function loadPersons(survivorId: string, mergedId: string) {
+		loading = true;
+		error = null;
+		survivor = null;
+		merged = null;
+		result = null;
+		routeSurvivorId = null;
+
+		if (!SAFE_ID_PATTERN.test(survivorId) || !SAFE_ID_PATTERN.test(mergedId)) {
+			error = 'Invalid person ID in URL.';
+			loading = false;
+			return;
+		}
+
+		if (survivorId === mergedId) {
+			error = 'Cannot merge a person with themselves.';
+			loading = false;
+			return;
+		}
+
+		try {
+			const [s, m] = await Promise.all([api.getPerson(survivorId), api.getPerson(mergedId)]);
+			survivor = s;
+			merged = m;
+			routeSurvivorId = survivorId;
+			resolution = buildInitialResolution(s, m);
+		} catch (e) {
+			error = truncateError(e, 'Failed to load one or both persons.');
+			survivor = null;
+			merged = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	// All non-string non-primitive values on PersonDetail's mergeable fields are
+	// GenDate-shaped (`birth_date`, `death_date`). If a future field adds another
+	// object type, extend the type guard rather than the catch-all `return false`.
+	function isGenDate(value: object): value is GenDate {
+		return 'raw' in value;
+	}
+
+	function isEmpty(value: unknown): boolean {
+		if (value === null || value === undefined) return true;
+		if (typeof value === 'string') return value.trim() === '';
+		if (typeof value === 'object') {
+			if (!isGenDate(value)) return false;
+			const raw = value.raw;
+			if (raw === undefined || raw === null) return true;
+			if (typeof raw === 'string' && raw.trim() === '') return true;
+			return false;
+		}
+		return false;
+	}
+
+	function rawValue(person: PersonDetail | null, field: MergeableField): unknown {
+		if (!person) return undefined;
+		return (person as unknown as Record<string, unknown>)[field];
+	}
+
+	function buildInitialResolution(
+		s: PersonDetail,
+		m: PersonDetail
+	): Record<string, Side> {
+		const next: Record<string, Side> = {};
+		for (const field of MERGEABLE_FIELDS) {
+			const sVal = (s as unknown as Record<string, unknown>)[field];
+			const mVal = (m as unknown as Record<string, unknown>)[field];
+			if (isEmpty(sVal) && !isEmpty(mVal)) {
+				next[field] = 'merged';
+			} else {
+				next[field] = 'survivor';
+			}
+		}
+		return next;
+	}
+
+	function formatFieldName(field: string): string {
+		return field
+			.split('_')
+			.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+			.join(' ');
+	}
+
+	function displayValue(person: PersonDetail | null, field: MergeableField): string {
+		const raw = rawValue(person, field);
+		if (isEmpty(raw)) return '(empty)';
+		if (DATE_FIELDS.has(field)) {
+			return formatGenDate(raw as GenDate) || '(empty)';
+		}
+		return String(raw);
+	}
+
+	// Compare raw underlying values, not their formatted display strings — two
+	// dates that format to the same case-folded text (e.g. "ABT 1850" vs "abt
+	// 1850") can be semantically different and the user should be prompted to
+	// pick a side.
+	function fieldsAgree(field: MergeableField): boolean {
+		if (!survivor || !merged) return true;
+		const a = rawValue(survivor, field);
+		const b = rawValue(merged, field);
+		if (isEmpty(a) && isEmpty(b)) return true;
+		if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null) {
+			if (isGenDate(a) && isGenDate(b)) {
+				return (a.raw ?? '') === (b.raw ?? '');
+			}
+			return JSON.stringify(a) === JSON.stringify(b);
+		}
+		return a === b;
+	}
+
+	async function handleMerge() {
+		if (!survivor || !merged || !routeSurvivorId) return;
+		const redirectTarget = routeSurvivorId;
+		submitting = true;
+		error = null;
+		try {
+			const req: MergePersonsRequest = {
+				survivor_id: survivor.id,
+				merged_id: merged.id,
+				survivor_version: survivor.version,
+				merged_version: merged.version,
+				field_resolution: { ...resolution }
+			};
+			result = await api.mergePersons(req);
+			setTimeout(() => {
+				goto(`/persons/${encodeURIComponent(redirectTarget)}`);
+			}, MERGE_REDIRECT_DELAY_MS);
+		} catch (e) {
+			error = truncateError(e, 'Merge failed');
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function handleCancel() {
+		goto('/quality');
+	}
+</script>
+
+<svelte:head>
+	<title>Merge Persons | My Family</title>
+</svelte:head>
+
+<div class="mx-auto max-w-5xl space-y-6 p-6">
+	<header class="space-y-1">
+		<a
+			href="/quality"
+			class="text-sm text-muted-foreground hover:text-foreground hover:underline"
+		>
+			&larr; Back to Quality
+		</a>
+		<h1 class="text-2xl font-semibold text-foreground">Merge Persons</h1>
+		<p class="text-sm text-muted-foreground">
+			Choose which value to keep for each field. The merged record will be deleted.
+		</p>
+	</header>
+
+	{#if !result}
+		<Card>
+			<CardHeader>
+				<CardTitle>Suggested merge</CardTitle>
+				<CardDescription>Review fields below before merging.</CardDescription>
+			</CardHeader>
+		</Card>
+	{/if}
+
+	{#if error}
+		<div
+			role="alert"
+			class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+		>
+			{error}
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="py-12 text-center text-sm text-muted-foreground">Loading persons&hellip;</div>
+	{:else if result}
+		<Card class="border-green-300 bg-green-50">
+			<CardHeader>
+				<CardTitle class="text-green-900">Merged successfully</CardTitle>
+				<CardDescription class="text-green-800">
+					{result.merge_summary.merged_person_name} was merged into the survivor.
+				</CardDescription>
+			</CardHeader>
+			<CardContent class="space-y-2 text-sm text-green-900">
+				<ul class="space-y-1">
+					<li>
+						Fields updated:
+						<span class="font-medium">
+							{result.merge_summary.fields_updated.length > 0
+								? result.merge_summary.fields_updated.join(', ')
+								: '(none)'}
+						</span>
+					</li>
+					<li>
+						Citations transferred:
+						<span class="font-medium">{result.merge_summary.citations_transferred}</span>
+					</li>
+					<li>
+						Names transferred:
+						<span class="font-medium">{result.merge_summary.names_transferred}</span>
+					</li>
+					<li>
+						Events transferred:
+						<span class="font-medium">{result.merge_summary.events_transferred}</span>
+					</li>
+					<li>
+						Media transferred:
+						<span class="font-medium">{result.merge_summary.media_transferred}</span>
+					</li>
+					<li>
+						Families updated:
+						<span class="font-medium">{result.merge_summary.families_updated}</span>
+					</li>
+				</ul>
+				{#if survivor && routeSurvivorId}
+					<p class="pt-2">
+						Redirecting to {formatPersonName(survivor)}&hellip;
+						<a
+							class="ml-1 underline hover:no-underline"
+							href={`/persons/${encodeURIComponent(routeSurvivorId)}`}
+						>
+							Go now
+						</a>
+					</p>
+				{/if}
+			</CardContent>
+		</Card>
+	{:else if survivor && merged}
+		<section class="grid grid-cols-1 gap-6 md:grid-cols-2">
+			{@render personPanel(survivor, 'Survivor (keeps existing ID)')}
+			{@render personPanel(merged, 'Will be merged & deleted')}
+		</section>
+
+		<Card>
+			<CardHeader>
+				<CardTitle>Field resolution</CardTitle>
+				<CardDescription>
+					Pick which side wins for each field. Rows where the two sides differ are
+					highlighted.
+				</CardDescription>
+			</CardHeader>
+			<CardContent class="space-y-3">
+				{#each MERGEABLE_FIELDS as field (field)}
+					{@const agree = fieldsAgree(field)}
+					{@const survivorText = displayValue(survivor, field)}
+					{@const mergedText = displayValue(merged, field)}
+					<div
+						class="rounded-md border p-3 {agree
+							? 'border-slate-200 bg-slate-50'
+							: 'border-amber-200 bg-amber-50'}"
+					>
+						<div class="mb-2 flex items-center justify-between gap-2">
+							<span class="text-sm font-semibold text-foreground">
+								{formatFieldName(field)}
+							</span>
+							{#if agree}
+								<span class="text-xs text-muted-foreground">
+									Both: {survivorText}
+								</span>
+							{:else}
+								<span class="text-xs font-medium text-amber-700">Values differ</span>
+							{/if}
+						</div>
+						<RadioGroup
+							bind:value={resolution[field]}
+							class="grid gap-2 sm:grid-cols-2"
+						>
+							<div class="flex items-start gap-2">
+								<RadioGroupItem
+									value="survivor"
+									id={`field-${field}-survivor`}
+								/>
+								<Label
+									for={`field-${field}-survivor`}
+									class="cursor-pointer text-sm font-normal text-foreground"
+								>
+									<span class="block text-xs uppercase tracking-wide text-muted-foreground">
+										Keep survivor
+									</span>
+									<span class="block break-words">{survivorText}</span>
+								</Label>
+							</div>
+							<div class="flex items-start gap-2">
+								<RadioGroupItem
+									value="merged"
+									id={`field-${field}-merged`}
+								/>
+								<Label
+									for={`field-${field}-merged`}
+									class="cursor-pointer text-sm font-normal text-foreground"
+								>
+									<span class="block text-xs uppercase tracking-wide text-muted-foreground">
+										Keep merged
+									</span>
+									<span class="block break-words">{mergedText}</span>
+								</Label>
+							</div>
+						</RadioGroup>
+					</div>
+				{/each}
+			</CardContent>
+		</Card>
+
+		<div class="flex items-center justify-end gap-3">
+			<Button variant="outline" onclick={handleCancel} disabled={submitting}>Cancel</Button>
+			<Button
+				onclick={handleMerge}
+				disabled={loading || submitting || !survivor || !merged}
+			>
+				{submitting ? 'Merging…' : 'Merge persons'}
+			</Button>
+		</div>
+	{/if}
+</div>
+
+{#snippet personPanel(person: PersonDetail, title: string)}
+	<Card>
+		<CardHeader>
+			<CardTitle>{title}</CardTitle>
+			<CardDescription>
+				<span class="block text-base font-medium text-foreground">
+					{formatPersonName(person)}
+				</span>
+				<span
+					class="mt-1 inline-block rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[0.7rem] text-slate-600"
+				>
+					{person.id}
+				</span>
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+				{#each MERGEABLE_FIELDS as field (field)}
+					<dt class="text-xs uppercase tracking-wide text-muted-foreground">
+						{formatFieldName(field)}
+					</dt>
+					<dd class="text-foreground break-words">{displayValue(person, field)}</dd>
+				{/each}
+			</dl>
+		</CardContent>
+	</Card>
+{/snippet}

--- a/web/src/routes/quality/merge/[survivorId]/[mergedId]/page.test.ts
+++ b/web/src/routes/quality/merge/[survivorId]/[mergedId]/page.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import * as apiModule from '$lib/api/client';
+
+// Configurable page params
+let mockPageParams: Record<string, string> = {
+	survivorId: 'p-survivor',
+	mergedId: 'p-merged'
+};
+
+// Mock the API module
+vi.mock('$lib/api/client', async (importOriginal) => {
+	const actual = await importOriginal<typeof apiModule>();
+	return {
+		...actual,
+		api: {
+			getPerson: vi.fn(),
+			mergePersons: vi.fn()
+		}
+	};
+});
+
+// Mock the page store with configurable params
+vi.mock('$app/stores', () => ({
+	page: {
+		subscribe: vi.fn((callback: (value: unknown) => void) => {
+			callback({ params: mockPageParams });
+			return () => {};
+		})
+	}
+}));
+
+// Mock navigation
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+const survivorPerson: apiModule.PersonDetail = {
+	id: 'p-survivor',
+	given_name: 'Jane',
+	surname: 'Smith',
+	gender: 'female',
+	// Survivor has no birth_date — initial resolution should pick 'merged'
+	birth_date: undefined,
+	birth_place: 'Cleveland',
+	death_date: undefined,
+	death_place: undefined,
+	notes: 'Survivor notes',
+	research_status: 'probable',
+	version: 7
+};
+
+const mergedPerson: apiModule.PersonDetail = {
+	id: 'p-merged',
+	given_name: 'Jane',
+	surname: 'Smith',
+	gender: 'female',
+	birth_date: { raw: '12 MAR 1850' },
+	birth_place: 'Cleveland',
+	death_date: { raw: '4 JUL 1920' },
+	death_place: 'Chicago',
+	notes: '',
+	research_status: 'possible',
+	version: 3
+};
+
+describe('Merge Picker Page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockPageParams = { survivorId: 'p-survivor', mergedId: 'p-merged' };
+		vi.mocked(apiModule.api.getPerson).mockImplementation(async (id: string) => {
+			if (id === 'p-survivor') return survivorPerson;
+			if (id === 'p-merged') return mergedPerson;
+			throw new Error(`Unexpected person id ${id}`);
+		});
+		vi.mocked(apiModule.api.mergePersons).mockResolvedValue({
+			person: { ...mergedPerson, id: 'p-survivor' },
+			merge_summary: {
+				merged_person_name: 'Jane Smith',
+				fields_updated: ['birth_date'],
+				families_updated: 0,
+				citations_transferred: 1,
+				names_transferred: 0,
+				events_transferred: 0,
+				media_transferred: 0
+			}
+		});
+	});
+
+	it('renders both persons side-by-side after load', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Survivor (keeps existing ID)')).toBeDefined();
+			expect(screen.getByText('Will be merged & deleted')).toBeDefined();
+		});
+	});
+
+	it('rejects self-merge before fetching', async () => {
+		mockPageParams = { survivorId: 'p-same', mergedId: 'p-same' };
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Cannot merge a person with themselves.')).toBeDefined();
+		});
+		expect(apiModule.api.getPerson).not.toHaveBeenCalled();
+	});
+
+	it('defaults birth_date to merged when survivor is empty and merged has a value', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Merge persons')).toBeDefined();
+		});
+
+		// Click submit and inspect the payload — easiest way to assert the initial
+		// resolution state without poking at internal state.
+		await fireEvent.click(screen.getByText('Merge persons'));
+
+		await waitFor(() => {
+			expect(apiModule.api.mergePersons).toHaveBeenCalledTimes(1);
+		});
+		const req = vi.mocked(apiModule.api.mergePersons).mock.calls[0][0];
+		expect(req.field_resolution?.birth_date).toBe('merged');
+	});
+
+	it('builds submit payload with both versions and the resolution map', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Merge persons')).toBeDefined();
+		});
+		await fireEvent.click(screen.getByText('Merge persons'));
+
+		await waitFor(() => {
+			expect(apiModule.api.mergePersons).toHaveBeenCalledTimes(1);
+		});
+		const req = vi.mocked(apiModule.api.mergePersons).mock.calls[0][0];
+		expect(req.survivor_id).toBe('p-survivor');
+		expect(req.merged_id).toBe('p-merged');
+		expect(req.survivor_version).toBe(7);
+		expect(req.merged_version).toBe(3);
+		// Resolution should include all 9 mergeable fields
+		const keys = Object.keys(req.field_resolution ?? {}).sort();
+		expect(keys).toEqual(
+			[
+				'birth_date',
+				'birth_place',
+				'death_date',
+				'death_place',
+				'gender',
+				'given_name',
+				'notes',
+				'research_status',
+				'surname'
+			].sort()
+		);
+		// Survivor has non-empty notes → defaults to 'survivor'
+		expect(req.field_resolution?.notes).toBe('survivor');
+	});
+
+	it('surfaces API error message on merge failure', async () => {
+		const apiErr = {
+			code: 'CONFLICT_RETRY_FAILED',
+			message: 'This record was modified by another operation. Please try again.',
+			status: 409
+		};
+		vi.mocked(apiModule.api.mergePersons).mockRejectedValue(apiErr);
+
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Merge persons')).toBeDefined();
+		});
+		await fireEvent.click(screen.getByText('Merge persons'));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('This record was modified by another operation. Please try again.')
+			).toBeDefined();
+		});
+	});
+
+	it('shows error when a person fetch fails', async () => {
+		vi.mocked(apiModule.api.getPerson).mockImplementation(async (id: string) => {
+			if (id === 'p-survivor') return survivorPerson;
+			throw { message: 'Person not found' };
+		});
+
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Person not found')).toBeDefined();
+		});
+	});
+});

--- a/web/src/routes/quality/page.test.ts
+++ b/web/src/routes/quality/page.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import * as apiModule from '$lib/api/client';
+
+// Mock the API module
+vi.mock('$lib/api/client', async (importOriginal) => {
+	const actual = await importOriginal<typeof apiModule>();
+	return {
+		...actual,
+		api: {
+			getValidationIssues: vi.fn(),
+			getPersonsDuplicates: vi.fn(),
+			dismissDuplicate: vi.fn(),
+			batchDismissDuplicates: vi.fn()
+		}
+	};
+});
+
+const mockValidationResponse: apiModule.ValidationIssuesResponse = {
+	issues: [
+		{
+			severity: 'error',
+			code: 'missing_name',
+			message: 'Person has no name',
+			record_id: '11111111-1111-1111-1111-111111111111'
+		},
+		{
+			severity: 'warning',
+			code: 'missing_dates',
+			message: 'Person has no birth or death date'
+		}
+	],
+	total: 2,
+	error_count: 1,
+	warning_count: 2,
+	info_count: 3
+};
+
+const mockDuplicatesResponse: apiModule.DuplicatesResponse = {
+	duplicates: [
+		{
+			person1_id: 'p1-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+			person1_name: 'Jane Doe',
+			person2_id: 'p2-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+			person2_name: 'Jane Doh',
+			confidence: 0.87,
+			match_reasons: ['Same surname', 'Birth year within 1', 'Same birth place']
+		},
+		{
+			person1_id: 'p3-cccccccc-cccc-cccc-cccc-cccccccccccc',
+			person1_name: 'John Smith',
+			person2_id: 'p4-dddddddd-dddd-dddd-dddd-dddddddddddd',
+			person2_name: 'Jon Smith',
+			confidence: 0.72,
+			match_reasons: ['Same surname']
+		}
+	],
+	total: 2
+};
+
+const mockBatchDismissResponse: apiModule.BatchDismissResponse = {
+	total: 1,
+	successful: 1,
+	failed: 0,
+	results: [
+		{
+			person1_id: 'p1-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+			person2_id: 'p2-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+			success: true
+		}
+	]
+};
+
+describe('Quality landing page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(apiModule.api.getValidationIssues).mockResolvedValue(mockValidationResponse);
+		vi.mocked(apiModule.api.getPersonsDuplicates).mockResolvedValue(mockDuplicatesResponse);
+		vi.mocked(apiModule.api.dismissDuplicate).mockResolvedValue(undefined);
+		vi.mocked(apiModule.api.batchDismissDuplicates).mockResolvedValue(mockBatchDismissResponse);
+	});
+
+	it('renders both tab triggers', async () => {
+		render(Page);
+		expect(screen.getByRole('tab', { name: /validation issues/i })).toBeDefined();
+		expect(screen.getByRole('tab', { name: /duplicates/i })).toBeDefined();
+	});
+
+	it('loads validation issues with no severity filter on mount', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(apiModule.api.getValidationIssues).toHaveBeenCalledWith({
+				severity: undefined,
+				limit: 20,
+				offset: 0
+			});
+		});
+	});
+
+	it('refetches with the selected severity when a filter pill is clicked', async () => {
+		render(Page);
+
+		// Initial unfiltered load establishes the count baseline.
+		await waitFor(() => {
+			expect(apiModule.api.getValidationIssues).toHaveBeenCalledWith({
+				severity: undefined,
+				limit: 20,
+				offset: 0
+			});
+		});
+
+		const errorsPill = await screen.findByRole('button', { name: /^Errors \(/ });
+		await fireEvent.click(errorsPill);
+
+		await waitFor(() => {
+			expect(apiModule.api.getValidationIssues).toHaveBeenCalledWith({
+				severity: 'error',
+				limit: 20,
+				offset: 0
+			});
+		});
+
+		const warningsPill = await screen.findByRole('button', { name: /^Warnings \(/ });
+		await fireEvent.click(warningsPill);
+
+		await waitFor(() => {
+			expect(apiModule.api.getValidationIssues).toHaveBeenCalledWith({
+				severity: 'warning',
+				limit: 20,
+				offset: 0
+			});
+		});
+
+		const infoPill = await screen.findByRole('button', { name: /^Info \(/ });
+		await fireEvent.click(infoPill);
+
+		await waitFor(() => {
+			expect(apiModule.api.getValidationIssues).toHaveBeenCalledWith({
+				severity: 'info',
+				limit: 20,
+				offset: 0
+			});
+		});
+	});
+
+	it('sends a batch dismiss request when a duplicate is selected and "Dismiss selected" is clicked', async () => {
+		render(Page);
+
+		// Switch to duplicates tab.
+		const duplicatesTab = screen.getByRole('tab', { name: /duplicates/i });
+		await fireEvent.click(duplicatesTab);
+
+		await waitFor(() => {
+			expect(apiModule.api.getPersonsDuplicates).toHaveBeenCalled();
+		});
+
+		// Wait for the duplicates list to render.
+		await screen.findByText('Jane Doe');
+
+		// Click the first per-row checkbox (skip the page-wide select-all).
+		const rowCheckbox = await screen.findByRole('checkbox', {
+			name: /Select duplicate pair Jane Doe and Jane Doh/i
+		});
+		await fireEvent.click(rowCheckbox);
+
+		// The bulk-action toolbar appears.
+		const dismissButton = await screen.findByRole('button', { name: /^Dismiss selected$/ });
+		await fireEvent.click(dismissButton);
+
+		await waitFor(() => {
+			expect(apiModule.api.batchDismissDuplicates).toHaveBeenCalledWith({
+				dismissals: [
+					{
+						person1_id: 'p1-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+						person2_id: 'p2-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+					}
+				]
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements #156 — a new `/quality` route with two tabs (validation issues + duplicates with bulk-select) and a `/quality/merge/[survivorId]/[mergedId]` page with a side-by-side, field-by-field merge picker. Backend #45 was already merged; this is the UI plus the contract polish that surfaced during the panel review.

## What's in the diff

**Frontend (new)**
- `web/src/routes/quality/+page.svelte` — landing page with severity-filtered validation tab + paginated duplicates tab + bulk-dismiss toolbar
- `web/src/routes/quality/merge/[survivorId]/[mergedId]/+page.svelte` — responsive side-by-side merge picker, 9 mergeable fields, RadioGroup per field, default "survivor unless empty"
- `web/src/lib/components/SeverityBadge.svelte` — small wrapper over shadcn `Badge` with error/warning/info color mapping
- shadcn primitives vended via CLI: `checkbox`, `progress`, `radio-group`
- Quality nav link added in `+layout.svelte`
- 10 vitest tests across 2 files

**Backend**
- `/quality/validation` gains `limit`/`offset` query params + a new `total` field; severity counts always reflect the unfiltered set (so the filter pills stay accurate across switches)
- `ValidationService.GetValidationIssues` now returns `*ValidationIssuesPage`
- New `TestValidationService_GetValidationIssues_Pagination`

**API client (`web/src/lib/api/client.ts`)**
- 6 new methods: `getValidationIssues`, `getPersonsDuplicates`, `mergePersons` (uses `requestWithConflictRetry` because Person sub-resources share the aggregate's version counter), `dismissDuplicate`, `batchMergePersons`, `batchDismissDuplicates`
- 15 new TS type re-exports

## Hardening (multi-persona panel review)

Five reviewer personas were run against the initial implementation; all findings were addressed before this PR:

- `offset=0` / `limit=0` now sent via `!= null` guards (the silent-drop bug)
- `pairKey` separator changed to `::` (illegal in UUIDs); `parsePairKey` hard-asserts exactly two non-empty segments
- Per-row dismiss button now gated by `dismissBusy` to prevent races with bulk operations
- Merge redirect uses the trusted route param (encoded) instead of `survivor.id` from the API response — closes an open-redirect surface
- Route params validated against a safe-id pattern before any `getPerson` call
- `fieldsAgree` compares raw values, not display strings (so case-different `GenDate.raw` values don't collapse)
- API error messages truncated to 200 chars
- `SvelteSet` replaces spread-on-toggle `Set` rebuilds (O(1) toggles)
- Inline `animate-spin` SVG replaces the (visually-broken) shadcn `Progress` component
- `MERGE_REDIRECT_DELAY_MS` extracted from a magic `1500`

## Verification

- ✅ `make lint`: 0 issues
- ✅ `make test`: 240/240 frontend tests + all Go packages green
- ✅ `make check-coverage`: per-package 85% threshold satisfied, total 76.2%
- ✅ `npx svelte-check --threshold error`: 0 errors
- ✅ `npm run build`: production build succeeds
- ✅ Playwright walkthrough against the `make binary` artifact in `DEMO_MODE=true`:
  - `/quality` renders both tabs with correct empty states and filter pills
  - `/quality/merge/<a>/<b>` renders side-by-side cards, amber "Values differ" rows, "Both: …" collapsed agreement, correct defaults (Death Date with empty survivor → merged value selected)
  - Self-merge guard fires before any API call
  - SAFE_ID_PATTERN rejects `foo bar` cleanly
  - Mobile (390×844): cards stack, radios stack, no horizontal overflow
  - Loading spinner + "Scanning…" label render mid-flight (verified by injecting a 100ms fetch delay)

## Test plan
- [ ] CI green
- [ ] Reviewer hits `/quality` and confirms validation + duplicates tabs render
- [ ] Reviewer clicks "Compare/Merge" on a duplicate pair and verifies the picker
- [ ] Reviewer tries `/quality/merge/<id>/<id>` to confirm the self-merge guard
- [ ] Reviewer tries narrow viewport and confirms responsive stacking

## Follow-up
- #493 — `entity_type` discriminator on `ValidationIssue` so `record_id` links route correctly when the validator covers non-person entities (filed as a separate LOW item from the panel review)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Quality section with Validation Issues tab: browse validation results with severity filtering and pagination support.
  * Added Quality section with Duplicates tab: review potential duplicate person pairs, dismiss individual or batch pairs.
  * Added merge workflow: resolve field conflicts when merging two person records.
  * Added UI components: severity badge, checkbox, progress indicator, and radio button group.

* **Dependencies**
  * Updated icon library to latest version.

* **Tests**
  * Added test coverage for quality page, merge workflow, and pagination functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/my-family/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->