### PR TITLE
Add API handler tests for Note, Submitter, Association, and LDSOrdinance

### DIFF
--- a/internal/api/association_handlers_test.go
+++ b/internal/api/association_handlers_test.go
@@ -1,0 +1,279 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/google/uuid"
+)
+
+// createAssociation is a test helper that POSTs an association between two
+// existing persons and returns its id and version.
+func createAssociation(t *testing.T, server *api.Server, personID, associateID, role string) (string, int64) {
+	t.Helper()
+	body := fmt.Sprintf(`{"person_id":%q,"associate_id":%q,"role":%q}`, personID, associateID, role)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/associations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createAssociation status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("createAssociation: failed to parse response: %v", err)
+	}
+	id, _ := resp["id"].(string)
+	version, _ := resp["version"].(float64)
+	return id, int64(version)
+}
+
+func TestCreateAssociation(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	associateID := createPerson(t, server, "Jane", "Smith")
+
+	body := fmt.Sprintf(`{"person_id":%q,"associate_id":%q,"role":"godparent","phrase":"Baptismal godparent"}`, personID, associateID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/associations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["role"] != "godparent" {
+		t.Errorf("role = %v, want godparent", resp["role"])
+	}
+	if resp["person_id"] != personID {
+		t.Errorf("person_id = %v, want %s", resp["person_id"], personID)
+	}
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("Expected non-empty id")
+	}
+}
+
+// TestCreateAssociation_UnknownPerson verifies the handler rejects an
+// association referencing a person that does not exist.
+func TestCreateAssociation_UnknownPerson(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+
+	body := fmt.Sprintf(`{"person_id":%q,"associate_id":%q,"role":"witness"}`, personID, uuid.NewString())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/associations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+// TestCreateAssociation_SelfReference verifies a person cannot be associated
+// with themselves.
+func TestCreateAssociation_SelfReference(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+
+	body := fmt.Sprintf(`{"person_id":%q,"associate_id":%q,"role":"witness"}`, personID, personID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/associations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListAssociations(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	createAssociation(t, server, p1, p2, "godparent")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/associations", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 1 {
+		t.Errorf("total = %v, want 1", resp["total"])
+	}
+	associations, ok := resp["associations"].([]any)
+	if !ok {
+		t.Fatalf("associations field missing or wrong type: %T", resp["associations"])
+	}
+	if len(associations) != 1 {
+		t.Errorf("associations count = %d, want 1", len(associations))
+	}
+}
+
+// TestListAssociationsForPerson verifies the bidirectional per-person lookup:
+// an association should surface for both the person and the associate.
+func TestListAssociationsForPerson(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	createAssociation(t, server, p1, p2, "godparent")
+
+	for _, id := range []string{p1, p2} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+id+"/associations", http.NoBody)
+		rec := httptest.NewRecorder()
+		server.Echo().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("person %s: Status = %d, want %d. Body: %s", id, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		// The per-person sub-resource returns a bare array, not a paginated envelope.
+		var associations []map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &associations); err != nil {
+			t.Fatalf("person %s: failed to parse response: %v", id, err)
+		}
+		if len(associations) != 1 {
+			t.Errorf("person %s: associations count = %d, want 1", id, len(associations))
+		}
+	}
+}
+
+func TestGetAssociation(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	id, _ := createAssociation(t, server, p1, p2, "witness")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/associations/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["role"] != "witness" {
+		t.Errorf("role = %v, want witness", resp["role"])
+	}
+}
+
+func TestGetAssociation_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/associations/"+uuid.NewString(), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateAssociation(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	id, version := createAssociation(t, server, p1, p2, "witness")
+
+	body := fmt.Sprintf(`{"role":"godparent","version":%d}`, version)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/associations/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["role"] != "godparent" {
+		t.Errorf("role = %v, want godparent", resp["role"])
+	}
+	if resp["version"].(float64) <= float64(version) {
+		t.Errorf("version = %v, want greater than %d", resp["version"], version)
+	}
+}
+
+func TestUpdateAssociation_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	id, version := createAssociation(t, server, p1, p2, "witness")
+
+	body := fmt.Sprintf(`{"role":"godparent","version":%d}`, version+99)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/associations/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestUpdateAssociation_NotFound(t *testing.T) {
+	server := setupTestServer()
+	body := `{"role":"witness","version":1}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/associations/"+uuid.NewString(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteAssociation(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	id, version := createAssociation(t, server, p1, p2, "witness")
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/associations/%s?version=%d", id, version), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/associations/"+id, http.NoBody)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Errorf("after delete, GET status = %d, want %d", getRec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteAssociation_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/associations/"+uuid.NewString()+"?version=0", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/lds_ordinance_handlers_test.go
+++ b/internal/api/lds_ordinance_handlers_test.go
@@ -1,0 +1,319 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/google/uuid"
+)
+
+// createIndividualOrdinance is a test helper that POSTs an individual (BAPL)
+// ordinance for the given person and returns its id and version.
+func createIndividualOrdinance(t *testing.T, server *api.Server, personID string) (string, int64) {
+	t.Helper()
+	body := fmt.Sprintf(`{"type":"BAPL","person_id":%q,"temple":"SLAKE","status":"COMPLETED","date":"1 JAN 1990"}`, personID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lds-ordinances", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createIndividualOrdinance status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("createIndividualOrdinance: failed to parse response: %v", err)
+	}
+	id, _ := resp["id"].(string)
+	version, _ := resp["version"].(float64)
+	return id, int64(version)
+}
+
+func TestCreateLDSOrdinance(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+
+	body := fmt.Sprintf(`{"type":"BAPL","person_id":%q,"temple":"SLAKE","status":"COMPLETED"}`, personID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lds-ordinances", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["type"] != "BAPL" {
+		t.Errorf("type = %v, want BAPL", resp["type"])
+	}
+	if resp["person_id"] != personID {
+		t.Errorf("person_id = %v, want %s", resp["person_id"], personID)
+	}
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("Expected non-empty id")
+	}
+}
+
+// TestCreateLDSOrdinance_MissingPersonForIndividual verifies that an individual
+// ordinance type without a person_id is rejected.
+func TestCreateLDSOrdinance_MissingPersonForIndividual(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lds-ordinances", strings.NewReader(`{"type":"BAPL"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+// TestCreateLDSOrdinance_InvalidType verifies an unknown ordinance type is rejected.
+func TestCreateLDSOrdinance_InvalidType(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lds-ordinances", strings.NewReader(`{"type":"NOPE"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListLDSOrdinances(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	createIndividualOrdinance(t, server, p1)
+	createIndividualOrdinance(t, server, p2)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/lds-ordinances", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2", resp["total"])
+	}
+	ordinances, ok := resp["lds_ordinances"].([]any)
+	if !ok {
+		t.Fatalf("lds_ordinances field missing or wrong type: %T", resp["lds_ordinances"])
+	}
+	if len(ordinances) != 2 {
+		t.Errorf("lds_ordinances count = %d, want 2", len(ordinances))
+	}
+}
+
+func TestGetLDSOrdinance(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	id, _ := createIndividualOrdinance(t, server, personID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/lds-ordinances/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["type"] != "BAPL" {
+		t.Errorf("type = %v, want BAPL", resp["type"])
+	}
+}
+
+func TestGetLDSOrdinance_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/lds-ordinances/"+uuid.NewString(), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateLDSOrdinance(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	id, version := createIndividualOrdinance(t, server, personID)
+
+	body := fmt.Sprintf(`{"temple":"PROVO","status":"BIC","version":%d}`, version)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/lds-ordinances/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["temple"] != "PROVO" {
+		t.Errorf("temple = %v, want PROVO", resp["temple"])
+	}
+	if resp["version"].(float64) <= float64(version) {
+		t.Errorf("version = %v, want greater than %d", resp["version"], version)
+	}
+}
+
+func TestUpdateLDSOrdinance_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	id, version := createIndividualOrdinance(t, server, personID)
+
+	body := fmt.Sprintf(`{"temple":"PROVO","version":%d}`, version+99)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/lds-ordinances/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestUpdateLDSOrdinance_NotFound(t *testing.T) {
+	server := setupTestServer()
+	body := `{"temple":"PROVO","version":1}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/lds-ordinances/"+uuid.NewString(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteLDSOrdinance(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	id, version := createIndividualOrdinance(t, server, personID)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/lds-ordinances/%s?version=%d", id, version), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/lds-ordinances/"+id, http.NoBody)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Errorf("after delete, GET status = %d, want %d", getRec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteLDSOrdinance_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/lds-ordinances/"+uuid.NewString()+"?version=0", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// TestListLDSOrdinancesForPerson verifies the per-person sub-resource lists
+// individual ordinances for an existing person.
+func TestListLDSOrdinancesForPerson(t *testing.T) {
+	server := setupTestServer()
+	personID := createPerson(t, server, "John", "Doe")
+	createIndividualOrdinance(t, server, personID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+personID+"/lds-ordinances", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("ordinance count = %d, want 1", len(items))
+	}
+}
+
+func TestListLDSOrdinancesForPerson_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/persons/"+uuid.NewString()+"/lds-ordinances", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// TestListLDSOrdinancesForFamily verifies the per-family sub-resource lists
+// spouse-sealing (SLGS) ordinances for an existing family.
+func TestListLDSOrdinancesForFamily(t *testing.T) {
+	server := setupTestServer()
+	p1 := createPerson(t, server, "John", "Doe")
+	p2 := createPerson(t, server, "Jane", "Smith")
+	familyID := createFamily(t, server, p1, p2)
+
+	body := fmt.Sprintf(`{"type":"SLGS","family_id":%q,"temple":"SLAKE","status":"COMPLETED"}`, familyID)
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/lds-ordinances", strings.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create SLGS status = %d, want %d. Body: %s", createRec.Code, http.StatusCreated, createRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/families/"+familyID+"/lds-ordinances", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("ordinance count = %d, want 1", len(items))
+	}
+}
+
+func TestListLDSOrdinancesForFamily_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/families/"+uuid.NewString()+"/lds-ordinances", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/note_handlers_test.go
+++ b/internal/api/note_handlers_test.go
@@ -1,0 +1,230 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/google/uuid"
+)
+
+// createNote is a test helper that POSTs a note and returns its id and version.
+func createNote(t *testing.T, server *api.Server, text string) (string, int64) {
+	t.Helper()
+	body := fmt.Sprintf(`{"text":%q}`, text)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/notes", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createNote status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("createNote: failed to parse response: %v", err)
+	}
+	id, _ := resp["id"].(string)
+	version, _ := resp["version"].(float64)
+	return id, int64(version)
+}
+
+func TestCreateNote(t *testing.T) {
+	server := setupTestServer()
+	body := `{"text":"A research note about the Doe family","gedcom_xref":"@N1@"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/notes", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["text"] != "A research note about the Doe family" {
+		t.Errorf("text = %v, want the note text", resp["text"])
+	}
+	if resp["gedcom_xref"] != "@N1@" {
+		t.Errorf("gedcom_xref = %v, want @N1@", resp["gedcom_xref"])
+	}
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("Expected non-empty id")
+	}
+}
+
+func TestCreateNote_MalformedJSON(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/notes", strings.NewReader(`{"text":`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestListNotes(t *testing.T) {
+	server := setupTestServer()
+	createNote(t, server, "first note")
+	createNote(t, server, "second note")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notes", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2", resp["total"])
+	}
+	notes, ok := resp["notes"].([]any)
+	if !ok {
+		t.Fatalf("notes field missing or wrong type: %T", resp["notes"])
+	}
+	if len(notes) != 2 {
+		t.Errorf("notes count = %d, want 2", len(notes))
+	}
+}
+
+func TestGetNote(t *testing.T) {
+	server := setupTestServer()
+	id, _ := createNote(t, server, "findable note")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notes/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["text"] != "findable note" {
+		t.Errorf("text = %v, want findable note", resp["text"])
+	}
+}
+
+func TestGetNote_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notes/"+uuid.NewString(), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateNote(t *testing.T) {
+	server := setupTestServer()
+	id, version := createNote(t, server, "original text")
+
+	body := fmt.Sprintf(`{"text":"updated text","version":%d}`, version)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/notes/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["text"] != "updated text" {
+		t.Errorf("text = %v, want updated text", resp["text"])
+	}
+	if resp["version"].(float64) <= float64(version) {
+		t.Errorf("version = %v, want greater than %d", resp["version"], version)
+	}
+}
+
+func TestUpdateNote_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	id, version := createNote(t, server, "conflict note")
+
+	body := fmt.Sprintf(`{"text":"stale update","version":%d}`, version+99)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/notes/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestUpdateNote_NotFound(t *testing.T) {
+	server := setupTestServer()
+	body := `{"text":"x","version":1}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/notes/"+uuid.NewString(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteNote(t *testing.T) {
+	server := setupTestServer()
+	id, version := createNote(t, server, "deletable note")
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/notes/%s?version=%d", id, version), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	// Confirm it is gone.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/notes/"+id, http.NoBody)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Errorf("after delete, GET status = %d, want %d", getRec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteNote_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	id, version := createNote(t, server, "guarded note")
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/notes/%s?version=%d", id, version+99), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestDeleteNote_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/notes/"+uuid.NewString()+"?version=0", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/submitter_handlers_test.go
+++ b/internal/api/submitter_handlers_test.go
@@ -1,0 +1,214 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/google/uuid"
+)
+
+// createSubmitter is a test helper that POSTs a submitter and returns its id and version.
+func createSubmitter(t *testing.T, server *api.Server, name string) (string, int64) {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q}`, name)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/submitters", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createSubmitter status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("createSubmitter: failed to parse response: %v", err)
+	}
+	id, _ := resp["id"].(string)
+	version, _ := resp["version"].(float64)
+	return id, int64(version)
+}
+
+func TestCreateSubmitter(t *testing.T) {
+	server := setupTestServer()
+	body := `{"name":"Jane Researcher","email":["jane@example.com"],"phone":["555-0100"],"language":"English"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/submitters", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "Jane Researcher" {
+		t.Errorf("name = %v, want Jane Researcher", resp["name"])
+	}
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("Expected non-empty id")
+	}
+}
+
+func TestCreateSubmitter_ValidationError(t *testing.T) {
+	server := setupTestServer()
+	// Missing required name.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/submitters", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListSubmitters(t *testing.T) {
+	server := setupTestServer()
+	createSubmitter(t, server, "Submitter One")
+	createSubmitter(t, server, "Submitter Two")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/submitters", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2", resp["total"])
+	}
+	submitters, ok := resp["submitters"].([]any)
+	if !ok {
+		t.Fatalf("submitters field missing or wrong type: %T", resp["submitters"])
+	}
+	if len(submitters) != 2 {
+		t.Errorf("submitters count = %d, want 2", len(submitters))
+	}
+}
+
+func TestGetSubmitter(t *testing.T) {
+	server := setupTestServer()
+	id, _ := createSubmitter(t, server, "Findable Submitter")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/submitters/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "Findable Submitter" {
+		t.Errorf("name = %v, want Findable Submitter", resp["name"])
+	}
+}
+
+func TestGetSubmitter_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/submitters/"+uuid.NewString(), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateSubmitter(t *testing.T) {
+	server := setupTestServer()
+	id, version := createSubmitter(t, server, "Original Name")
+
+	body := fmt.Sprintf(`{"name":"Updated Name","version":%d}`, version)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/submitters/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "Updated Name" {
+		t.Errorf("name = %v, want Updated Name", resp["name"])
+	}
+	if resp["version"].(float64) <= float64(version) {
+		t.Errorf("version = %v, want greater than %d", resp["version"], version)
+	}
+}
+
+func TestUpdateSubmitter_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	id, version := createSubmitter(t, server, "Conflict Submitter")
+
+	body := fmt.Sprintf(`{"name":"Stale","version":%d}`, version+99)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/submitters/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestUpdateSubmitter_NotFound(t *testing.T) {
+	server := setupTestServer()
+	body := `{"name":"Ghost","version":1}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/submitters/"+uuid.NewString(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteSubmitter(t *testing.T) {
+	server := setupTestServer()
+	id, version := createSubmitter(t, server, "Deletable Submitter")
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/submitters/%s?version=%d", id, version), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/submitters/"+id, http.NoBody)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Errorf("after delete, GET status = %d, want %d", getRec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteSubmitter_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/submitters/"+uuid.NewString()+"?version=0", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}


### PR DESCRIPTION
## Summary

Backfills the missing API handler tests for the **Note**, **Submitter**, **Association**, and **LDSOrdinance** entities, resolving #242.

### Scope note

While picking up #242, I found its "Current State" table was stale: the API layer for all four entities was actually implemented back in **v0.7** (commit `0eeae2c`), *before* the issue was filed. The only genuine gap was test coverage. I posted a [correction comment](https://github.com/cacack/my-family/issues/242#issuecomment-4587909029) on the issue documenting this. This PR closes the remaining (test) gap.

## What's added

Four black-box HTTP test files under `internal/api/`, following the existing `handlers_test.go` pattern (in-memory stores, `httptest`):

| File | Coverage |
|------|----------|
| `note_handlers_test.go` | CRUD + malformed-body 400, 404, 409 conflict |
| `submitter_handlers_test.go` | CRUD + missing-name 400, 404, 409 |
| `association_handlers_test.go` | CRUD, bidirectional per-person list, unknown-person & self-reference 400, 404, 409 |
| `lds_ordinance_handlers_test.go` | CRUD, per-person & per-family sub-resources, missing-person/invalid-type 400, 404, 409 |

The association and LDS per-person/per-family sub-resources return **bare arrays** (not paginated envelopes) — the tests assert that shape.

## Coverage impact

Effective `internal/api` coverage (excluding generated code, as CI measures) rises to **~71%**, comfortably above the 60% override in `.testcoverage.yml` and chipping away at its TODO, which explicitly named notes/associations/LDS ordinances as the reason the package threshold was lowered after v0.7.

## Verification

- `make lint` → 0 issues
- `make check-coverage` → PASS (package + total thresholds satisfied; total 78.9%)
- `gofmt` / `go vet` clean

No production code changed — tests only.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
