### PR TITLE
Add CLAUDE.md guidance to file gedcom-go gaps upstream first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,11 +97,12 @@ This project uses `github.com/cacack/gedcom-go`. For local development, uncommen
 
 When changes to gedcom-go are needed:
 
-1. **Keep changes atomic**: Each gedcom-go enhancement should be a single logical unit
-2. **Always add tests**: Any new gedcom-go functionality must include tests in that repo
-3. **Run both test suites**: After gedcom-go changes, run `go test ./...` in both repos
-4. **Commit separately**: gedcom-go changes should be committed to that repo independently
-5. **Document the dependency**: Note what my-family feature required the gedcom-go change
+1. **File upstream first**: If you hit a gedcom-go gap (missing feature, awkward API, bug) and are about to add a workaround in `internal/gedcom/`, file an issue against `cacack/gedcom-go` first — workarounds rot, upstream fixes don't.
+2. **Keep changes atomic**: Each gedcom-go enhancement should be a single logical unit
+3. **Always add tests**: Any new gedcom-go functionality must include tests in that repo
+4. **Run both test suites**: After gedcom-go changes, run `go test ./...` in both repos
+5. **Commit separately**: gedcom-go changes should be committed to that repo independently
+6. **Document the dependency**: Note what my-family feature required the gedcom-go change
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Add a leading guideline to the **Linked Library Development** section in `CLAUDE.md`: file an issue against `cacack/gedcom-go` first when hitting a gap, rather than adding a workaround in `internal/gedcom/`.

Renumbers the existing five items (now 2-6).

## Why

Today's review surfaced four real upstream gaps (cacack/gedcom-go#288 coordinate helper, #289 structured REPO link, #290 inline notes accessor, #291 RequiresGEDCOM7 helper) that our integration code already works around. Codifying "file upstream first" keeps that drift from accumulating silently.

## Test plan

- [x] `CLAUDE.md` renders correctly (numbered list, no orphaned references)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines for handling upstream issue contributions and workarounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/my-family/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->