### PR TITLE
Complete Repository entity integration across all 7 layers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,6 +104,11 @@ linters:
           - revive
         path: internal/api/middleware\.go
         text: type name will be used as api.APIError
+      # Repository (genealogy archive) entity shares its name with the repository package
+      - linters:
+          - revive
+        path: internal/repository/readmodel\.go
+        text: type name will be used as repository.RepositoryReadModel
       # Test helper functions designed for flexibility
       - linters:
           - unparam

--- a/docs/INTEGRATION-MATRIX.md
+++ b/docs/INTEGRATION-MATRIX.md
@@ -167,7 +167,7 @@ Current implementation status for tracking completeness.
 | LDSOrdinance | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Partial |
 | LifeEvent | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ | ✅ | Partial |
 | Attribute | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ | ✅ | Partial |
-| Repository | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Partial |
+| Repository | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Complete |
 | Snapshot | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | N/A | Partial |
 
 Legend: ✅ Complete | ⚠️ Partial/Needed | ❌ Missing

--- a/internal/api/generated.go
+++ b/internal/api/generated.go
@@ -1312,6 +1312,42 @@ func (e GetValidationIssuesParamsSeverity) Valid() bool {
 	}
 }
 
+// Defines values for ListRepositoriesParamsSort.
+const (
+	ListRepositoriesParamsSortName      ListRepositoriesParamsSort = "name"
+	ListRepositoriesParamsSortUpdatedAt ListRepositoriesParamsSort = "updated_at"
+)
+
+// Valid indicates whether the value is a known member of the ListRepositoriesParamsSort enum.
+func (e ListRepositoriesParamsSort) Valid() bool {
+	switch e {
+	case ListRepositoriesParamsSortName:
+		return true
+	case ListRepositoriesParamsSortUpdatedAt:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListRepositoriesParamsOrder.
+const (
+	ListRepositoriesParamsOrderAsc  ListRepositoriesParamsOrder = "asc"
+	ListRepositoriesParamsOrderDesc ListRepositoriesParamsOrder = "desc"
+)
+
+// Valid indicates whether the value is a known member of the ListRepositoriesParamsOrder enum.
+func (e ListRepositoriesParamsOrder) Valid() bool {
+	switch e {
+	case ListRepositoriesParamsOrderAsc:
+		return true
+	case ListRepositoriesParamsOrderDesc:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListResearchLogsParamsSort.
 const (
 	ListResearchLogsParamsSortCreatedAt  ListResearchLogsParamsSort = "created_at"
@@ -1395,22 +1431,22 @@ func (e SearchPersonsParamsOrder) Valid() bool {
 
 // Defines values for ListSourcesParamsSort.
 const (
-	CreatedAt  ListSourcesParamsSort = "created_at"
-	SourceType ListSourcesParamsSort = "source_type"
-	Title      ListSourcesParamsSort = "title"
-	UpdatedAt  ListSourcesParamsSort = "updated_at"
+	ListSourcesParamsSortCreatedAt  ListSourcesParamsSort = "created_at"
+	ListSourcesParamsSortSourceType ListSourcesParamsSort = "source_type"
+	ListSourcesParamsSortTitle      ListSourcesParamsSort = "title"
+	ListSourcesParamsSortUpdatedAt  ListSourcesParamsSort = "updated_at"
 )
 
 // Valid indicates whether the value is a known member of the ListSourcesParamsSort enum.
 func (e ListSourcesParamsSort) Valid() bool {
 	switch e {
-	case CreatedAt:
+	case ListSourcesParamsSortCreatedAt:
 		return true
-	case SourceType:
+	case ListSourcesParamsSortSourceType:
 		return true
-	case Title:
+	case ListSourcesParamsSortTitle:
 		return true
-	case UpdatedAt:
+	case ListSourcesParamsSortUpdatedAt:
 		return true
 	default:
 		return false
@@ -1455,16 +1491,16 @@ func (e ListSubmittersParamsSort) Valid() bool {
 
 // Defines values for ListSubmittersParamsOrder.
 const (
-	ListSubmittersParamsOrderAsc  ListSubmittersParamsOrder = "asc"
-	ListSubmittersParamsOrderDesc ListSubmittersParamsOrder = "desc"
+	Asc  ListSubmittersParamsOrder = "asc"
+	Desc ListSubmittersParamsOrder = "desc"
 )
 
 // Valid indicates whether the value is a known member of the ListSubmittersParamsOrder enum.
 func (e ListSubmittersParamsOrder) Valid() bool {
 	switch e {
-	case ListSubmittersParamsOrderAsc:
+	case Asc:
 		return true
-	case ListSubmittersParamsOrderDesc:
+	case Desc:
 		return true
 	default:
 		return false
@@ -3271,6 +3307,69 @@ type RelationshipResult struct {
 	Summary *string `json:"summary,omitempty"`
 }
 
+// Repository A GEDCOM REPO (repository) record describing where source documents are stored
+type Repository struct {
+	// Address Structured GEDCOM address (embedded in other entities)
+	Address *Address `json:"address,omitempty"`
+
+	// GedcomXref GEDCOM cross-reference ID for round-trip support
+	GedcomXref *string            `json:"gedcom_xref,omitempty"`
+	Id         openapi_types.UUID `json:"id"`
+
+	// Name Repository's name
+	Name string `json:"name"`
+
+	// Notes Free-form notes about the repository
+	Notes     *string    `json:"notes,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+
+	// Version Optimistic locking version
+	Version int64 `json:"version"`
+}
+
+// RepositoryCreate defines model for RepositoryCreate.
+type RepositoryCreate struct {
+	// Address Structured GEDCOM address (embedded in other entities)
+	Address *Address `json:"address,omitempty"`
+
+	// GedcomXref Optional GEDCOM cross-reference ID for import
+	GedcomXref *string `json:"gedcom_xref,omitempty"`
+
+	// Name Repository's name
+	Name string `json:"name"`
+
+	// Notes Free-form notes about the repository
+	Notes *string `json:"notes,omitempty"`
+}
+
+// RepositoryList defines model for RepositoryList.
+type RepositoryList struct {
+	Limit        *int         `json:"limit,omitempty"`
+	Offset       *int         `json:"offset,omitempty"`
+	Repositories []Repository `json:"repositories"`
+
+	// Total Total number of repositories
+	Total int `json:"total"`
+}
+
+// RepositoryUpdate defines model for RepositoryUpdate.
+type RepositoryUpdate struct {
+	// Address Structured GEDCOM address (embedded in other entities)
+	Address *Address `json:"address,omitempty"`
+
+	// GedcomXref Updated GEDCOM cross-reference ID
+	GedcomXref *string `json:"gedcom_xref,omitempty"`
+
+	// Name Updated repository name
+	Name *string `json:"name,omitempty"`
+
+	// Notes Updated notes
+	Notes *string `json:"notes,omitempty"`
+
+	// Version Current version for optimistic locking
+	Version int64 `json:"version"`
+}
+
 // ResearchLog defines model for ResearchLog.
 type ResearchLog struct {
 	CreatedAt *time.Time         `json:"created_at,omitempty"`
@@ -3764,6 +3863,9 @@ type PersonId = openapi_types.UUID
 // ProofSummaryId defines model for proofSummaryId.
 type ProofSummaryId = openapi_types.UUID
 
+// RepositoryId defines model for repositoryId.
+type RepositoryId = openapi_types.UUID
+
 // ResearchLogId defines model for researchLogId.
 type ResearchLogId = openapi_types.UUID
 
@@ -4126,6 +4228,26 @@ type GetValidationIssuesParams struct {
 // GetValidationIssuesParamsSeverity defines parameters for GetValidationIssues.
 type GetValidationIssuesParamsSeverity string
 
+// ListRepositoriesParams defines parameters for ListRepositories.
+type ListRepositoriesParams struct {
+	Limit  *LimitParam                  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *OffsetParam                 `form:"offset,omitempty" json:"offset,omitempty"`
+	Sort   *ListRepositoriesParamsSort  `form:"sort,omitempty" json:"sort,omitempty"`
+	Order  *ListRepositoriesParamsOrder `form:"order,omitempty" json:"order,omitempty"`
+}
+
+// ListRepositoriesParamsSort defines parameters for ListRepositories.
+type ListRepositoriesParamsSort string
+
+// ListRepositoriesParamsOrder defines parameters for ListRepositories.
+type ListRepositoriesParamsOrder string
+
+// DeleteRepositoryParams defines parameters for DeleteRepository.
+type DeleteRepositoryParams struct {
+	// Version Entity version for optimistic locking
+	Version *VersionParam `form:"version,omitempty" json:"version,omitempty"`
+}
+
 // ListResearchLogsParams defines parameters for ListResearchLogs.
 type ListResearchLogsParams struct {
 	Limit  *LimitParam                  `form:"limit,omitempty" json:"limit,omitempty"`
@@ -4346,6 +4468,12 @@ type CreateProofSummaryJSONRequestBody = ProofSummaryCreate
 
 // UpdateProofSummaryJSONRequestBody defines body for UpdateProofSummary for application/json ContentType.
 type UpdateProofSummaryJSONRequestBody = ProofSummaryUpdate
+
+// CreateRepositoryJSONRequestBody defines body for CreateRepository for application/json ContentType.
+type CreateRepositoryJSONRequestBody = RepositoryCreate
+
+// UpdateRepositoryJSONRequestBody defines body for UpdateRepository for application/json ContentType.
+type UpdateRepositoryJSONRequestBody = RepositoryUpdate
 
 // CreateResearchLogJSONRequestBody defines body for CreateResearchLog for application/json ContentType.
 type CreateResearchLogJSONRequestBody = ResearchLogCreate
@@ -4703,6 +4831,21 @@ type ServerInterface interface {
 	// Calculate relationship between two people
 	// (GET /relationship/{personId1}/{personId2})
 	GetRelationship(ctx echo.Context, personId1 openapi_types.UUID, personId2 openapi_types.UUID) error
+	// List all repositories
+	// (GET /repositories)
+	ListRepositories(ctx echo.Context, params ListRepositoriesParams) error
+	// Create a new repository
+	// (POST /repositories)
+	CreateRepository(ctx echo.Context) error
+	// Delete a repository
+	// (DELETE /repositories/{id})
+	DeleteRepository(ctx echo.Context, id RepositoryId, params DeleteRepositoryParams) error
+	// Get a repository by ID
+	// (GET /repositories/{id})
+	GetRepository(ctx echo.Context, id RepositoryId) error
+	// Update a repository
+	// (PUT /repositories/{id})
+	UpdateRepository(ctx echo.Context, id RepositoryId) error
 	// List all research log entries
 	// (GET /research-logs)
 	ListResearchLogs(ctx echo.Context, params ListResearchLogsParams) error
@@ -6906,6 +7049,111 @@ func (w *ServerInterfaceWrapper) GetRelationship(ctx echo.Context) error {
 	return err
 }
 
+// ListRepositories converts echo context to params.
+func (w *ServerInterfaceWrapper) ListRepositories(ctx echo.Context) error {
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListRepositoriesParams
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", ctx.QueryParams(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", ctx.QueryParams(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter offset: %s", err))
+	}
+
+	// ------------- Optional query parameter "sort" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "sort", ctx.QueryParams(), &params.Sort, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sort: %s", err))
+	}
+
+	// ------------- Optional query parameter "order" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "order", ctx.QueryParams(), &params.Order, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter order: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListRepositories(ctx, params)
+	return err
+}
+
+// CreateRepository converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateRepository(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.CreateRepository(ctx)
+	return err
+}
+
+// DeleteRepository converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteRepository(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id RepositoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteRepositoryParams
+	// ------------- Optional query parameter "version" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "version", ctx.QueryParams(), &params.Version, runtime.BindQueryParameterOptions{Type: "integer", Format: "int64"})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter version: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.DeleteRepository(ctx, id, params)
+	return err
+}
+
+// GetRepository converts echo context to params.
+func (w *ServerInterfaceWrapper) GetRepository(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id RepositoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetRepository(ctx, id)
+	return err
+}
+
+// UpdateRepository converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateRepository(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id RepositoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.UpdateRepository(ctx, id)
+	return err
+}
+
 // ListResearchLogs converts echo context to params.
 func (w *ServerInterfaceWrapper) ListResearchLogs(ctx echo.Context) error {
 	var err error
@@ -7700,6 +7948,11 @@ func RegisterHandlersWithOptions(router EchoRouter, si ServerInterface, options 
 	router.GET(options.BaseURL+"/quality/report", wrapper.GetQualityReport, options.OperationMiddlewares["getQualityReport"]...)
 	router.GET(options.BaseURL+"/quality/validation", wrapper.GetValidationIssues, options.OperationMiddlewares["getValidationIssues"]...)
 	router.GET(options.BaseURL+"/relationship/:personId1/:personId2", wrapper.GetRelationship, options.OperationMiddlewares["getRelationship"]...)
+	router.GET(options.BaseURL+"/repositories", wrapper.ListRepositories, options.OperationMiddlewares["listRepositories"]...)
+	router.POST(options.BaseURL+"/repositories", wrapper.CreateRepository, options.OperationMiddlewares["createRepository"]...)
+	router.DELETE(options.BaseURL+"/repositories/:id", wrapper.DeleteRepository, options.OperationMiddlewares["deleteRepository"]...)
+	router.GET(options.BaseURL+"/repositories/:id", wrapper.GetRepository, options.OperationMiddlewares["getRepository"]...)
+	router.PUT(options.BaseURL+"/repositories/:id", wrapper.UpdateRepository, options.OperationMiddlewares["updateRepository"]...)
 	router.GET(options.BaseURL+"/research-logs", wrapper.ListResearchLogs, options.OperationMiddlewares["listResearchLogs"]...)
 	router.POST(options.BaseURL+"/research-logs", wrapper.CreateResearchLog, options.OperationMiddlewares["createResearchLog"]...)
 	router.GET(options.BaseURL+"/research-logs/by-subject/:subjectId", wrapper.GetResearchLogsBySubject, options.OperationMiddlewares["getResearchLogsBySubject"]...)
@@ -12070,6 +12323,224 @@ func (response GetRelationship404JSONResponse) VisitGetRelationshipResponse(w ht
 	return err
 }
 
+type ListRepositoriesRequestObject struct {
+	Params ListRepositoriesParams
+}
+
+type ListRepositoriesResponseObject interface {
+	VisitListRepositoriesResponse(w http.ResponseWriter) error
+}
+
+type ListRepositories200JSONResponse RepositoryList
+
+func (response ListRepositories200JSONResponse) VisitListRepositoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListRepositories400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response ListRepositories400JSONResponse) VisitListRepositoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateRepositoryRequestObject struct {
+	Body *CreateRepositoryJSONRequestBody
+}
+
+type CreateRepositoryResponseObject interface {
+	VisitCreateRepositoryResponse(w http.ResponseWriter) error
+}
+
+type CreateRepository201JSONResponse Repository
+
+func (response CreateRepository201JSONResponse) VisitCreateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type CreateRepository400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response CreateRepository400JSONResponse) VisitCreateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteRepositoryRequestObject struct {
+	Id     RepositoryId `json:"id"`
+	Params DeleteRepositoryParams
+}
+
+type DeleteRepositoryResponseObject interface {
+	VisitDeleteRepositoryResponse(w http.ResponseWriter) error
+}
+
+type DeleteRepository204Response struct {
+}
+
+func (response DeleteRepository204Response) VisitDeleteRepositoryResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteRepository404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response DeleteRepository404JSONResponse) VisitDeleteRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteRepository409JSONResponse struct{ ConflictJSONResponse }
+
+func (response DeleteRepository409JSONResponse) VisitDeleteRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetRepositoryRequestObject struct {
+	Id RepositoryId `json:"id"`
+}
+
+type GetRepositoryResponseObject interface {
+	VisitGetRepositoryResponse(w http.ResponseWriter) error
+}
+
+type GetRepository200JSONResponse Repository
+
+func (response GetRepository200JSONResponse) VisitGetRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetRepository404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetRepository404JSONResponse) VisitGetRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateRepositoryRequestObject struct {
+	Id   RepositoryId `json:"id"`
+	Body *UpdateRepositoryJSONRequestBody
+}
+
+type UpdateRepositoryResponseObject interface {
+	VisitUpdateRepositoryResponse(w http.ResponseWriter) error
+}
+
+type UpdateRepository200JSONResponse Repository
+
+func (response UpdateRepository200JSONResponse) VisitUpdateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateRepository400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response UpdateRepository400JSONResponse) VisitUpdateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateRepository404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response UpdateRepository404JSONResponse) VisitUpdateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type UpdateRepository409JSONResponse struct{ ConflictJSONResponse }
+
+func (response UpdateRepository409JSONResponse) VisitUpdateRepositoryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListResearchLogsRequestObject struct {
 	Params ListResearchLogsParams
 }
@@ -13506,6 +13977,21 @@ type StrictServerInterface interface {
 	// Calculate relationship between two people
 	// (GET /relationship/{personId1}/{personId2})
 	GetRelationship(ctx context.Context, request GetRelationshipRequestObject) (GetRelationshipResponseObject, error)
+	// List all repositories
+	// (GET /repositories)
+	ListRepositories(ctx context.Context, request ListRepositoriesRequestObject) (ListRepositoriesResponseObject, error)
+	// Create a new repository
+	// (POST /repositories)
+	CreateRepository(ctx context.Context, request CreateRepositoryRequestObject) (CreateRepositoryResponseObject, error)
+	// Delete a repository
+	// (DELETE /repositories/{id})
+	DeleteRepository(ctx context.Context, request DeleteRepositoryRequestObject) (DeleteRepositoryResponseObject, error)
+	// Get a repository by ID
+	// (GET /repositories/{id})
+	GetRepository(ctx context.Context, request GetRepositoryRequestObject) (GetRepositoryResponseObject, error)
+	// Update a repository
+	// (PUT /repositories/{id})
+	UpdateRepository(ctx context.Context, request UpdateRepositoryRequestObject) (UpdateRepositoryResponseObject, error)
 	// List all research log entries
 	// (GET /research-logs)
 	ListResearchLogs(ctx context.Context, request ListResearchLogsRequestObject) (ListResearchLogsResponseObject, error)
@@ -16517,6 +17003,142 @@ func (sh *strictHandler) GetRelationship(ctx echo.Context, personId1 openapi_typ
 		return err
 	} else if validResponse, ok := response.(GetRelationshipResponseObject); ok {
 		return validResponse.VisitGetRelationshipResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// ListRepositories operation middleware
+func (sh *strictHandler) ListRepositories(ctx echo.Context, params ListRepositoriesParams) error {
+	var request ListRepositoriesRequestObject
+
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ListRepositories(ctx.Request().Context(), request.(ListRepositoriesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListRepositories")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ListRepositoriesResponseObject); ok {
+		return validResponse.VisitListRepositoriesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// CreateRepository operation middleware
+func (sh *strictHandler) CreateRepository(ctx echo.Context) error {
+	var request CreateRepositoryRequestObject
+
+	var body CreateRepositoryJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateRepository(ctx.Request().Context(), request.(CreateRepositoryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateRepository")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(CreateRepositoryResponseObject); ok {
+		return validResponse.VisitCreateRepositoryResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// DeleteRepository operation middleware
+func (sh *strictHandler) DeleteRepository(ctx echo.Context, id RepositoryId, params DeleteRepositoryParams) error {
+	var request DeleteRepositoryRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteRepository(ctx.Request().Context(), request.(DeleteRepositoryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteRepository")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(DeleteRepositoryResponseObject); ok {
+		return validResponse.VisitDeleteRepositoryResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetRepository operation middleware
+func (sh *strictHandler) GetRepository(ctx echo.Context, id RepositoryId) error {
+	var request GetRepositoryRequestObject
+
+	request.Id = id
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetRepository(ctx.Request().Context(), request.(GetRepositoryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetRepository")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetRepositoryResponseObject); ok {
+		return validResponse.VisitGetRepositoryResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// UpdateRepository operation middleware
+func (sh *strictHandler) UpdateRepository(ctx echo.Context, id RepositoryId) error {
+	var request UpdateRepositoryRequestObject
+
+	request.Id = id
+
+	var body UpdateRepositoryJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateRepository(ctx.Request().Context(), request.(UpdateRepositoryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateRepository")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UpdateRepositoryResponseObject); ok {
+		return validResponse.VisitUpdateRepositoryResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -53,6 +53,8 @@ tags:
     description: GEDCOM NOTE record management
   - name: submitters
     description: GEDCOM SUBM record management (file provenance)
+  - name: repositories
+    description: GEDCOM REPO record management (where sources are stored)
   - name: associations
     description: GEDCOM ASSO record management (non-family relationships)
   - name: lds-ordinances
@@ -2584,6 +2586,114 @@ paths:
         '409':
           $ref: '#/components/responses/Conflict'
 
+  # Repositories endpoints
+  /repositories:
+    get:
+      operationId: listRepositories
+      summary: List all repositories
+      description: Returns paginated list of GEDCOM REPO (repository) records
+      tags: [repositories]
+      parameters:
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [name, updated_at]
+            default: updated_at
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+      responses:
+        '200':
+          description: List of repositories
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+    post:
+      operationId: createRepository
+      summary: Create a new repository
+      tags: [repositories]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositoryCreate'
+      responses:
+        '201':
+          description: Repository created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Repository'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /repositories/{id}:
+    parameters:
+      - $ref: '#/components/parameters/repositoryId'
+
+    get:
+      operationId: getRepository
+      summary: Get a repository by ID
+      tags: [repositories]
+      responses:
+        '200':
+          description: Repository details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Repository'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      operationId: updateRepository
+      summary: Update a repository
+      tags: [repositories]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositoryUpdate'
+      responses:
+        '200':
+          description: Repository updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Repository'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+    delete:
+      operationId: deleteRepository
+      summary: Delete a repository
+      tags: [repositories]
+      parameters:
+        - $ref: '#/components/parameters/versionParam'
+      responses:
+        '204':
+          description: Repository deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
   # Associations endpoints
   /associations:
     get:
@@ -3426,6 +3536,15 @@ components:
       in: path
       required: true
       description: Submitter UUID
+      schema:
+        type: string
+        format: uuid
+
+    repositoryId:
+      name: id
+      in: path
+      required: true
+      description: Repository UUID
       schema:
         type: string
         format: uuid
@@ -6030,6 +6149,90 @@ components:
         total:
           type: integer
           description: Total number of submitters
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    # Repository schemas
+    Repository:
+      type: object
+      description: A GEDCOM REPO (repository) record describing where source documents are stored
+      required: [id, name, version]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: Repository's name
+        address:
+          $ref: '#/components/schemas/Address'
+        notes:
+          type: string
+          description: Free-form notes about the repository
+        gedcom_xref:
+          type: string
+          description: GEDCOM cross-reference ID for round-trip support
+        version:
+          type: integer
+          format: int64
+          description: Optimistic locking version
+        updated_at:
+          type: string
+          format: date-time
+
+    RepositoryCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Repository's name
+          minLength: 1
+          maxLength: 200
+        address:
+          $ref: '#/components/schemas/Address'
+        notes:
+          type: string
+          description: Free-form notes about the repository
+        gedcom_xref:
+          type: string
+          description: Optional GEDCOM cross-reference ID for import
+
+    RepositoryUpdate:
+      type: object
+      required: [version]
+      properties:
+        name:
+          type: string
+          description: Updated repository name
+          minLength: 1
+          maxLength: 200
+        address:
+          $ref: '#/components/schemas/Address'
+        notes:
+          type: string
+          description: Updated notes
+        gedcom_xref:
+          type: string
+          description: Updated GEDCOM cross-reference ID
+        version:
+          type: integer
+          format: int64
+          description: Current version for optimistic locking
+
+    RepositoryList:
+      type: object
+      required: [repositories, total]
+      properties:
+        repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Repository'
+        total:
+          type: integer
+          description: Total number of repositories
         limit:
           type: integer
         offset:

--- a/internal/api/repository_handlers_test.go
+++ b/internal/api/repository_handlers_test.go
@@ -1,0 +1,221 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/google/uuid"
+)
+
+// createRepository is a test helper that POSTs a repository and returns its id and version.
+func createRepository(t *testing.T, server *api.Server, name string) (string, int64) {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q}`, name)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("createRepository status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("createRepository: failed to parse response: %v", err)
+	}
+	id, _ := resp["id"].(string)
+	version, _ := resp["version"].(float64)
+	return id, int64(version)
+}
+
+func TestCreateRepository(t *testing.T) {
+	server := setupTestServer()
+	body := `{"name":"National Archives","address":{"city":"Washington","state":"DC"},"notes":"Primary holdings"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "National Archives" {
+		t.Errorf("name = %v, want National Archives", resp["name"])
+	}
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("Expected non-empty id")
+	}
+	addr, ok := resp["address"].(map[string]any)
+	if !ok {
+		t.Fatalf("address field missing or wrong type: %T", resp["address"])
+	}
+	if addr["city"] != "Washington" {
+		t.Errorf("address.city = %v, want Washington", addr["city"])
+	}
+}
+
+func TestCreateRepository_ValidationError(t *testing.T) {
+	server := setupTestServer()
+	// Missing required name.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d. Body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestListRepositories(t *testing.T) {
+	server := setupTestServer()
+	createRepository(t, server, "Repository One")
+	createRepository(t, server, "Repository Two")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2", resp["total"])
+	}
+	repositories, ok := resp["repositories"].([]any)
+	if !ok {
+		t.Fatalf("repositories field missing or wrong type: %T", resp["repositories"])
+	}
+	if len(repositories) != 2 {
+		t.Errorf("repositories count = %d, want 2", len(repositories))
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	server := setupTestServer()
+	id, _ := createRepository(t, server, "Findable Repository")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+id, http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "Findable Repository" {
+		t.Errorf("name = %v, want Findable Repository", resp["name"])
+	}
+}
+
+func TestGetRepository_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+uuid.NewString(), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateRepository(t *testing.T) {
+	server := setupTestServer()
+	id, version := createRepository(t, server, "Original Name")
+
+	body := fmt.Sprintf(`{"name":"Updated Name","version":%d}`, version)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/repositories/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["name"] != "Updated Name" {
+		t.Errorf("name = %v, want Updated Name", resp["name"])
+	}
+	if resp["version"].(float64) <= float64(version) {
+		t.Errorf("version = %v, want greater than %d", resp["version"], version)
+	}
+}
+
+func TestUpdateRepository_VersionConflict(t *testing.T) {
+	server := setupTestServer()
+	id, version := createRepository(t, server, "Conflict Repository")
+
+	body := fmt.Sprintf(`{"name":"Stale","version":%d}`, version+99)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/repositories/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+}
+
+func TestUpdateRepository_NotFound(t *testing.T) {
+	server := setupTestServer()
+	body := `{"name":"Ghost","version":1}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/repositories/"+uuid.NewString(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteRepository(t *testing.T) {
+	server := setupTestServer()
+	id, version := createRepository(t, server, "Deletable Repository")
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/repositories/%s?version=%d", id, version), http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("Status = %d, want %d. Body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+id, http.NoBody)
+	getRec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Errorf("after delete, GET status = %d, want %d", getRec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDeleteRepository_NotFound(t *testing.T) {
+	server := setupTestServer()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/repositories/"+uuid.NewString()+"?version=0", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,6 +63,7 @@ type Server struct {
 	relationshipService *query.RelationshipService
 	noteService         *query.NoteService
 	submitterService    *query.SubmitterService
+	repositoryService   *query.RepositoryService
 	associationService  *query.AssociationService
 	ldsOrdinanceService *query.LDSOrdinanceService
 	exportService       *query.ExportService
@@ -122,6 +123,7 @@ func NewServer(
 	relationshipSvc := query.NewRelationshipService(readStore)
 	noteSvc := query.NewNoteService(readStore)
 	submitterSvc := query.NewSubmitterService(readStore)
+	repositorySvc := query.NewRepositoryService(readStore)
 	associationSvc := query.NewAssociationService(readStore)
 	ldsOrdinanceSvc := query.NewLDSOrdinanceService(readStore)
 	exportSvc := query.NewExportService(readStore)
@@ -147,6 +149,7 @@ func NewServer(
 		relationshipService: relationshipSvc,
 		noteService:         noteSvc,
 		submitterService:    submitterSvc,
+		repositoryService:   repositorySvc,
 		associationService:  associationSvc,
 		ldsOrdinanceService: ldsOrdinanceSvc,
 		exportService:       exportSvc,

--- a/internal/api/server_strict.go
+++ b/internal/api/server_strict.go
@@ -4517,6 +4517,205 @@ func convertDomainAddressToGenerated(a *domain.Address) *Address {
 	}
 }
 
+// Repository endpoints
+// ---------------------
+
+// ListRepositories implements StrictServerInterface.
+func (ss *StrictServer) ListRepositories(ctx context.Context, request ListRepositoriesRequestObject) (ListRepositoriesResponseObject, error) {
+	limit := 20
+	offset := 0
+	sort := "updated_at"
+	order := "desc"
+
+	if request.Params.Limit != nil {
+		limit = *request.Params.Limit
+	}
+	if request.Params.Offset != nil {
+		offset = *request.Params.Offset
+	}
+	if request.Params.Sort != nil {
+		sort = string(*request.Params.Sort)
+	}
+	if request.Params.Order != nil {
+		order = string(*request.Params.Order)
+	}
+
+	result, err := ss.server.repositoryService.ListRepositories(ctx, query.ListRepositoriesInput{
+		Limit:     limit,
+		Offset:    offset,
+		Sort:      sort,
+		SortOrder: order,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	repositories := make([]Repository, len(result.Repositories))
+	for i, r := range result.Repositories {
+		repositories[i] = convertQueryRepositoryToGenerated(r)
+	}
+
+	limitVal := result.Limit
+	offsetVal := result.Offset
+	return ListRepositories200JSONResponse{
+		Repositories: repositories,
+		Total:        result.Total,
+		Limit:        &limitVal,
+		Offset:       &offsetVal,
+	}, nil
+}
+
+// CreateRepository implements StrictServerInterface.
+func (ss *StrictServer) CreateRepository(ctx context.Context, request CreateRepositoryRequestObject) (CreateRepositoryResponseObject, error) {
+	input := command.CreateRepositoryInput{
+		Name: request.Body.Name,
+	}
+	if request.Body.Address != nil {
+		input.Address = convertGeneratedAddressToDomain(request.Body.Address)
+	}
+	if request.Body.Notes != nil {
+		input.Notes = *request.Body.Notes
+	}
+	if request.Body.GedcomXref != nil {
+		input.GedcomXref = *request.Body.GedcomXref
+	}
+
+	result, err := ss.server.commandHandler.CreateRepository(ctx, input)
+	if err != nil {
+		if errors.Is(err, command.ErrInvalidInput) {
+			return CreateRepository400JSONResponse{BadRequestJSONResponse{
+				Code:    "invalid_input",
+				Message: err.Error(),
+			}}, nil
+		}
+		return nil, err
+	}
+
+	// Fetch the created repository
+	repo, err := ss.server.repositoryService.GetRepository(ctx, result.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return CreateRepository201JSONResponse(convertQueryRepositoryToGenerated(*repo)), nil
+}
+
+// GetRepository implements StrictServerInterface.
+func (ss *StrictServer) GetRepository(ctx context.Context, request GetRepositoryRequestObject) (GetRepositoryResponseObject, error) {
+	repo, err := ss.server.repositoryService.GetRepository(ctx, request.Id)
+	if err != nil {
+		if errors.Is(err, query.ErrNotFound) {
+			return GetRepository404JSONResponse{NotFoundJSONResponse{
+				Code:    "not_found",
+				Message: "Repository not found",
+			}}, nil
+		}
+		return nil, err
+	}
+
+	return GetRepository200JSONResponse(convertQueryRepositoryToGenerated(*repo)), nil
+}
+
+// UpdateRepository implements StrictServerInterface.
+func (ss *StrictServer) UpdateRepository(ctx context.Context, request UpdateRepositoryRequestObject) (UpdateRepositoryResponseObject, error) {
+	input := command.UpdateRepositoryInput{
+		ID:      request.Id,
+		Version: request.Body.Version,
+	}
+	if request.Body.Name != nil {
+		input.Name = request.Body.Name
+	}
+	if request.Body.Address != nil {
+		input.Address = convertGeneratedAddressToDomain(request.Body.Address)
+	}
+	if request.Body.Notes != nil {
+		input.Notes = request.Body.Notes
+	}
+	if request.Body.GedcomXref != nil {
+		input.GedcomXref = request.Body.GedcomXref
+	}
+
+	_, err := ss.server.commandHandler.UpdateRepository(ctx, input)
+	if err != nil {
+		if errors.Is(err, command.ErrRepositoryNotFound) {
+			return UpdateRepository404JSONResponse{NotFoundJSONResponse{
+				Code:    "not_found",
+				Message: "Repository not found",
+			}}, nil
+		}
+		if errors.Is(err, repository.ErrConcurrencyConflict) {
+			return UpdateRepository409JSONResponse{ConflictJSONResponse{
+				Code:    "conflict",
+				Message: "Version conflict",
+			}}, nil
+		}
+		if errors.Is(err, command.ErrInvalidInput) {
+			return UpdateRepository400JSONResponse{BadRequestJSONResponse{
+				Code:    "invalid_input",
+				Message: err.Error(),
+			}}, nil
+		}
+		return nil, err
+	}
+
+	// Fetch the updated repository
+	repo, err := ss.server.repositoryService.GetRepository(ctx, request.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	return UpdateRepository200JSONResponse(convertQueryRepositoryToGenerated(*repo)), nil
+}
+
+// DeleteRepository implements StrictServerInterface.
+func (ss *StrictServer) DeleteRepository(ctx context.Context, request DeleteRepositoryRequestObject) (DeleteRepositoryResponseObject, error) {
+	version := int64(0)
+	if request.Params.Version != nil {
+		version = *request.Params.Version
+	}
+
+	err := ss.server.commandHandler.DeleteRepository(ctx, request.Id, version, "")
+	if err != nil {
+		if errors.Is(err, command.ErrRepositoryNotFound) {
+			return DeleteRepository404JSONResponse{NotFoundJSONResponse{
+				Code:    "not_found",
+				Message: "Repository not found",
+			}}, nil
+		}
+		if errors.Is(err, repository.ErrConcurrencyConflict) {
+			return DeleteRepository409JSONResponse{ConflictJSONResponse{
+				Code:    "conflict",
+				Message: "Version conflict",
+			}}, nil
+		}
+		return nil, err
+	}
+
+	return DeleteRepository204Response{}, nil
+}
+
+// convertQueryRepositoryToGenerated converts a query.Repository to the generated Repository type.
+func convertQueryRepositoryToGenerated(r query.Repository) Repository {
+	resp := Repository{
+		Id:        r.ID,
+		Name:      r.Name,
+		Version:   r.Version,
+		UpdatedAt: &r.UpdatedAt,
+	}
+
+	if r.Address != nil {
+		resp.Address = convertDomainAddressToGenerated(r.Address)
+	}
+	if r.Notes != nil {
+		resp.Notes = r.Notes
+	}
+	if r.GedcomXref != nil {
+		resp.GedcomXref = r.GedcomXref
+	}
+
+	return resp
+}
+
 // Association endpoints
 // ---------------------
 

--- a/internal/command/repository_commands.go
+++ b/internal/command/repository_commands.go
@@ -1,0 +1,155 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// Repository-related errors.
+var (
+	ErrRepositoryNotFound = errors.New("repository not found")
+)
+
+// CreateRepositoryInput contains the data for creating a new repository.
+type CreateRepositoryInput struct {
+	Name       string
+	Address    *domain.Address
+	Notes      string
+	GedcomXref string
+}
+
+// CreateRepositoryResult contains the result of creating a repository.
+type CreateRepositoryResult struct {
+	ID      uuid.UUID
+	Version int64
+}
+
+// CreateRepository creates a new repository record.
+func (h *Handler) CreateRepository(ctx context.Context, input CreateRepositoryInput) (*CreateRepositoryResult, error) {
+	// Create repository entity
+	repo := domain.NewRepository(input.Name)
+
+	if input.Address != nil {
+		repo.SetAddress(input.Address)
+	}
+	if input.Notes != "" {
+		repo.Notes = input.Notes
+	}
+	if input.GedcomXref != "" {
+		repo.GedcomXref = input.GedcomXref
+	}
+
+	// Validate repository
+	if err := repo.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+
+	// Create event
+	event := domain.NewRepositoryCreated(repo)
+
+	// Execute command (append + project)
+	version, err := h.execute(ctx, repo.ID.String(), "Repository", []domain.Event{event}, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CreateRepositoryResult{
+		ID:      repo.ID,
+		Version: version,
+	}, nil
+}
+
+// UpdateRepositoryInput contains the data for updating a repository.
+type UpdateRepositoryInput struct {
+	ID         uuid.UUID
+	Name       *string
+	Address    *domain.Address
+	Notes      *string
+	GedcomXref *string
+	Version    int64 // Required for optimistic locking
+}
+
+// UpdateRepositoryResult contains the result of updating a repository.
+type UpdateRepositoryResult struct {
+	Version int64
+}
+
+// UpdateRepository updates an existing repository record.
+func (h *Handler) UpdateRepository(ctx context.Context, input UpdateRepositoryInput) (*UpdateRepositoryResult, error) {
+	// Get current repository from read model
+	current, err := h.readStore.GetRepository(ctx, input.ID)
+	if err != nil {
+		return nil, err
+	}
+	if current == nil {
+		return nil, ErrRepositoryNotFound
+	}
+
+	// Check version for optimistic locking
+	if current.Version != input.Version {
+		return nil, repository.ErrConcurrencyConflict
+	}
+
+	// Build changes map. Keys must match the projection's RepositoryUpdated
+	// handler exactly: name, address (*domain.Address), notes, gedcom_xref.
+	changes := make(map[string]any)
+
+	if input.Name != nil && *input.Name != current.Name {
+		changes["name"] = *input.Name
+	}
+	if input.Address != nil {
+		changes["address"] = input.Address
+	}
+	if input.Notes != nil && *input.Notes != current.Notes {
+		changes["notes"] = *input.Notes
+	}
+	if input.GedcomXref != nil && *input.GedcomXref != current.GedcomXref {
+		changes["gedcom_xref"] = *input.GedcomXref
+	}
+
+	// No changes?
+	if len(changes) == 0 {
+		return &UpdateRepositoryResult{Version: current.Version}, nil
+	}
+
+	// Create event
+	event := domain.NewRepositoryUpdated(input.ID, changes)
+
+	// Execute command
+	version, err := h.execute(ctx, input.ID.String(), "Repository", []domain.Event{event}, input.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UpdateRepositoryResult{Version: version}, nil
+}
+
+// DeleteRepository deletes a repository record.
+func (h *Handler) DeleteRepository(ctx context.Context, id uuid.UUID, version int64, reason string) error {
+	// Get current repository from read model
+	current, err := h.readStore.GetRepository(ctx, id)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return ErrRepositoryNotFound
+	}
+
+	// Check version for optimistic locking
+	if current.Version != version {
+		return repository.ErrConcurrencyConflict
+	}
+
+	// Create event
+	event := domain.NewRepositoryDeleted(id, reason)
+
+	// Execute command
+	_, err = h.execute(ctx, id.String(), "Repository", []domain.Event{event}, version)
+	return err
+}

--- a/internal/command/repository_commands_test.go
+++ b/internal/command/repository_commands_test.go
@@ -1,0 +1,291 @@
+package command_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cacack/my-family/internal/command"
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+func TestCreateRepository(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		input   command.CreateRepositoryInput
+		wantErr bool
+	}{
+		{
+			name: "create repository with name only",
+			input: command.CreateRepositoryInput{
+				Name: "National Archives",
+			},
+			wantErr: false,
+		},
+		{
+			name: "create repository with all fields",
+			input: command.CreateRepositoryInput{
+				Name: "State Historical Society",
+				Address: &domain.Address{
+					Line1:      "123 Archive Way",
+					City:       "Springfield",
+					State:      "IL",
+					PostalCode: "62701",
+					Country:    "USA",
+					Phone:      "555-1234",
+					Email:      "info@archives.example.com",
+					Website:    "https://archives.example.com",
+				},
+				Notes:      "Open weekdays 9-5",
+				GedcomXref: "@REPO1@",
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail with empty name",
+			input: command.CreateRepositoryInput{
+				Name: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := handler.CreateRepository(ctx, tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.NotEqual(t, uuid.Nil, result.ID)
+			assert.Equal(t, int64(1), result.Version)
+
+			// Verify repository was saved in read model
+			saved, err := readStore.GetRepository(ctx, result.ID)
+			require.NoError(t, err)
+			require.NotNil(t, saved)
+			assert.Equal(t, tc.input.Name, saved.Name)
+		})
+	}
+}
+
+func TestCreateRepository_WithAddress(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	input := command.CreateRepositoryInput{
+		Name: "County Library",
+		Address: &domain.Address{
+			Line1: "456 Oak Ave",
+			City:  "Boston",
+		},
+	}
+
+	result, err := handler.CreateRepository(ctx, input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	saved, err := readStore.GetRepository(ctx, result.ID)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	require.NotNil(t, saved.Address)
+	assert.Equal(t, "456 Oak Ave", saved.Address.Line1)
+	assert.Equal(t, "Boston", saved.Address.City)
+}
+
+func TestUpdateRepository(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create initial repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "Old Name",
+	})
+	require.NoError(t, err)
+
+	// Update the repository
+	newName := "New Name"
+	updateResult, err := handler.UpdateRepository(ctx, command.UpdateRepositoryInput{
+		ID:      createResult.ID,
+		Name:    &newName,
+		Version: createResult.Version,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updateResult.Version)
+
+	// Verify the update
+	saved, err := readStore.GetRepository(ctx, createResult.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", saved.Name)
+}
+
+func TestUpdateRepository_AllFields(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create initial repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "Original Repo",
+	})
+	require.NoError(t, err)
+
+	// Update with all fields
+	newName := "Updated Repo"
+	newNotes := "Updated notes"
+	newXref := "@REPO99@"
+	updateResult, err := handler.UpdateRepository(ctx, command.UpdateRepositoryInput{
+		ID:   createResult.ID,
+		Name: &newName,
+		Address: &domain.Address{
+			Line1: "789 Pine St",
+			City:  "Chicago",
+		},
+		Notes:      &newNotes,
+		GedcomXref: &newXref,
+		Version:    createResult.Version,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updateResult.Version)
+
+	// Verify the update
+	saved, err := readStore.GetRepository(ctx, createResult.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Repo", saved.Name)
+	assert.Equal(t, "Updated notes", saved.Notes)
+	assert.Equal(t, "@REPO99@", saved.GedcomXref)
+	require.NotNil(t, saved.Address)
+	assert.Equal(t, "789 Pine St", saved.Address.Line1)
+}
+
+func TestUpdateRepository_NoChanges(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create initial repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "Same Name",
+	})
+	require.NoError(t, err)
+
+	// Update with same name (no changes)
+	sameName := "Same Name"
+	updateResult, err := handler.UpdateRepository(ctx, command.UpdateRepositoryInput{
+		ID:      createResult.ID,
+		Name:    &sameName,
+		Version: createResult.Version,
+	})
+	require.NoError(t, err)
+	// Version should remain the same since no actual changes
+	assert.Equal(t, createResult.Version, updateResult.Version)
+}
+
+func TestUpdateRepository_NotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	newName := "New Name"
+	_, err := handler.UpdateRepository(ctx, command.UpdateRepositoryInput{
+		ID:      uuid.New(),
+		Name:    &newName,
+		Version: 1,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, command.ErrRepositoryNotFound)
+}
+
+func TestUpdateRepository_ConcurrencyConflict(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create initial repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "Test Repo",
+	})
+	require.NoError(t, err)
+
+	// Update with wrong version
+	newName := "Changed"
+	_, err = handler.UpdateRepository(ctx, command.UpdateRepositoryInput{
+		ID:      createResult.ID,
+		Name:    &newName,
+		Version: 99, // Wrong version
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrConcurrencyConflict)
+}
+
+func TestDeleteRepository(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "To Delete",
+	})
+	require.NoError(t, err)
+
+	// Delete the repository
+	err = handler.DeleteRepository(ctx, createResult.ID, createResult.Version, "Test deletion")
+	require.NoError(t, err)
+
+	// Verify it's deleted from read model
+	deleted, err := readStore.GetRepository(ctx, createResult.ID)
+	require.NoError(t, err)
+	assert.Nil(t, deleted)
+}
+
+func TestDeleteRepository_NotFound(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	err := handler.DeleteRepository(ctx, uuid.New(), 1, "Test deletion")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, command.ErrRepositoryNotFound)
+}
+
+func TestDeleteRepository_ConcurrencyConflict(t *testing.T) {
+	eventStore := memory.NewEventStore()
+	readStore := memory.NewReadModelStore()
+	handler := command.NewHandler(eventStore, readStore)
+	ctx := context.Background()
+
+	// Create a repository
+	createResult, err := handler.CreateRepository(ctx, command.CreateRepositoryInput{
+		Name: "Test Repo",
+	})
+	require.NoError(t, err)
+
+	// Delete with wrong version
+	err = handler.DeleteRepository(ctx, createResult.ID, 99, "Test deletion")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrConcurrencyConflict)
+}

--- a/internal/gedcom/exporter.go
+++ b/internal/gedcom/exporter.go
@@ -26,6 +26,7 @@ type ExportResult struct {
 	AttributesExported    int
 	NotesExported         int
 	SubmittersExported    int
+	RepositoriesExported  int
 	AssociationsExported  int
 	LDSOrdinancesExported int
 }
@@ -106,15 +107,21 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 		return nil, fmt.Errorf("failed to list submitters: %w", err)
 	}
 
+	repositories, err := repository.ListAll(ctx, 1000, exp.readStore.ListRepositories)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list repositories: %w", err)
+	}
+
 	// Calculate total items for progress tracking
 	// Weight persons more heavily since they have the most processing
-	totalItems := len(sources) + len(persons)*2 + len(families) + len(notes) + len(submitters) + 1 // +1 for encoding
+	totalItems := len(sources) + len(persons)*2 + len(families) + len(notes) + len(submitters) + len(repositories) + 1 // +1 for encoding
 	processedItems := 0
 
 	// Create XREF mappings (UUID -> @Xn@)
 	personXrefs := make(map[uuid.UUID]string)
 	familyXrefs := make(map[uuid.UUID]string)
 	sourceXrefs := make(map[uuid.UUID]string)
+	repositoryXrefs := make(map[uuid.UUID]string)
 
 	// Sort persons by ID for stable output
 	sort.Slice(persons, func(i, j int) bool {
@@ -145,6 +152,25 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 		}
 	}
 
+	// Sort repositories by ID for stable output and assign xrefs.
+	sort.Slice(repositories, func(i, j int) bool {
+		return repositories[i].ID.String() < repositories[j].ID.String()
+	})
+	// repoNameToXref lets sources that reference a repository by name be linked
+	// to the standalone REPO record via a SOUR.REPO cross-reference.
+	repoNameToXref := make(map[string]string)
+	for i, r := range repositories {
+		// Use GedcomXref if available (for round-trip), otherwise generate.
+		if r.GedcomXref != "" {
+			repositoryXrefs[r.ID] = r.GedcomXref
+		} else {
+			repositoryXrefs[r.ID] = fmt.Sprintf("@R%d@", i+1)
+		}
+		if r.Name != "" {
+			repoNameToXref[r.Name] = repositoryXrefs[r.ID]
+		}
+	}
+
 	// Build GEDCOM document
 	doc := &gedcom.Document{
 		Header: &gedcom.Header{
@@ -158,7 +184,7 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 	// Add source records
 	for i, s := range sources {
 		xref := sourceXrefs[s.ID]
-		src := toGedcomSource(s)
+		src := toGedcomSource(s, repoNameToXref)
 		doc.Records = append(doc.Records, &gedcom.Record{
 			XRef:   xref,
 			Type:   gedcom.RecordTypeSource,
@@ -321,6 +347,28 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 		}
 	}
 
+	// Add repository records (REPO). Standalone records that sources reference
+	// via SOUR.REPO cross-references.
+	for i, r := range repositories {
+		xref := repositoryXrefs[r.ID]
+		repo := toGedcomRepository(r)
+		doc.Records = append(doc.Records, &gedcom.Record{
+			XRef:   xref,
+			Type:   gedcom.RecordTypeRepository,
+			Entity: repo,
+		})
+		result.RepositoriesExported++
+		processedItems++
+
+		// Report progress every 10 items or at the end
+		if i%10 == 0 || i == len(repositories)-1 {
+			pct := float64(processedItems) / float64(totalItems) * 100
+			if err := reportProgress("repositories", i+1, len(repositories), pct); err != nil {
+				return result, err
+			}
+		}
+	}
+
 	// Bump to GEDCOM 7.0 if any negated events are present (NO tags require 7.0)
 	if hasNegatedEvents(doc) {
 		doc.Header.Version = gedcom.Version70
@@ -364,7 +412,12 @@ func (cw *countingWriter) Write(p []byte) (n int, err error) {
 
 // toGedcomSource converts a repository SourceReadModel to a gedcom.Source entity.
 // The encoder will automatically convert this to GEDCOM tags, handling CONT/CONC.
-func toGedcomSource(s repository.SourceReadModel) *gedcom.Source {
+//
+// repoNameToXref maps a Repository's name (and any @XREF@ used as a name) to the
+// xref of its standalone REPO record. When a source references a repository that
+// exists as a Repository entity, emit a SOUR.REPO cross-reference to that record;
+// otherwise fall back to an inline repository definition (name-only sources).
+func toGedcomSource(s repository.SourceReadModel, repoNameToXref map[string]string) *gedcom.Source {
 	src := &gedcom.Source{}
 
 	// Title
@@ -384,11 +437,16 @@ func toGedcomSource(s repository.SourceReadModel) *gedcom.Source {
 
 	// Repository
 	if s.RepositoryName != "" {
-		// If it looks like an XREF, use RepositoryRef
-		if strings.HasPrefix(s.RepositoryName, "@") && strings.HasSuffix(s.RepositoryName, "@") {
+		switch {
+		case repoNameToXref[s.RepositoryName] != "":
+			// Source references a Repository entity by name: emit a SOUR.REPO
+			// cross-reference to the standalone REPO record.
+			src.RepositoryRef = repoNameToXref[s.RepositoryName]
+		case strings.HasPrefix(s.RepositoryName, "@") && strings.HasSuffix(s.RepositoryName, "@"):
+			// Already an XREF (e.g. an unresolved import reference): preserve it.
 			src.RepositoryRef = s.RepositoryName
-		} else {
-			// Inline repository with NAME subordinate
+		default:
+			// Inline repository with NAME subordinate (name-only / unlinked source).
 			src.Repository = &gedcom.InlineRepository{Name: s.RepositoryName}
 		}
 	}
@@ -937,6 +995,26 @@ func toGedcomSubmitter(s repository.SubmitterReadModel) *gedcom.Submitter {
 	}
 
 	return subm
+}
+
+// toGedcomRepository converts a repository RepositoryReadModel to a gedcom.Repository entity.
+// The encoder will automatically convert this to GEDCOM tags (NAME, ADDR, NOTE).
+func toGedcomRepository(r repository.RepositoryReadModel) *gedcom.Repository {
+	repo := &gedcom.Repository{
+		Name: r.Name,
+	}
+
+	// Convert address if present (includes phone/email/website).
+	if r.Address != nil && !r.Address.IsEmpty() {
+		repo.Address = convertDomainAddressToGedcom(r.Address)
+	}
+
+	// Notes - encoder handles CONT/CONC automatically for multiline text.
+	if r.Notes != "" {
+		repo.Notes = []string{r.Notes}
+	}
+
+	return repo
 }
 
 // toGedcomLDSOrdinance converts a repository LDSOrdinanceReadModel to a gedcom.LDSOrdinance.

--- a/internal/gedcom/exporter_test.go
+++ b/internal/gedcom/exporter_test.go
@@ -2532,3 +2532,235 @@ func TestExport_NegatedEventRoundTrip(t *testing.T) {
 		t.Error("Round-trip should preserve birth date")
 	}
 }
+
+func TestExport_Repositories(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	ctx := context.Background()
+
+	// Repository linked to a source by name.
+	repoID := uuid.New()
+	repo := &repository.RepositoryReadModel{
+		ID:   repoID,
+		Name: "National Archives",
+		Address: &domain.Address{
+			Line1:   "700 Pennsylvania Ave NW",
+			City:    "Washington",
+			State:   "DC",
+			Country: "USA",
+		},
+		Notes:      "Federal repository",
+		GedcomXref: "@R1@",
+	}
+	if err := readStore.SaveRepository(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	// Source whose RepositoryName matches the repository: should become a
+	// SOUR.REPO cross-reference, not an inline repository.
+	linkedSource := &repository.SourceReadModel{
+		ID:             uuid.New(),
+		SourceType:     "book",
+		Title:          "Census Records",
+		RepositoryName: "National Archives",
+		GedcomXref:     "@S1@",
+	}
+	if err := readStore.SaveSource(ctx, linkedSource); err != nil {
+		t.Fatal(err)
+	}
+
+	// Source referencing a repository only by name (no Repository entity):
+	// should keep the inline repository fallback.
+	unlinkedSource := &repository.SourceReadModel{
+		ID:             uuid.New(),
+		SourceType:     "book",
+		Title:          "Parish Register",
+		RepositoryName: "St. Mary's Church",
+		GedcomXref:     "@S2@",
+	}
+	if err := readStore.SaveSource(ctx, unlinkedSource); err != nil {
+		t.Fatal(err)
+	}
+
+	exporter := gedcom.NewExporter(readStore)
+	buf := &bytes.Buffer{}
+	result, err := exporter.Export(ctx, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.RepositoriesExported != 1 {
+		t.Errorf("RepositoriesExported = %d, want 1", result.RepositoriesExported)
+	}
+
+	output := buf.String()
+
+	// Standalone REPO record with name and address.
+	if !strings.Contains(output, "0 @R1@ REPO\n") {
+		t.Errorf("Output should contain standalone REPO record; got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 NAME National Archives\n") {
+		t.Error("Output should contain repository NAME")
+	}
+	if !strings.Contains(output, "700 Pennsylvania Ave NW") {
+		t.Error("Output should contain repository address")
+	}
+	if !strings.Contains(output, "Federal repository") {
+		t.Error("Output should contain repository note")
+	}
+
+	// Linked source uses a SOUR.REPO cross-reference (no inline NAME).
+	if !strings.Contains(output, "1 REPO @R1@\n") {
+		t.Errorf("Linked source should reference REPO via xref; got:\n%s", output)
+	}
+
+	// Unlinked source keeps the inline repository fallback.
+	if !strings.Contains(output, "2 NAME St. Mary's Church\n") {
+		t.Errorf("Unlinked source should keep inline repository name; got:\n%s", output)
+	}
+}
+
+// TestExport_RepositoryRoundTrip imports a GEDCOM containing REPO records and
+// SOUR.REPO cross-references, exports it, and asserts the repositories and the
+// source->repository links survive with no dropped data.
+func TestExport_RepositoryRoundTrip(t *testing.T) {
+	gedcomInput := `0 HEAD
+1 GEDC
+2 VERS 5.5
+1 CHAR UTF-8
+0 @S1@ SOUR
+1 TITL 1900 Census
+1 REPO @R1@
+0 @S2@ SOUR
+1 TITL Family Bible
+0 @R1@ REPO
+1 NAME National Archives
+1 ADDR 700 Pennsylvania Ave NW
+2 CITY Washington
+2 STAE DC
+2 CTRY USA
+0 @I1@ INDI
+1 NAME Test /Person/
+0 TRLR
+`
+	ctx := context.Background()
+
+	// Step 1: Import.
+	importer := gedcom.NewImporter()
+	_, persons, _, sources, _, repositories, _, _, _, _, _, _, _, err := importer.Import(ctx, strings.NewReader(gedcomInput))
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if len(repositories) != 1 {
+		t.Fatalf("Import should produce 1 repository, got %d", len(repositories))
+	}
+	if len(sources) != 2 {
+		t.Fatalf("Import should produce 2 sources, got %d", len(sources))
+	}
+
+	// Step 2: Store in read model.
+	readStore := memory.NewReadModelStore()
+
+	// Map repository xref -> name so linked sources can be re-linked by name.
+	// (The SourceReadModel carries only RepositoryName, not RepositoryID.)
+	repoNameByID := make(map[uuid.UUID]string)
+	for _, r := range repositories {
+		var addr *domain.Address
+		if r.Address != "" || r.City != "" || r.State != "" || r.Country != "" {
+			addr = &domain.Address{
+				Line1:   r.Address,
+				City:    r.City,
+				State:   r.State,
+				Country: r.Country,
+			}
+		}
+		rm := &repository.RepositoryReadModel{
+			ID:         r.ID,
+			Name:       r.Name,
+			Address:    addr,
+			Notes:      r.Notes,
+			GedcomXref: r.GedcomXref,
+			Version:    1,
+		}
+		if err := readStore.SaveRepository(ctx, rm); err != nil {
+			t.Fatalf("Failed to save repository: %v", err)
+		}
+		repoNameByID[r.ID] = r.Name
+	}
+
+	for _, s := range sources {
+		// Resolved SOUR.REPO references set RepositoryID; bridge it to the
+		// repository name the read model stores for display/export.
+		repoName := s.RepositoryName
+		if s.RepositoryID != nil {
+			if name, ok := repoNameByID[*s.RepositoryID]; ok {
+				repoName = name
+			}
+		}
+		sm := &repository.SourceReadModel{
+			ID:             s.ID,
+			SourceType:     domain.SourceType(s.SourceType),
+			Title:          s.Title,
+			Author:         s.Author,
+			Publisher:      s.Publisher,
+			RepositoryName: repoName,
+			Notes:          s.Notes,
+			GedcomXref:     s.GedcomXref,
+			Version:        1,
+		}
+		if err := readStore.SaveSource(ctx, sm); err != nil {
+			t.Fatalf("Failed to save source: %v", err)
+		}
+	}
+
+	for _, p := range persons {
+		pm := &repository.PersonReadModel{
+			ID:        p.ID,
+			GivenName: p.GivenName,
+			Surname:   p.Surname,
+			FullName:  p.GivenName + " " + p.Surname,
+		}
+		if err := readStore.SavePerson(ctx, pm); err != nil {
+			t.Fatalf("Failed to save person: %v", err)
+		}
+	}
+
+	// Step 3: Export.
+	exporter := gedcom.NewExporter(readStore)
+	buf := &bytes.Buffer{}
+	result, err := exporter.Export(ctx, buf)
+	if err != nil {
+		t.Fatalf("Export failed: %v", err)
+	}
+
+	if result.RepositoriesExported != 1 {
+		t.Errorf("RepositoriesExported = %d, want 1", result.RepositoriesExported)
+	}
+	if result.SourcesExported != 2 {
+		t.Errorf("SourcesExported = %d, want 2", result.SourcesExported)
+	}
+
+	output := buf.String()
+
+	// Step 4: Assert nothing dropped.
+	// Standalone REPO record preserved with its original xref and name.
+	if !strings.Contains(output, "0 @R1@ REPO\n") {
+		t.Errorf("Round-trip should preserve standalone REPO record; got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 NAME National Archives\n") {
+		t.Error("Round-trip should preserve repository NAME")
+	}
+	if !strings.Contains(output, "700 Pennsylvania Ave NW") {
+		t.Error("Round-trip should preserve repository address")
+	}
+
+	// Linked source (@S1@) keeps its SOUR.REPO cross-reference.
+	if !strings.Contains(output, "1 REPO @R1@\n") {
+		t.Errorf("Round-trip should preserve SOUR.REPO xref for linked source; got:\n%s", output)
+	}
+
+	// Source without a repository (@S2@) survives without a spurious REPO link.
+	if !strings.Contains(output, "1 TITL Family Bible\n") {
+		t.Errorf("Round-trip should preserve unlinked source; got:\n%s", output)
+	}
+}

--- a/internal/query/history_queries_test.go
+++ b/internal/query/history_queries_test.go
@@ -303,6 +303,20 @@ func (m *mockReadModelStore) DeleteSubmitter(ctx context.Context, id uuid.UUID) 
 	return nil
 }
 
+// Repository stub methods
+func (m *mockReadModelStore) GetRepository(ctx context.Context, id uuid.UUID) (*repository.RepositoryReadModel, error) {
+	return nil, nil
+}
+func (m *mockReadModelStore) ListRepositories(ctx context.Context, opts repository.ListOptions) ([]repository.RepositoryReadModel, int, error) {
+	return nil, 0, nil
+}
+func (m *mockReadModelStore) SaveRepository(ctx context.Context, repo *repository.RepositoryReadModel) error {
+	return nil
+}
+func (m *mockReadModelStore) DeleteRepository(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
 // Association stub methods
 func (m *mockReadModelStore) GetAssociation(ctx context.Context, id uuid.UUID) (*repository.AssociationReadModel, error) {
 	return nil, nil

--- a/internal/query/repository_queries.go
+++ b/internal/query/repository_queries.go
@@ -1,0 +1,119 @@
+package query
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/repository"
+)
+
+// RepositoryService provides query operations for repositories.
+type RepositoryService struct {
+	readStore repository.ReadModelStore
+}
+
+// NewRepositoryService creates a new repository query service.
+func NewRepositoryService(readStore repository.ReadModelStore) *RepositoryService {
+	return &RepositoryService{readStore: readStore}
+}
+
+// Repository represents a repository in query results.
+type Repository struct {
+	ID         uuid.UUID       `json:"id"`
+	Name       string          `json:"name"`
+	Address    *domain.Address `json:"address,omitempty"`
+	Notes      *string         `json:"notes,omitempty"`
+	GedcomXref *string         `json:"gedcom_xref,omitempty"`
+	Version    int64           `json:"version"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// ListRepositoriesInput contains options for listing repositories.
+type ListRepositoriesInput struct {
+	Limit     int
+	Offset    int
+	Sort      string // name, updated_at
+	SortOrder string // asc, desc
+}
+
+// RepositoryListResult contains paginated repository results.
+type RepositoryListResult struct {
+	Repositories []Repository `json:"repositories"`
+	Total        int          `json:"total"`
+	Limit        int          `json:"limit"`
+	Offset       int          `json:"offset"`
+}
+
+// ListRepositories returns a paginated list of repositories.
+func (s *RepositoryService) ListRepositories(ctx context.Context, input ListRepositoriesInput) (*RepositoryListResult, error) {
+	opts := repository.ListOptions{
+		Limit:  input.Limit,
+		Offset: input.Offset,
+		Sort:   input.Sort,
+		Order:  input.SortOrder,
+	}
+
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+	if opts.Limit > 100 {
+		opts.Limit = 100
+	}
+	if opts.Order == "" {
+		opts.Order = "desc"
+	}
+
+	readModels, total, err := s.readStore.ListRepositories(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	repositories := make([]Repository, len(readModels))
+	for i, rm := range readModels {
+		repositories[i] = convertReadModelToRepository(rm)
+	}
+
+	return &RepositoryListResult{
+		Repositories: repositories,
+		Total:        total,
+		Limit:        opts.Limit,
+		Offset:       opts.Offset,
+	}, nil
+}
+
+// GetRepository returns a repository by ID.
+func (s *RepositoryService) GetRepository(ctx context.Context, id uuid.UUID) (*Repository, error) {
+	rm, err := s.readStore.GetRepository(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if rm == nil {
+		return nil, ErrNotFound
+	}
+
+	repo := convertReadModelToRepository(*rm)
+	return &repo, nil
+}
+
+// Helper function to convert read model to query result.
+func convertReadModelToRepository(rm repository.RepositoryReadModel) Repository {
+	repo := Repository{
+		ID:        rm.ID,
+		Name:      rm.Name,
+		Address:   rm.Address,
+		Version:   rm.Version,
+		UpdatedAt: rm.UpdatedAt,
+	}
+
+	if rm.Notes != "" {
+		repo.Notes = &rm.Notes
+	}
+	if rm.GedcomXref != "" {
+		repo.GedcomXref = &rm.GedcomXref
+	}
+
+	return repo
+}

--- a/internal/query/repository_queries_test.go
+++ b/internal/query/repository_queries_test.go
@@ -1,0 +1,179 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cacack/my-family/internal/domain"
+	"github.com/cacack/my-family/internal/query"
+	"github.com/cacack/my-family/internal/repository"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+func TestNewRepositoryService(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	service := query.NewRepositoryService(readStore)
+	require.NotNil(t, service)
+}
+
+func TestRepositoryService_ListRepositories(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	service := query.NewRepositoryService(readStore)
+	ctx := context.Background()
+
+	// Add some repositories to the read store
+	now := time.Now()
+	repo1 := &repository.RepositoryReadModel{
+		ID:        uuid.New(),
+		Name:      "National Archives",
+		Notes:     "Primary source location",
+		Version:   1,
+		UpdatedAt: now,
+	}
+	repo2 := &repository.RepositoryReadModel{
+		ID:        uuid.New(),
+		Name:      "County Library",
+		Version:   1,
+		UpdatedAt: now.Add(-time.Hour),
+	}
+
+	require.NoError(t, readStore.SaveRepository(ctx, repo1))
+	require.NoError(t, readStore.SaveRepository(ctx, repo2))
+
+	t.Run("list all repositories", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit:  10,
+			Offset: 0,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Repositories, 2)
+		assert.Equal(t, 2, result.Total)
+		assert.Equal(t, 10, result.Limit)
+	})
+
+	t.Run("list with pagination", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit:  1,
+			Offset: 0,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Repositories, 1)
+		assert.Equal(t, 2, result.Total)
+	})
+
+	t.Run("list with offset", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit:  10,
+			Offset: 1,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Repositories, 1)
+		assert.Equal(t, 2, result.Total)
+		assert.Equal(t, 1, result.Offset)
+	})
+
+	t.Run("default limit applied when zero", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit: 0,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 20, result.Limit)
+	})
+
+	t.Run("max limit capped at 100", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit: 200,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 100, result.Limit)
+	})
+
+	t.Run("default order is desc", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit: 10,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("ascending order", func(t *testing.T) {
+		result, err := service.ListRepositories(ctx, query.ListRepositoriesInput{
+			Limit:     10,
+			SortOrder: "asc",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+}
+
+func TestRepositoryService_GetRepository(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	service := query.NewRepositoryService(readStore)
+	ctx := context.Background()
+
+	t.Run("get existing repository", func(t *testing.T) {
+		// Add a repository
+		id := uuid.New()
+		repo := &repository.RepositoryReadModel{
+			ID:         id,
+			Name:       "National Archives",
+			Address:    &domain.Address{Line1: "123 Archive Way", City: "Springfield"},
+			Notes:      "Open weekdays",
+			GedcomXref: "@REPO1@",
+			Version:    1,
+			UpdatedAt:  time.Now(),
+		}
+		require.NoError(t, readStore.SaveRepository(ctx, repo))
+
+		// Get the repository
+		result, err := service.GetRepository(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, id, result.ID)
+		assert.Equal(t, "National Archives", result.Name)
+		require.NotNil(t, result.Address)
+		assert.Equal(t, "123 Archive Way", result.Address.Line1)
+		require.NotNil(t, result.Notes)
+		assert.Equal(t, "Open weekdays", *result.Notes)
+		require.NotNil(t, result.GedcomXref)
+		assert.Equal(t, "@REPO1@", *result.GedcomXref)
+		assert.Equal(t, int64(1), result.Version)
+	})
+
+	t.Run("get repository with minimal fields", func(t *testing.T) {
+		// Add a repository with only required fields
+		id := uuid.New()
+		repo := &repository.RepositoryReadModel{
+			ID:        id,
+			Name:      "County Library",
+			Version:   1,
+			UpdatedAt: time.Now(),
+		}
+		require.NoError(t, readStore.SaveRepository(ctx, repo))
+
+		// Get the repository
+		result, err := service.GetRepository(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, id, result.ID)
+		assert.Equal(t, "County Library", result.Name)
+		assert.Nil(t, result.Address)
+		assert.Nil(t, result.Notes)
+		assert.Nil(t, result.GedcomXref)
+	})
+
+	t.Run("get non-existent repository", func(t *testing.T) {
+		result, err := service.GetRepository(ctx, uuid.New())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, query.ErrNotFound)
+		assert.Nil(t, result)
+	})
+}

--- a/internal/repository/memory/readmodel.go
+++ b/internal/repository/memory/readmodel.go
@@ -1681,13 +1681,24 @@ func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.L
 
 	total := len(results)
 
-	// Sort by name
+	// Sort by name or updated_at (matches the postgres/sqlite implementations,
+	// which default to updated_at and switch to name when opts.Sort == "name").
+	sortField := opts.Sort
+	if sortField == "" {
+		sortField = "updated_at"
+	}
 	asc := opts.Order == "asc"
 	sort.Slice(results, func(i, j int) bool {
-		if asc {
-			return results[i].Name < results[j].Name
+		var cmp int
+		if sortField == "name" {
+			cmp = strings.Compare(results[i].Name, results[j].Name)
+		} else {
+			cmp = compareTimestamps(results[i].UpdatedAt, results[j].UpdatedAt)
 		}
-		return results[i].Name > results[j].Name
+		if asc {
+			return cmp < 0
+		}
+		return cmp > 0
 	})
 
 	// Apply pagination

--- a/internal/repository/memory/readmodel.go
+++ b/internal/repository/memory/readmodel.go
@@ -29,6 +29,7 @@ type ReadModelStore struct {
 	attributes        map[uuid.UUID]*repository.AttributeReadModel
 	notes             map[uuid.UUID]*repository.NoteReadModel
 	submitters        map[uuid.UUID]*repository.SubmitterReadModel
+	repositories      map[uuid.UUID]*repository.RepositoryReadModel
 	associations      map[uuid.UUID]*repository.AssociationReadModel
 	ldsOrdinances     map[uuid.UUID]*repository.LDSOrdinanceReadModel
 	evidenceAnalyses  map[uuid.UUID]*repository.EvidenceAnalysisReadModel
@@ -52,6 +53,7 @@ func NewReadModelStore() *ReadModelStore {
 		attributes:        make(map[uuid.UUID]*repository.AttributeReadModel),
 		notes:             make(map[uuid.UUID]*repository.NoteReadModel),
 		submitters:        make(map[uuid.UUID]*repository.SubmitterReadModel),
+		repositories:      make(map[uuid.UUID]*repository.RepositoryReadModel),
 		associations:      make(map[uuid.UUID]*repository.AssociationReadModel),
 		ldsOrdinances:     make(map[uuid.UUID]*repository.LDSOrdinanceReadModel),
 		evidenceAnalyses:  make(map[uuid.UUID]*repository.EvidenceAnalysisReadModel),
@@ -650,6 +652,7 @@ func (s *ReadModelStore) Reset() {
 	s.attributes = make(map[uuid.UUID]*repository.AttributeReadModel)
 	s.notes = make(map[uuid.UUID]*repository.NoteReadModel)
 	s.submitters = make(map[uuid.UUID]*repository.SubmitterReadModel)
+	s.repositories = make(map[uuid.UUID]*repository.RepositoryReadModel)
 	s.associations = make(map[uuid.UUID]*repository.AssociationReadModel)
 	s.ldsOrdinances = make(map[uuid.UUID]*repository.LDSOrdinanceReadModel)
 	s.evidenceAnalyses = make(map[uuid.UUID]*repository.EvidenceAnalysisReadModel)
@@ -1650,6 +1653,72 @@ func (s *ReadModelStore) DeleteSubmitter(ctx context.Context, id uuid.UUID) erro
 	defer s.mu.Unlock()
 
 	delete(s.submitters, id)
+	return nil
+}
+
+// GetRepository retrieves a repository by ID.
+func (s *ReadModelStore) GetRepository(ctx context.Context, id uuid.UUID) (*repository.RepositoryReadModel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	repo, exists := s.repositories[id]
+	if !exists {
+		return nil, nil
+	}
+	result := *repo
+	return &result, nil
+}
+
+// ListRepositories returns a paginated list of repositories.
+func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.ListOptions) ([]repository.RepositoryReadModel, int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []repository.RepositoryReadModel
+	for _, repo := range s.repositories {
+		results = append(results, *repo)
+	}
+
+	total := len(results)
+
+	// Sort by name
+	asc := opts.Order == "asc"
+	sort.Slice(results, func(i, j int) bool {
+		if asc {
+			return results[i].Name < results[j].Name
+		}
+		return results[i].Name > results[j].Name
+	})
+
+	// Apply pagination
+	if opts.Offset > 0 && opts.Offset < len(results) {
+		results = results[opts.Offset:]
+	} else if opts.Offset >= len(results) {
+		results = nil
+	}
+	if opts.Limit > 0 && opts.Limit < len(results) {
+		results = results[:opts.Limit]
+	}
+
+	return results, total, nil
+}
+
+// SaveRepository saves or updates a repository.
+func (s *ReadModelStore) SaveRepository(ctx context.Context, repo *repository.RepositoryReadModel) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := *repo
+	s.repositories[repo.ID] = &result
+	return nil
+}
+
+// DeleteRepository removes a repository.
+func (s *ReadModelStore) DeleteRepository(ctx context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.repositories, id)
 	return nil
 }
 

--- a/internal/repository/memory/readmodel.go
+++ b/internal/repository/memory/readmodel.go
@@ -1695,6 +1695,11 @@ func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.L
 		} else {
 			cmp = compareTimestamps(results[i].UpdatedAt, results[j].UpdatedAt)
 		}
+		// id is a stable tie-breaker so pagination is deterministic when sort
+		// keys collide, matching the postgres/sqlite implementations.
+		if cmp == 0 {
+			cmp = strings.Compare(results[i].ID.String(), results[j].ID.String())
+		}
 		if asc {
 			return cmp < 0
 		}

--- a/internal/repository/memory/readmodel_test.go
+++ b/internal/repository/memory/readmodel_test.go
@@ -4074,3 +4074,115 @@ func TestReadModelStore_ListProofSummaries(t *testing.T) {
 		t.Errorf("len(results) = %d, want 3", len(results))
 	}
 }
+
+func TestReadModelStore_SaveAndGetRepository(t *testing.T) {
+	store := memory.NewReadModelStore()
+	ctx := context.Background()
+
+	repo := &repository.RepositoryReadModel{
+		ID:         uuid.New(),
+		Name:       "National Archives",
+		Address:    &domain.Address{City: "Washington", State: "DC", Phone: "+1-866-272-6272"},
+		Notes:      "Primary federal records repository",
+		GedcomXref: "@R1@",
+		Version:    1,
+		UpdatedAt:  time.Now(),
+	}
+
+	if err := store.SaveRepository(ctx, repo); err != nil {
+		t.Fatalf("SaveRepository() failed: %v", err)
+	}
+
+	retrieved, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("Repository not found")
+	}
+	if retrieved.Name != "National Archives" {
+		t.Errorf("Name = %s, want National Archives", retrieved.Name)
+	}
+	if retrieved.Notes != "Primary federal records repository" {
+		t.Errorf("Notes = %s, want Primary federal records repository", retrieved.Notes)
+	}
+	if retrieved.GedcomXref != "@R1@" {
+		t.Errorf("GedcomXref = %s, want @R1@", retrieved.GedcomXref)
+	}
+	if retrieved.Address == nil || retrieved.Address.City != "Washington" {
+		t.Errorf("Address not round-tripped: %+v", retrieved.Address)
+	}
+
+	// Test delete
+	if err := store.DeleteRepository(ctx, repo.ID); err != nil {
+		t.Fatalf("DeleteRepository() failed: %v", err)
+	}
+	deleted, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() after delete failed: %v", err)
+	}
+	if deleted != nil {
+		t.Error("Repository should be deleted")
+	}
+}
+
+func TestReadModelStore_ListRepositories(t *testing.T) {
+	store := memory.NewReadModelStore()
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		repo := &repository.RepositoryReadModel{
+			ID:        uuid.New(),
+			Name:      fmt.Sprintf("Repo %d", i),
+			Version:   1,
+			UpdatedAt: time.Now().Add(time.Duration(i) * time.Second),
+		}
+		if err := store.SaveRepository(ctx, repo); err != nil {
+			t.Fatalf("SaveRepository() failed: %v", err)
+		}
+	}
+
+	results, total, err := store.ListRepositories(ctx, repository.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRepositories() failed: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(results) != 3 {
+		t.Errorf("len(results) = %d, want 3", len(results))
+	}
+
+	// Limit truncation: total still reflects all rows, page is capped.
+	results, total, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ListRepositories(limit=2) failed: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(results) != 2 {
+		t.Errorf("len(results) = %d, want 2", len(results))
+	}
+
+	// Offset past the end returns an empty page.
+	results, total, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Offset: 5})
+	if err != nil {
+		t.Fatalf("ListRepositories(offset=5) failed: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(results) != 0 {
+		t.Errorf("len(results) = %d, want 0", len(results))
+	}
+
+	// Ascending order is honored.
+	results, _, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Order: "asc"})
+	if err != nil {
+		t.Fatalf("ListRepositories(asc) failed: %v", err)
+	}
+	if len(results) == 3 && results[0].Name != "Repo 0" {
+		t.Errorf("ascending order: first = %s, want Repo 0", results[0].Name)
+	}
+}

--- a/internal/repository/memory/readmodel_test.go
+++ b/internal/repository/memory/readmodel_test.go
@@ -4177,12 +4177,22 @@ func TestReadModelStore_ListRepositories(t *testing.T) {
 		t.Errorf("len(results) = %d, want 0", len(results))
 	}
 
-	// Ascending order is honored.
-	results, _, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Order: "asc"})
+	// Default sort is updated_at descending (matches postgres/sqlite), so the
+	// most recently updated repository (Repo 2) comes first.
+	results, _, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 10})
 	if err != nil {
-		t.Fatalf("ListRepositories(asc) failed: %v", err)
+		t.Fatalf("ListRepositories(default) failed: %v", err)
+	}
+	if len(results) == 3 && results[0].Name != "Repo 2" {
+		t.Errorf("default order: first = %s, want Repo 2 (newest updated_at)", results[0].Name)
+	}
+
+	// Explicit name sort orders alphabetically regardless of updated_at.
+	results, _, err = store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Sort: "name", Order: "asc"})
+	if err != nil {
+		t.Fatalf("ListRepositories(sort=name) failed: %v", err)
 	}
 	if len(results) == 3 && results[0].Name != "Repo 0" {
-		t.Errorf("ascending order: first = %s, want Repo 0", results[0].Name)
+		t.Errorf("name sort ascending: first = %s, want Repo 0", results[0].Name)
 	}
 }

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -267,6 +267,19 @@ func (s *ReadModelStore) createTables() error {
 
 		CREATE INDEX IF NOT EXISTS idx_submitters_gedcom_xref ON submitters(gedcom_xref);
 
+		-- Repositories table (GEDCOM REPO records for source document locations)
+		CREATE TABLE IF NOT EXISTS repositories (
+			id UUID PRIMARY KEY,
+			name VARCHAR(200) NOT NULL,
+			address JSONB,
+			notes TEXT,
+			gedcom_xref VARCHAR(50),
+			version BIGINT NOT NULL DEFAULT 1,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_repositories_gedcom_xref ON repositories(gedcom_xref);
+
 		-- Associations table (GEDCOM ASSO records for non-family relationships)
 		CREATE TABLE IF NOT EXISTS associations (
 			id UUID PRIMARY KEY,
@@ -3280,6 +3293,151 @@ func (s *ReadModelStore) DeleteSubmitter(ctx context.Context, id uuid.UUID) erro
 	_, err := s.db.ExecContext(ctx, "DELETE FROM submitters WHERE id = $1", id)
 	if err != nil {
 		return fmt.Errorf("delete submitter: %w", err)
+	}
+	return nil
+}
+
+// GetRepository retrieves a repository by ID.
+func (s *ReadModelStore) GetRepository(ctx context.Context, id uuid.UUID) (*repository.RepositoryReadModel, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, address, notes, gedcom_xref, version, updated_at
+		FROM repositories WHERE id = $1
+	`, id)
+
+	var repo repository.RepositoryReadModel
+	var addressJSON []byte
+	var notes, gedcomXref sql.NullString
+	err := row.Scan(
+		&repo.ID,
+		&repo.Name,
+		&addressJSON,
+		&notes,
+		&gedcomXref,
+		&repo.Version,
+		&repo.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan repository: %w", err)
+	}
+	if notes.Valid {
+		repo.Notes = notes.String
+	}
+	if gedcomXref.Valid {
+		repo.GedcomXref = gedcomXref.String
+	}
+	if len(addressJSON) > 0 {
+		var addr domain.Address
+		if err := json.Unmarshal(addressJSON, &addr); err == nil {
+			repo.Address = &addr
+		}
+	}
+	return &repo, nil
+}
+
+// ListRepositories returns a paginated list of repositories.
+func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.ListOptions) ([]repository.RepositoryReadModel, int, error) {
+	// Count total
+	var total int
+	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM repositories").Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count repositories: %w", err)
+	}
+
+	// Build order clause
+	orderColumn := "updated_at"
+	if opts.Sort == "name" {
+		orderColumn = "name"
+	}
+	orderDir := "DESC"
+	if opts.Order == "asc" {
+		orderDir = "ASC"
+	}
+
+	// #nosec G201 -- orderColumn and orderDir are validated via switch/if above, not user input
+	query := fmt.Sprintf(`
+		SELECT id, name, address, notes, gedcom_xref, version, updated_at
+		FROM repositories
+		ORDER BY %s %s
+		LIMIT $1 OFFSET $2
+	`, orderColumn, orderDir)
+
+	rows, err := s.db.QueryContext(ctx, query, opts.Limit, opts.Offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query repositories: %w", err)
+	}
+	defer rows.Close()
+
+	var repositories []repository.RepositoryReadModel
+	for rows.Next() {
+		var repo repository.RepositoryReadModel
+		var addressJSON []byte
+		var notes, gedcomXref sql.NullString
+		if err := rows.Scan(
+			&repo.ID,
+			&repo.Name,
+			&addressJSON,
+			&notes,
+			&gedcomXref,
+			&repo.Version,
+			&repo.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan repository: %w", err)
+		}
+		if notes.Valid {
+			repo.Notes = notes.String
+		}
+		if gedcomXref.Valid {
+			repo.GedcomXref = gedcomXref.String
+		}
+		if len(addressJSON) > 0 {
+			var addr domain.Address
+			if err := json.Unmarshal(addressJSON, &addr); err == nil {
+				repo.Address = &addr
+			}
+		}
+		repositories = append(repositories, repo)
+	}
+
+	return repositories, total, rows.Err()
+}
+
+// SaveRepository saves or updates a repository.
+func (s *ReadModelStore) SaveRepository(ctx context.Context, repo *repository.RepositoryReadModel) error {
+	var addressJSON []byte
+	var err error
+
+	if repo.Address != nil {
+		addressJSON, err = json.Marshal(repo.Address)
+		if err != nil {
+			return fmt.Errorf("marshal address: %w", err)
+		}
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO repositories (id, name, address, notes, gedcom_xref, version, updated_at)
+		VALUES ($1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), $6, $7)
+		ON CONFLICT (id) DO UPDATE SET
+			name = EXCLUDED.name,
+			address = EXCLUDED.address,
+			notes = EXCLUDED.notes,
+			gedcom_xref = EXCLUDED.gedcom_xref,
+			version = EXCLUDED.version,
+			updated_at = EXCLUDED.updated_at
+	`, repo.ID, repo.Name, addressJSON, repo.Notes, repo.GedcomXref, repo.Version, repo.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("save repository: %w", err)
+	}
+	return nil
+}
+
+// DeleteRepository deletes a repository by ID.
+func (s *ReadModelStore) DeleteRepository(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.ExecContext(ctx, "DELETE FROM repositories WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("delete repository: %w", err)
 	}
 	return nil
 }

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -3357,12 +3357,13 @@ func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.L
 	}
 
 	// #nosec G201 -- orderColumn and orderDir are validated via switch/if above, not user input
+	// id is a stable tie-breaker so LIMIT/OFFSET pagination is deterministic when sort keys collide.
 	query := fmt.Sprintf(`
 		SELECT id, name, address, notes, gedcom_xref, version, updated_at
 		FROM repositories
-		ORDER BY %s %s
+		ORDER BY %s %s, id %s
 		LIMIT $1 OFFSET $2
-	`, orderColumn, orderDir)
+	`, orderColumn, orderDir, orderDir)
 
 	rows, err := s.db.QueryContext(ctx, query, opts.Limit, opts.Offset)
 	if err != nil {

--- a/internal/repository/postgres/readmodel_test.go
+++ b/internal/repository/postgres/readmodel_test.go
@@ -1068,3 +1068,113 @@ func TestSearchPersons_BackwardCompatible(t *testing.T) {
 		}
 	})
 }
+
+func TestReadModelStore_RepositoryCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	store, cleanup := setupReadModelStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Microsecond)
+
+	repo := &repository.RepositoryReadModel{
+		ID:         uuid.New(),
+		Name:       "National Archives",
+		Address:    &domain.Address{City: "Washington", State: "DC", Phone: "+1-866-272-6272"},
+		Notes:      "Primary federal records repository",
+		GedcomXref: "@R1@",
+		Version:    1,
+		UpdatedAt:  now,
+	}
+
+	if err := store.SaveRepository(ctx, repo); err != nil {
+		t.Fatalf("save repository: %v", err)
+	}
+
+	retrieved, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("get repository: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("repository not found")
+	}
+	if retrieved.Name != "National Archives" {
+		t.Errorf("expected Name National Archives, got %s", retrieved.Name)
+	}
+	if retrieved.Notes != "Primary federal records repository" {
+		t.Errorf("expected Notes set, got %s", retrieved.Notes)
+	}
+	if retrieved.GedcomXref != "@R1@" {
+		t.Errorf("expected GedcomXref @R1@, got %s", retrieved.GedcomXref)
+	}
+	if retrieved.Address == nil || retrieved.Address.City != "Washington" || retrieved.Address.Phone != "+1-866-272-6272" {
+		t.Errorf("address not round-tripped: %+v", retrieved.Address)
+	}
+
+	// Update
+	repo.Name = "US National Archives"
+	repo.Version = 2
+	if err := store.SaveRepository(ctx, repo); err != nil {
+		t.Fatalf("update repository: %v", err)
+	}
+	retrieved, err = store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("get updated repository: %v", err)
+	}
+	if retrieved.Name != "US National Archives" || retrieved.Version != 2 {
+		t.Errorf("update not persisted: name=%s version=%d", retrieved.Name, retrieved.Version)
+	}
+
+	// Delete
+	if err := store.DeleteRepository(ctx, repo.ID); err != nil {
+		t.Fatalf("delete repository: %v", err)
+	}
+	retrieved, err = store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("get deleted repository: %v", err)
+	}
+	if retrieved != nil {
+		t.Error("repository should have been deleted")
+	}
+}
+
+func TestReadModelStore_ListRepositories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	store, cleanup := setupReadModelStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	names := []string{"Alpha Archive", "Beta Library", "Gamma Collection"}
+	for i, name := range names {
+		repo := &repository.RepositoryReadModel{
+			ID:        uuid.New(),
+			Name:      name,
+			Version:   1,
+			UpdatedAt: time.Now().Add(time.Duration(i) * time.Second),
+		}
+		if err := store.SaveRepository(ctx, repo); err != nil {
+			t.Fatalf("save repository: %v", err)
+		}
+	}
+
+	results, total, err := store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Sort: "name", Order: "asc"})
+	if err != nil {
+		t.Fatalf("list repositories: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	if results[0].Name != "Alpha Archive" {
+		t.Errorf("first result = %s, want Alpha Archive (asc by name)", results[0].Name)
+	}
+}

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -1091,8 +1091,22 @@ func (p *Projector) projectRepositoryUpdated(ctx context.Context, e domain.Repos
 				repo.Name = v
 			}
 		case "address":
-			if v, ok := value.(*domain.Address); ok {
-				repo.Address = v
+			// On replay the event is decoded from JSON, so the address arrives
+			// as map[string]any rather than *domain.Address. Handle both, plus
+			// nil to clear. Mirrors projectLifeEventUpdated.
+			if value == nil {
+				repo.Address = nil
+			} else {
+				switch v := value.(type) {
+				case *domain.Address:
+					repo.Address = v
+				case map[string]any:
+					b, _ := json.Marshal(v)
+					var addr domain.Address
+					if json.Unmarshal(b, &addr) == nil {
+						repo.Address = &addr
+					}
+				}
 			}
 		case "notes":
 			if v, ok := value.(string); ok {

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -1043,19 +1043,76 @@ func (p *Projector) projectAttributeUpdated(ctx context.Context, e domain.Attrib
 	return p.readStore.SaveAttribute(ctx, attribute)
 }
 
-// projectRepositoryCreated is a no-op until RepositoryReadModel is implemented (#239).
-func (p *Projector) projectRepositoryCreated(_ context.Context, _ domain.RepositoryCreated, _ int64) error {
-	return nil
+func (p *Projector) projectRepositoryCreated(ctx context.Context, e domain.RepositoryCreated, version int64) error {
+	// Build a domain.Repository to reuse GetAddress() for mapping the flat
+	// address fields into a structured *domain.Address.
+	r := &domain.Repository{
+		ID:            e.RepositoryID,
+		Name:          e.Name,
+		StreetAddress: e.StreetAddress,
+		City:          e.City,
+		State:         e.State,
+		PostalCode:    e.PostalCode,
+		Country:       e.Country,
+		Phone:         e.Phone,
+		Email:         e.Email,
+		Website:       e.Website,
+		Notes:         e.Notes,
+		GedcomXref:    e.GedcomXref,
+	}
+
+	repo := &RepositoryReadModel{
+		ID:         e.RepositoryID,
+		Name:       e.Name,
+		Address:    r.GetAddress(),
+		Notes:      e.Notes,
+		GedcomXref: e.GedcomXref,
+		Version:    version,
+		UpdatedAt:  e.OccurredAt(),
+	}
+
+	return p.readStore.SaveRepository(ctx, repo)
 }
 
-// projectRepositoryUpdated is a no-op until RepositoryReadModel is implemented (#239).
-func (p *Projector) projectRepositoryUpdated(_ context.Context, _ domain.RepositoryUpdated, _ int64) error {
-	return nil
+func (p *Projector) projectRepositoryUpdated(ctx context.Context, e domain.RepositoryUpdated, version int64) error {
+	repo, err := p.readStore.GetRepository(ctx, e.RepositoryID)
+	if err != nil {
+		return err
+	}
+	if repo == nil {
+		return nil // Repository doesn't exist in read model, skip
+	}
+
+	// Apply changes
+	for key, value := range e.Changes {
+		switch key {
+		case "name":
+			if v, ok := value.(string); ok {
+				repo.Name = v
+			}
+		case "address":
+			if v, ok := value.(*domain.Address); ok {
+				repo.Address = v
+			}
+		case "notes":
+			if v, ok := value.(string); ok {
+				repo.Notes = v
+			}
+		case "gedcom_xref":
+			if v, ok := value.(string); ok {
+				repo.GedcomXref = v
+			}
+		}
+	}
+
+	repo.Version = version
+	repo.UpdatedAt = e.OccurredAt()
+
+	return p.readStore.SaveRepository(ctx, repo)
 }
 
-// projectRepositoryDeleted is a no-op until RepositoryReadModel is implemented (#239).
-func (p *Projector) projectRepositoryDeleted(_ context.Context, _ domain.RepositoryDeleted) error {
-	return nil
+func (p *Projector) projectRepositoryDeleted(ctx context.Context, e domain.RepositoryDeleted) error {
+	return p.readStore.DeleteRepository(ctx, e.RepositoryID)
 }
 
 func (p *Projector) projectNameAdded(ctx context.Context, e domain.NameAdded, version int64) error {

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -4299,3 +4299,138 @@ func TestProjector_ProofSummaryDeleted(t *testing.T) {
 		t.Error("ProofSummary should be deleted")
 	}
 }
+
+func TestProjector_RepositoryCreated(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	repo := domain.NewRepository("National Archives")
+	repo.StreetAddress = "700 Pennsylvania Ave NW"
+	repo.City = "Washington"
+	repo.State = "DC"
+	repo.PostalCode = "20408"
+	repo.Country = "USA"
+	repo.Phone = "+1-866-272-6272"
+	repo.Email = "archives@example.gov"
+	repo.Website = "https://www.archives.gov"
+	repo.Notes = "Primary federal records repository"
+	repo.GedcomXref = "@R1@"
+
+	createEvent := domain.NewRepositoryCreated(repo)
+	if err := projector.Project(ctx, createEvent, 1); err != nil {
+		t.Fatalf("Project create failed: %v", err)
+	}
+
+	rm, err := readStore.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if rm == nil {
+		t.Fatal("Repository should exist after create")
+	}
+	if rm.Name != "National Archives" {
+		t.Errorf("Name = %s, want National Archives", rm.Name)
+	}
+	if rm.Notes != "Primary federal records repository" {
+		t.Errorf("Notes = %s, want Primary federal records repository", rm.Notes)
+	}
+	if rm.GedcomXref != "@R1@" {
+		t.Errorf("GedcomXref = %s, want @R1@", rm.GedcomXref)
+	}
+	if rm.Version != 1 {
+		t.Errorf("Version = %d, want 1", rm.Version)
+	}
+	if rm.Address == nil {
+		t.Fatal("Address should be populated from flat fields")
+	}
+	if rm.Address.City != "Washington" {
+		t.Errorf("Address.City = %s, want Washington", rm.Address.City)
+	}
+	if rm.Address.Phone != "+1-866-272-6272" {
+		t.Errorf("Address.Phone = %s, want +1-866-272-6272", rm.Address.Phone)
+	}
+}
+
+func TestProjector_RepositoryUpdated(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	repo := domain.NewRepository("Old Name")
+	createEvent := domain.NewRepositoryCreated(repo)
+	if err := projector.Project(ctx, createEvent, 1); err != nil {
+		t.Fatalf("Project create failed: %v", err)
+	}
+
+	newAddr := &domain.Address{City: "Boston", State: "MA"}
+	updateEvent := domain.NewRepositoryUpdated(repo.ID, map[string]any{
+		"name":        "New Name",
+		"address":     newAddr,
+		"notes":       "Updated notes",
+		"gedcom_xref": "@R9@",
+	})
+	if err := projector.Project(ctx, updateEvent, 2); err != nil {
+		t.Fatalf("Project update failed: %v", err)
+	}
+
+	rm, err := readStore.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if rm == nil {
+		t.Fatal("Repository should exist after update")
+	}
+	if rm.Name != "New Name" {
+		t.Errorf("Name = %s, want New Name", rm.Name)
+	}
+	if rm.Notes != "Updated notes" {
+		t.Errorf("Notes = %s, want Updated notes", rm.Notes)
+	}
+	if rm.GedcomXref != "@R9@" {
+		t.Errorf("GedcomXref = %s, want @R9@", rm.GedcomXref)
+	}
+	if rm.Address == nil || rm.Address.City != "Boston" {
+		t.Errorf("Address not updated: %+v", rm.Address)
+	}
+	if rm.Version != 2 {
+		t.Errorf("Version = %d, want 2", rm.Version)
+	}
+}
+
+func TestProjector_RepositoryUpdated_NonExistent(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	// Updating a repository absent from the read model is a no-op (no error).
+	updateEvent := domain.NewRepositoryUpdated(uuid.New(), map[string]any{"name": "Ghost"})
+	if err := projector.Project(ctx, updateEvent, 2); err != nil {
+		t.Fatalf("Project update of missing repository should be a no-op, got: %v", err)
+	}
+}
+
+func TestProjector_RepositoryDeleted(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	repo := domain.NewRepository("To Delete")
+	createEvent := domain.NewRepositoryCreated(repo)
+	if err := projector.Project(ctx, createEvent, 1); err != nil {
+		t.Fatalf("Project create failed: %v", err)
+	}
+
+	deleteEvent := domain.NewRepositoryDeleted(repo.ID, "test")
+	if err := projector.Project(ctx, deleteEvent, 2); err != nil {
+		t.Fatalf("Project delete failed: %v", err)
+	}
+
+	rm, err := readStore.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if rm != nil {
+		t.Error("Repository should be deleted")
+	}
+}

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -4398,6 +4398,39 @@ func TestProjector_RepositoryUpdated(t *testing.T) {
 	}
 }
 
+// TestProjector_RepositoryUpdated_ReplayAddress simulates reprojection from the
+// event store, where Changes is decoded from JSON and "address" arrives as
+// map[string]any rather than *domain.Address. The projection must still apply it.
+func TestProjector_RepositoryUpdated_ReplayAddress(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	repo := domain.NewRepository("Old Name")
+	if err := projector.Project(ctx, domain.NewRepositoryCreated(repo), 1); err != nil {
+		t.Fatalf("Project create failed: %v", err)
+	}
+
+	// As it would look after JSON round-trip through the event store.
+	updateEvent := domain.NewRepositoryUpdated(repo.ID, map[string]any{
+		"address": map[string]any{"city": "Boston", "state": "MA"},
+	})
+	if err := projector.Project(ctx, updateEvent, 2); err != nil {
+		t.Fatalf("Project update failed: %v", err)
+	}
+
+	rm, err := readStore.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if rm == nil || rm.Address == nil {
+		t.Fatalf("Address dropped on replay: %+v", rm)
+	}
+	if rm.Address.City != "Boston" || rm.Address.State != "MA" {
+		t.Errorf("Address = %+v, want City=Boston State=MA", rm.Address)
+	}
+}
+
 func TestProjector_RepositoryUpdated_NonExistent(t *testing.T) {
 	readStore := memory.NewReadModelStore()
 	projector := repository.NewProjector(readStore)

--- a/internal/repository/readmodel.go
+++ b/internal/repository/readmodel.go
@@ -203,6 +203,18 @@ type SubmitterReadModel struct {
 	UpdatedAt  time.Time       `json:"updated_at"`
 }
 
+// RepositoryReadModel represents a GEDCOM REPO (Repository) record in the read model.
+// Repositories track physical or digital locations where source documents are stored.
+type RepositoryReadModel struct {
+	ID         uuid.UUID       `json:"id"`
+	Name       string          `json:"name"`                  // NAME - Repository name
+	Address    *domain.Address `json:"address,omitempty"`     // ADDR - Structured address (incl. phone/email/website)
+	Notes      string          `json:"notes,omitempty"`       // NOTE - Inline note text
+	GedcomXref string          `json:"gedcom_xref,omitempty"` // GEDCOM cross-reference ID for round-trip
+	Version    int64           `json:"version"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
 // AssociationReadModel represents a GEDCOM ASSO (Association) record in the read model.
 // Associations capture non-family relationships like godparents, witnesses, mentors, etc.
 type AssociationReadModel struct {
@@ -380,6 +392,12 @@ type ReadModelStore interface {
 	ListSubmitters(ctx context.Context, opts ListOptions) ([]SubmitterReadModel, int, error)
 	SaveSubmitter(ctx context.Context, submitter *SubmitterReadModel) error
 	DeleteSubmitter(ctx context.Context, id uuid.UUID) error
+
+	// Repository operations
+	GetRepository(ctx context.Context, id uuid.UUID) (*RepositoryReadModel, error)
+	ListRepositories(ctx context.Context, opts ListOptions) ([]RepositoryReadModel, int, error)
+	SaveRepository(ctx context.Context, repository *RepositoryReadModel) error
+	DeleteRepository(ctx context.Context, id uuid.UUID) error
 
 	// Association operations
 	GetAssociation(ctx context.Context, id uuid.UUID) (*AssociationReadModel, error)

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -3844,12 +3844,13 @@ func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.L
 	}
 
 	// #nosec G201 -- orderColumn and orderDir are validated via switch/if above, not user input
+	// id is a stable tie-breaker so LIMIT/OFFSET pagination is deterministic when sort keys collide.
 	query := fmt.Sprintf(`
 		SELECT id, name, address, notes, gedcom_xref, version, updated_at
 		FROM repositories
-		ORDER BY %s %s
+		ORDER BY %s %s, id %s
 		LIMIT ? OFFSET ?
-	`, orderColumn, orderDir)
+	`, orderColumn, orderDir, orderDir)
 
 	rows, err := s.db.QueryContext(ctx, query, opts.Limit, opts.Offset)
 	if err != nil {

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -237,6 +237,19 @@ func (s *ReadModelStore) createTables() error {
 
 		CREATE INDEX IF NOT EXISTS idx_submitters_gedcom_xref ON submitters(gedcom_xref);
 
+		-- Repositories table (GEDCOM REPO records for source document locations)
+		CREATE TABLE IF NOT EXISTS repositories (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			address TEXT,
+			notes TEXT,
+			gedcom_xref TEXT,
+			version INTEGER NOT NULL DEFAULT 1,
+			updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_repositories_gedcom_xref ON repositories(gedcom_xref);
+
 		-- Associations table (GEDCOM ASSO records for non-family relationships)
 		CREATE TABLE IF NOT EXISTS associations (
 			id TEXT PRIMARY KEY,
@@ -3758,6 +3771,178 @@ func (s *ReadModelStore) DeleteSubmitter(ctx context.Context, id uuid.UUID) erro
 	_, err := s.db.ExecContext(ctx, "DELETE FROM submitters WHERE id = ?", id.String())
 	if err != nil {
 		return fmt.Errorf("delete submitter: %w", err)
+	}
+	return nil
+}
+
+// GetRepository retrieves a repository by ID.
+func (s *ReadModelStore) GetRepository(ctx context.Context, id uuid.UUID) (*repository.RepositoryReadModel, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, address, notes, gedcom_xref, version, updated_at
+		FROM repositories WHERE id = ?
+	`, id.String())
+
+	var repo repository.RepositoryReadModel
+	var idStr string
+	var addressJSON []byte
+	var notes, gedcomXref sql.NullString
+	var updatedAtStr string
+
+	err := row.Scan(
+		&idStr,
+		&repo.Name,
+		&addressJSON,
+		&notes,
+		&gedcomXref,
+		&repo.Version,
+		&updatedAtStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan repository: %w", err)
+	}
+
+	repo.ID, _ = uuid.Parse(idStr)
+	if notes.Valid {
+		repo.Notes = notes.String
+	}
+	if gedcomXref.Valid {
+		repo.GedcomXref = gedcomXref.String
+	}
+	if len(addressJSON) > 0 {
+		var addr domain.Address
+		if err := json.Unmarshal(addressJSON, &addr); err == nil {
+			repo.Address = &addr
+		}
+	}
+	if t, err := parseTimestamp(updatedAtStr); err == nil {
+		repo.UpdatedAt = t
+	}
+
+	return &repo, nil
+}
+
+// ListRepositories returns a paginated list of repositories.
+func (s *ReadModelStore) ListRepositories(ctx context.Context, opts repository.ListOptions) ([]repository.RepositoryReadModel, int, error) {
+	// Count total
+	var total int
+	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM repositories").Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count repositories: %w", err)
+	}
+
+	// Build order clause
+	orderColumn := "updated_at"
+	if opts.Sort == "name" {
+		orderColumn = "name"
+	}
+	orderDir := "DESC"
+	if opts.Order == "asc" {
+		orderDir = "ASC"
+	}
+
+	// #nosec G201 -- orderColumn and orderDir are validated via switch/if above, not user input
+	query := fmt.Sprintf(`
+		SELECT id, name, address, notes, gedcom_xref, version, updated_at
+		FROM repositories
+		ORDER BY %s %s
+		LIMIT ? OFFSET ?
+	`, orderColumn, orderDir)
+
+	rows, err := s.db.QueryContext(ctx, query, opts.Limit, opts.Offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query repositories: %w", err)
+	}
+	defer rows.Close()
+
+	var repositories []repository.RepositoryReadModel
+	for rows.Next() {
+		var repo repository.RepositoryReadModel
+		var idStr string
+		var addressJSON []byte
+		var notes, gedcomXref sql.NullString
+		var updatedAtStr string
+
+		if err := rows.Scan(
+			&idStr,
+			&repo.Name,
+			&addressJSON,
+			&notes,
+			&gedcomXref,
+			&repo.Version,
+			&updatedAtStr,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan repository: %w", err)
+		}
+
+		repo.ID, _ = uuid.Parse(idStr)
+		if notes.Valid {
+			repo.Notes = notes.String
+		}
+		if gedcomXref.Valid {
+			repo.GedcomXref = gedcomXref.String
+		}
+		if len(addressJSON) > 0 {
+			var addr domain.Address
+			if err := json.Unmarshal(addressJSON, &addr); err == nil {
+				repo.Address = &addr
+			}
+		}
+		if t, err := parseTimestamp(updatedAtStr); err == nil {
+			repo.UpdatedAt = t
+		}
+		repositories = append(repositories, repo)
+	}
+
+	return repositories, total, rows.Err()
+}
+
+// SaveRepository saves or updates a repository.
+func (s *ReadModelStore) SaveRepository(ctx context.Context, repo *repository.RepositoryReadModel) error {
+	var addressJSON []byte
+	var err error
+
+	if repo.Address != nil {
+		addressJSON, err = json.Marshal(repo.Address)
+		if err != nil {
+			return fmt.Errorf("marshal address: %w", err)
+		}
+	}
+
+	var notes any
+	if repo.Notes != "" {
+		notes = repo.Notes
+	}
+	var gedcomXref any
+	if repo.GedcomXref != "" {
+		gedcomXref = repo.GedcomXref
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO repositories (id, name, address, notes, gedcom_xref, version, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			name = excluded.name,
+			address = excluded.address,
+			notes = excluded.notes,
+			gedcom_xref = excluded.gedcom_xref,
+			version = excluded.version,
+			updated_at = excluded.updated_at
+	`, repo.ID.String(), repo.Name, addressJSON, notes, gedcomXref,
+		repo.Version, repo.UpdatedAt.Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("save repository: %w", err)
+	}
+	return nil
+}
+
+// DeleteRepository deletes a repository by ID.
+func (s *ReadModelStore) DeleteRepository(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.ExecContext(ctx, "DELETE FROM repositories WHERE id = ?", id.String())
+	if err != nil {
+		return fmt.Errorf("delete repository: %w", err)
 	}
 	return nil
 }

--- a/internal/repository/sqlite/readmodel_test.go
+++ b/internal/repository/sqlite/readmodel_test.go
@@ -1830,3 +1830,102 @@ func TestSearchPersons_BackwardCompatible(t *testing.T) {
 		}
 	})
 }
+
+func TestReadModelStore_RepositoryCRUD(t *testing.T) {
+	store, cleanup := setupTestReadModelDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repo := &repository.RepositoryReadModel{
+		ID:         uuid.New(),
+		Name:       "National Archives",
+		Address:    &domain.Address{City: "Washington", State: "DC", Phone: "+1-866-272-6272"},
+		Notes:      "Primary federal records repository",
+		GedcomXref: "@R1@",
+		Version:    1,
+		UpdatedAt:  time.Now(),
+	}
+
+	if err := store.SaveRepository(ctx, repo); err != nil {
+		t.Fatalf("SaveRepository() failed: %v", err)
+	}
+
+	retrieved, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("Repository not found")
+	}
+	if retrieved.Name != "National Archives" {
+		t.Errorf("Name = %s, want National Archives", retrieved.Name)
+	}
+	if retrieved.Notes != "Primary federal records repository" {
+		t.Errorf("Notes = %s, want Primary federal records repository", retrieved.Notes)
+	}
+	if retrieved.GedcomXref != "@R1@" {
+		t.Errorf("GedcomXref = %s, want @R1@", retrieved.GedcomXref)
+	}
+	if retrieved.Address == nil || retrieved.Address.City != "Washington" || retrieved.Address.Phone != "+1-866-272-6272" {
+		t.Errorf("Address not round-tripped: %+v", retrieved.Address)
+	}
+
+	// Update via Save (upsert)
+	retrieved.Name = "US National Archives"
+	retrieved.Version = 2
+	if err := store.SaveRepository(ctx, retrieved); err != nil {
+		t.Fatalf("SaveRepository() update failed: %v", err)
+	}
+	updated, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() after update failed: %v", err)
+	}
+	if updated.Name != "US National Archives" || updated.Version != 2 {
+		t.Errorf("update not persisted: name=%s version=%d", updated.Name, updated.Version)
+	}
+
+	// Delete
+	if err := store.DeleteRepository(ctx, repo.ID); err != nil {
+		t.Fatalf("DeleteRepository() failed: %v", err)
+	}
+	deleted, err := store.GetRepository(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepository() after delete failed: %v", err)
+	}
+	if deleted != nil {
+		t.Error("Repository should be deleted")
+	}
+}
+
+func TestReadModelStore_ListRepositories(t *testing.T) {
+	store, cleanup := setupTestReadModelDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	names := []string{"Alpha Archive", "Beta Library", "Gamma Collection"}
+	for i, name := range names {
+		repo := &repository.RepositoryReadModel{
+			ID:        uuid.New(),
+			Name:      name,
+			Version:   1,
+			UpdatedAt: time.Now().Add(time.Duration(i) * time.Second),
+		}
+		if err := store.SaveRepository(ctx, repo); err != nil {
+			t.Fatalf("SaveRepository() failed: %v", err)
+		}
+	}
+
+	results, total, err := store.ListRepositories(ctx, repository.ListOptions{Limit: 10, Sort: "name", Order: "asc"})
+	if err != nil {
+		t.Fatalf("ListRepositories() failed: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	if results[0].Name != "Alpha Archive" {
+		t.Errorf("first result = %s, want Alpha Archive (asc by name)", results[0].Name)
+	}
+}

--- a/web/src/lib/api/types.generated.ts
+++ b/web/src/lib/api/types.generated.ts
@@ -1620,6 +1620,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all repositories
+         * @description Returns paginated list of GEDCOM REPO (repository) records
+         */
+        get: operations["listRepositories"];
+        put?: never;
+        /** Create a new repository */
+        post: operations["createRepository"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repositories/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Repository UUID */
+                id: components["parameters"]["repositoryId"];
+            };
+            cookie?: never;
+        };
+        /** Get a repository by ID */
+        get: operations["getRepository"];
+        /** Update a repository */
+        put: operations["updateRepository"];
+        post?: never;
+        /** Delete a repository */
+        delete: operations["deleteRepository"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/associations": {
         parameters: {
             query?: never;
@@ -3559,6 +3602,55 @@ export interface components {
             limit?: number;
             offset?: number;
         };
+        /** @description A GEDCOM REPO (repository) record describing where source documents are stored */
+        Repository: {
+            /** Format: uuid */
+            id: string;
+            /** @description Repository's name */
+            name: string;
+            address?: components["schemas"]["Address"];
+            /** @description Free-form notes about the repository */
+            notes?: string;
+            /** @description GEDCOM cross-reference ID for round-trip support */
+            gedcom_xref?: string;
+            /**
+             * Format: int64
+             * @description Optimistic locking version
+             */
+            version: number;
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        RepositoryCreate: {
+            /** @description Repository's name */
+            name: string;
+            address?: components["schemas"]["Address"];
+            /** @description Free-form notes about the repository */
+            notes?: string;
+            /** @description Optional GEDCOM cross-reference ID for import */
+            gedcom_xref?: string;
+        };
+        RepositoryUpdate: {
+            /** @description Updated repository name */
+            name?: string;
+            address?: components["schemas"]["Address"];
+            /** @description Updated notes */
+            notes?: string;
+            /** @description Updated GEDCOM cross-reference ID */
+            gedcom_xref?: string;
+            /**
+             * Format: int64
+             * @description Current version for optimistic locking
+             */
+            version: number;
+        };
+        RepositoryList: {
+            repositories: components["schemas"]["Repository"][];
+            /** @description Total number of repositories */
+            total: number;
+            limit?: number;
+            offset?: number;
+        };
         Association: {
             /** Format: uuid */
             id: string;
@@ -4006,6 +4098,8 @@ export interface components {
         noteId: string;
         /** @description Submitter UUID */
         submitterId: string;
+        /** @description Repository UUID */
+        repositoryId: string;
         /** @description Association UUID */
         associationId: string;
         /** @description LDS Ordinance UUID */
@@ -6779,6 +6873,137 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Submitter deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+        };
+    };
+    listRepositories: {
+        parameters: {
+            query?: {
+                limit?: components["parameters"]["limitParam"];
+                offset?: components["parameters"]["offsetParam"];
+                sort?: "name" | "updated_at";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of repositories */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepositoryList"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+        };
+    };
+    createRepository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepositoryCreate"];
+            };
+        };
+        responses: {
+            /** @description Repository created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Repository"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+        };
+    };
+    getRepository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Repository UUID */
+                id: components["parameters"]["repositoryId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repository details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Repository"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateRepository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Repository UUID */
+                id: components["parameters"]["repositoryId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepositoryUpdate"];
+            };
+        };
+        responses: {
+            /** @description Repository updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Repository"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+        };
+    };
+    deleteRepository: {
+        parameters: {
+            query?: {
+                /** @description Entity version for optimistic locking */
+                version?: components["parameters"]["versionParam"];
+            };
+            header?: never;
+            path: {
+                /** @description Repository UUID */
+                id: components["parameters"]["repositoryId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repository deleted */
             204: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

Completes the Repository entity (GEDCOM `REPO` — archives, libraries, record repositories) across all 7 integration layers. Previously the domain type and events existed, but 6 of 7 layers were missing: GEDCOM import emitted `RepositoryCreated` events while the projection handlers were **no-ops**, silently dropping imported repositories from the read model — a data-loss path for anyone migrating from existing genealogy software.

Dependency #238 (event wiring into `DecodeEvent`/`Project`) was already closed; this builds on it.

## What changed (by layer)

- **Read model** — `RepositoryReadModel` + `Get/List/Save/DeleteRepository` on `ReadModelStore`, implemented in `memory`, `postgres`, and `sqlite` (invariant DB-001).
- **Projections** — three no-op handlers replaced with real Created/Updated/Deleted logic.
- **Commands** — `CreateRepository`, `UpdateRepository`, `DeleteRepository`.
- **Query** — `RepositoryService` with `GetRepository` / `ListRepositories`.
- **API** — `/repositories` (list, create) and `/repositories/{id}` (get, update, delete); regenerated Go server + TypeScript types via `make generate`; strict-server handlers, converter, service wiring, and handler tests.
- **GEDCOM export** — emits standalone `REPO` records and `SOUR.REPO` cross-references, preserving the inline name-only fallback for unlinked sources; round-trip test added.
- **Docs** — `INTEGRATION-MATRIX.md` Repository row → Complete.
- **Lint** — added a `.golangci.yml` exclusion for the unavoidable `repository.RepositoryReadModel` revive stutter (the genealogy "Repository" entity shares its name with the persistence `repository` package), mirroring the existing `api.APIError` exclusion.

## Verification

- `make lint` clean, `make test` green (Go + 240 frontend tests).
- `make check-coverage` passes: per-package ≥85%, total 79.3%.
- `make generate` is idempotent; generated Go + TS in sync.

## Scope notes / follow-ups

- Frontend UI is intentionally out of scope — tracked in **#524** (Repository management UI, milestone v0.11).
- GEDCOM export currently links source→repository by **name**: `SourceReadModel` has no `RepositoryID` and the source projection drops the `RepositoryID` carried by `SourceCreated`. Tracked in **#525** (milestone v0.11).

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full repository CRUD API with listing (pagination/sorting), client typings, and optimistic concurrency; exporter now includes repositories and progress reporting.

* **Documentation**
  * Marked Repository integration as complete in the integration matrix.

* **Tests**
  * Added extensive tests covering API handlers, commands, queries, projections, exporter, and persistence (memory/SQLite/Postgres).

* **Chores**
  * Adjusted linter configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->