### PR TITLE
Import progress reporting for GEDCOM imports

### DIFF
--- a/internal/api/import_progress.go
+++ b/internal/api/import_progress.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/cacack/my-family/internal/command"
+	"github.com/cacack/my-family/internal/gedcom"
+)
+
+// importProgressEvent is the payload for a Server-Sent Events "progress" event
+// emitted while a GEDCOM file is being parsed.
+type importProgressEvent struct {
+	BytesRead  int64 `json:"bytes_read"`
+	TotalBytes int64 `json:"total_bytes"` // -1 when unknown
+	// Percent is the completion percentage (0-100), or -1 when the total size is
+	// unknown. Provided for convenience so clients need not compute it.
+	Percent int `json:"percent"`
+}
+
+// importStreamResult is the payload for the terminal SSE "result" event,
+// mirroring the JSON shape returned by the standard /gedcom/import endpoint.
+type importStreamResult struct {
+	Success          bool            `json:"success"`
+	PersonsImported  int             `json:"persons_imported"`
+	FamiliesImported int             `json:"families_imported"`
+	Warnings         []importMessage `json:"warnings,omitempty"`
+	Errors           []importMessage `json:"errors,omitempty"`
+}
+
+type importMessage struct {
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+}
+
+// registerImportProgressRoutes wires the streaming GEDCOM import endpoint. It is
+// registered outside the generated handler because Server-Sent Events do not map
+// cleanly onto the OpenAPI-generated strict server.
+func (s *Server) registerImportProgressRoutes(api *echo.Group) {
+	api.POST("/gedcom/import/stream", s.importGedcomStream)
+}
+
+// importGedcomStream imports a GEDCOM file while streaming parse progress to the
+// client via Server-Sent Events (SSE). It emits zero or more "progress" events
+// followed by exactly one terminal event: "result" on success or "error" on
+// failure.
+//
+// The upload is buffered first so the total size is known up front, allowing the
+// progress events to report a meaningful percentage. This matches the existing
+// import behaviour, which already materialises the full document in memory.
+func (s *Server) importGedcomStream(c echo.Context) error {
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		return s.sseError(c, http.StatusBadRequest, "No file uploaded")
+	}
+
+	src, err := fileHeader.Open()
+	if err != nil {
+		return s.sseError(c, http.StatusBadRequest, "Failed to read uploaded file")
+	}
+	defer func() { _ = src.Close() }()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, src); err != nil {
+		return s.sseError(c, http.StatusBadRequest, "Failed to read uploaded file")
+	}
+	totalSize := int64(buf.Len())
+
+	// Set up the SSE response stream.
+	resp := c.Response()
+	resp.Header().Set(echo.HeaderContentType, "text/event-stream")
+	resp.Header().Set("Cache-Control", "no-cache")
+	resp.Header().Set("Connection", "keep-alive")
+	resp.Header().Set("X-Accel-Buffering", "no") // disable proxy buffering (e.g. nginx)
+	resp.WriteHeader(http.StatusOK)
+
+	flusher, canFlush := resp.Writer.(http.Flusher)
+
+	// Throttle progress events so we do not flood the client: emit at most once
+	// per whole-percent change (and always the first read).
+	lastPercent := -1
+	emitProgress := func(bytesRead, totalBytes int64) {
+		percent := -1
+		if totalBytes > 0 {
+			percent = int(bytesRead * 100 / totalBytes)
+		}
+		if percent == lastPercent {
+			return
+		}
+		lastPercent = percent
+		_ = s.writeSSE(c, "progress", importProgressEvent{
+			BytesRead:  bytesRead,
+			TotalBytes: totalBytes,
+			Percent:    percent,
+		})
+		if canFlush {
+			flusher.Flush()
+		}
+	}
+
+	result, err := s.commandHandler.ImportGedcom(c.Request().Context(), command.ImportGedcomInput{
+		Filename:   fileHeader.Filename,
+		FileSize:   totalSize,
+		Reader:     &buf,
+		OnProgress: gedcom.ImportProgressCallback(emitProgress),
+	})
+	if err != nil {
+		_ = s.writeSSE(c, "error", map[string]string{"message": err.Error()})
+		if canFlush {
+			flusher.Flush()
+		}
+		return nil
+	}
+
+	payload := importStreamResult{
+		Success:          true,
+		PersonsImported:  result.PersonsImported,
+		FamiliesImported: result.FamiliesImported,
+	}
+	for _, w := range result.Warnings {
+		payload.Warnings = append(payload.Warnings, importMessage{Message: w})
+	}
+	for _, e := range result.Errors {
+		payload.Errors = append(payload.Errors, importMessage{Message: e})
+	}
+
+	_ = s.writeSSE(c, "result", payload)
+	if canFlush {
+		flusher.Flush()
+	}
+	return nil
+}
+
+// writeSSE writes a single named Server-Sent Event with a JSON-encoded payload.
+func (s *Server) writeSSE(c echo.Context, event string, data any) error {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(c.Response().Writer, "event: %s\ndata: %s\n\n", event, encoded)
+	return err
+}
+
+// sseError writes a JSON error response for failures that occur before the SSE
+// stream has started (e.g. a missing upload).
+func (s *Server) sseError(c echo.Context, status int, message string) error {
+	return c.JSON(status, map[string]string{"code": "bad_request", "message": message})
+}

--- a/internal/api/import_progress_test.go
+++ b/internal/api/import_progress_test.go
@@ -1,0 +1,177 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/api"
+	"github.com/cacack/my-family/internal/config"
+	"github.com/cacack/my-family/internal/repository/memory"
+)
+
+func setupStreamTestServer(t *testing.T) *api.Server {
+	t.Helper()
+	cfg := &config.Config{Port: 8080, LogFormat: "text"}
+	eventStore := memory.NewEventStore()
+	snapshotStore := memory.NewSnapshotStore(eventStore)
+	readStore := memory.NewReadModelStore()
+	return api.NewServer(cfg, eventStore, readStore, snapshotStore, nil)
+}
+
+// sseEvent is one parsed Server-Sent Event.
+type sseEvent struct {
+	name string
+	data string
+}
+
+// parseSSE splits a Server-Sent Events response body into discrete events.
+func parseSSE(body string) []sseEvent {
+	var events []sseEvent
+	for _, block := range strings.Split(body, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		var ev sseEvent
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				ev.name = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				ev.data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func TestImportGedcomStream_Success(t *testing.T) {
+	server := setupStreamTestServer(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "test.ged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.WriteString(part, testGedcom)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/gedcom/import/stream", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Expected text/event-stream content type, got %q", ct)
+	}
+
+	events := parseSSE(rec.Body.String())
+	if len(events) == 0 {
+		t.Fatal("No SSE events received")
+	}
+
+	// The terminal event must be a "result" carrying the import counts.
+	last := events[len(events)-1]
+	if last.name != "result" {
+		t.Fatalf("Expected final event 'result', got %q (body: %s)", last.name, rec.Body.String())
+	}
+
+	var result struct {
+		Success          bool `json:"success"`
+		PersonsImported  int  `json:"persons_imported"`
+		FamiliesImported int  `json:"families_imported"`
+	}
+	if err := json.Unmarshal([]byte(last.data), &result); err != nil {
+		t.Fatalf("Failed to parse result event: %v", err)
+	}
+	if !result.Success {
+		t.Error("result.success should be true")
+	}
+	if result.PersonsImported != 3 {
+		t.Errorf("persons_imported = %d, want 3", result.PersonsImported)
+	}
+	if result.FamiliesImported != 1 {
+		t.Errorf("families_imported = %d, want 1", result.FamiliesImported)
+	}
+
+	// Any progress events that were emitted must carry sane percentages.
+	for _, ev := range events {
+		if ev.name != "progress" {
+			continue
+		}
+		var p struct {
+			BytesRead  int64 `json:"bytes_read"`
+			TotalBytes int64 `json:"total_bytes"`
+			Percent    int   `json:"percent"`
+		}
+		if err := json.Unmarshal([]byte(ev.data), &p); err != nil {
+			t.Fatalf("Failed to parse progress event: %v", err)
+		}
+		if p.Percent < 0 || p.Percent > 100 {
+			t.Errorf("progress percent out of range: %d", p.Percent)
+		}
+		if p.TotalBytes <= 0 {
+			t.Errorf("progress total_bytes should be known (>0), got %d", p.TotalBytes)
+		}
+	}
+}
+
+func TestImportGedcomStream_NoFile(t *testing.T) {
+	server := setupStreamTestServer(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/gedcom/import/stream", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestImportGedcomStream_ImportError(t *testing.T) {
+	server := setupStreamTestServer(t)
+
+	// An empty GEDCOM (header + trailer, no records) fails import validation. Once
+	// the SSE stream has begun (HTTP 200 + headers written), such failures are
+	// surfaced as a terminal "error" event rather than an HTTP error status.
+	emptyGedcom := "0 HEAD\n1 GEDC\n2 VERS 5.5\n1 CHAR UTF-8\n0 TRLR\n"
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, _ := writer.CreateFormFile("file", "empty.ged")
+	io.WriteString(part, emptyGedcom)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/gedcom/import/stream", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	server.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status 200 (errors reported in-stream), got %d: %s", rec.Code, rec.Body.String())
+	}
+	events := parseSSE(rec.Body.String())
+	if len(events) == 0 {
+		t.Fatal("Expected at least one SSE event")
+	}
+	last := events[len(events)-1]
+	if last.name != "error" {
+		t.Errorf("Expected terminal 'error' event for failed import, got %q (body: %s)", last.name, rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -186,6 +186,10 @@ func (s *Server) registerRoutes() {
 	// API documentation (outside generated routes)
 	s.registerDocsRoutes(api)
 
+	// Streaming GEDCOM import with Server-Sent Events progress (outside generated
+	// routes; SSE does not map onto the OpenAPI strict server).
+	s.registerImportProgressRoutes(api)
+
 	// Use generated strict handler registration for all API routes
 	// This provides compile-time type safety for all endpoints
 	strictServer := NewStrictServer(s)

--- a/internal/command/gedcom_commands.go
+++ b/internal/command/gedcom_commands.go
@@ -16,6 +16,12 @@ type ImportGedcomInput struct {
 	Filename string
 	FileSize int64
 	Reader   io.Reader
+
+	// OnProgress, when non-nil, is invoked periodically while the GEDCOM file is
+	// being parsed. bytesRead is the cumulative bytes read and totalBytes is the
+	// expected total (FileSize), or -1 when unknown. Used to surface real-time
+	// import progress to clients. When nil there is zero overhead.
+	OnProgress gedcom.ImportProgressCallback
 }
 
 // ImportGedcomResult contains the result of a GEDCOM import.
@@ -40,8 +46,11 @@ type ImportGedcomResult struct {
 func (h *Handler) ImportGedcom(ctx context.Context, input ImportGedcomInput) (*ImportGedcomResult, error) {
 	importer := gedcom.NewImporter()
 
-	// Parse the GEDCOM file
-	importResult, persons, families, sources, citations, repositories, events, attributes, notes, submitters, associations, ldsOrdinances, _, err := importer.Import(ctx, input.Reader)
+	// Parse the GEDCOM file, forwarding progress callbacks when requested.
+	importResult, persons, families, sources, citations, repositories, events, attributes, notes, submitters, associations, ldsOrdinances, _, err := importer.ImportWithOptions(ctx, input.Reader, gedcom.ImportOptions{
+		TotalSize:  input.FileSize,
+		OnProgress: input.OnProgress,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse GEDCOM file: %w", err)
 	}

--- a/internal/gedcom/importer.go
+++ b/internal/gedcom/importer.go
@@ -259,6 +259,25 @@ type LDSOrdinanceData struct {
 	Status   string                  // Status: COMPLETED, BIC, CHILD, EXCLUDED, etc.
 }
 
+// ImportProgressCallback reports parsing progress during a GEDCOM import.
+// bytesRead is the cumulative number of bytes read from the input so far.
+// totalBytes is the expected total size in bytes, or -1 when the size is unknown.
+type ImportProgressCallback func(bytesRead, totalBytes int64)
+
+// ImportOptions configures an import operation.
+type ImportOptions struct {
+	// TotalSize is the expected total size of the input in bytes. When greater
+	// than zero it allows OnProgress to report a meaningful percentage. Leave
+	// as zero when the size is unknown.
+	TotalSize int64
+
+	// OnProgress, when non-nil, is invoked periodically during parsing with the
+	// cumulative bytes read and the total size (or -1 when unknown). The callback
+	// must be cheap and non-blocking; parsing happens on the calling goroutine.
+	// When nil there is zero progress-reporting overhead.
+	OnProgress ImportProgressCallback
+}
+
 // Importer handles GEDCOM file parsing and conversion to domain events.
 type Importer struct{}
 
@@ -269,6 +288,13 @@ func NewImporter() *Importer {
 
 // Import parses a GEDCOM file and returns structured data for import.
 func (imp *Importer) Import(ctx context.Context, reader io.Reader) (*ImportResult, []PersonData, []FamilyData, []SourceData, []CitationData, []RepositoryData, []EventData, []AttributeData, []NoteData, []SubmitterData, []AssociationData, []LDSOrdinanceData, []MediaData, error) {
+	return imp.ImportWithOptions(ctx, reader, ImportOptions{})
+}
+
+// ImportWithOptions parses a GEDCOM file with the given options and returns
+// structured data for import. It is identical to Import but allows callers to
+// receive progress callbacks during decoding (see ImportOptions).
+func (imp *Importer) ImportWithOptions(ctx context.Context, reader io.Reader, importOpts ImportOptions) (*ImportResult, []PersonData, []FamilyData, []SourceData, []CitationData, []RepositoryData, []EventData, []AttributeData, []NoteData, []SubmitterData, []AssociationData, []LDSOrdinanceData, []MediaData, error) {
 	result := &ImportResult{
 		PersonXrefToID:     make(map[string]uuid.UUID),
 		FamilyXrefToID:     make(map[string]uuid.UUID),
@@ -284,6 +310,14 @@ func (imp *Importer) Import(ctx context.Context, reader io.Reader) (*ImportResul
 	// Lenient mode collects parse errors as diagnostics instead of failing
 	opts := decoder.DefaultOptions()
 	opts.Context = ctx
+
+	// Wire progress reporting through to the decoder when requested. The decoder
+	// reports -1 as the total when TotalSize is unknown (zero), matching our
+	// ProgressCallback contract, so we forward callbacks unchanged.
+	if importOpts.OnProgress != nil {
+		opts.TotalSize = importOpts.TotalSize
+		opts.OnProgress = decoder.ProgressCallback(importOpts.OnProgress)
+	}
 
 	decodeResult, err := decoder.DecodeWithDiagnostics(reader, opts)
 	if err != nil {

--- a/internal/gedcom/importer_progress_test.go
+++ b/internal/gedcom/importer_progress_test.go
@@ -1,0 +1,71 @@
+package gedcom_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cacack/my-family/internal/gedcom"
+)
+
+// TestImportWithOptions_ProgressCallback verifies that ImportWithOptions forwards
+// decoder progress callbacks to the caller-supplied OnProgress function and that
+// the final byte count reflects the full input size.
+func TestImportWithOptions_ProgressCallback(t *testing.T) {
+	importer := gedcom.NewImporter()
+	ctx := context.Background()
+
+	totalSize := int64(len(sampleGedcom))
+
+	var calls int
+	var lastBytesRead, lastTotalBytes int64
+	opts := gedcom.ImportOptions{
+		TotalSize: totalSize,
+		OnProgress: func(bytesRead, totalBytes int64) {
+			calls++
+			lastBytesRead = bytesRead
+			lastTotalBytes = totalBytes
+		},
+	}
+
+	result, _, _, _, _, _, _, _, _, _, _, _, _, err := importer.ImportWithOptions(ctx, strings.NewReader(sampleGedcom), opts)
+	if err != nil {
+		t.Fatalf("ImportWithOptions failed: %v", err)
+	}
+
+	// Parsing must still succeed exactly as the plain Import path does.
+	if result.PersonsImported != 3 {
+		t.Errorf("PersonsImported = %d, want 3", result.PersonsImported)
+	}
+
+	if calls == 0 {
+		t.Fatal("OnProgress was never called")
+	}
+	if lastTotalBytes != totalSize {
+		t.Errorf("reported total bytes = %d, want %d", lastTotalBytes, totalSize)
+	}
+	if lastBytesRead <= 0 {
+		t.Errorf("reported bytes read = %d, want > 0", lastBytesRead)
+	}
+	if lastBytesRead > lastTotalBytes {
+		t.Errorf("bytes read %d exceeds total %d", lastBytesRead, lastTotalBytes)
+	}
+}
+
+// TestImportWithOptions_NilCallback verifies that omitting OnProgress is safe and
+// behaves identically to the plain Import path (zero progress-reporting overhead).
+func TestImportWithOptions_NilCallback(t *testing.T) {
+	importer := gedcom.NewImporter()
+	ctx := context.Background()
+
+	result, _, _, _, _, _, _, _, _, _, _, _, _, err := importer.ImportWithOptions(ctx, strings.NewReader(sampleGedcom), gedcom.ImportOptions{})
+	if err != nil {
+		t.Fatalf("ImportWithOptions failed: %v", err)
+	}
+	if result.PersonsImported != 3 {
+		t.Errorf("PersonsImported = %d, want 3", result.PersonsImported)
+	}
+	if result.FamiliesImported != 1 {
+		t.Errorf("FamiliesImported = %d, want 1", result.FamiliesImported)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -313,6 +313,12 @@ export interface ImportResult {
 	errors?: ImportError[];
 }
 
+export interface ImportProgress {
+	bytes_read: number;
+	total_bytes: number; // -1 when unknown
+	percent: number; // 0-100, or -1 when total is unknown
+}
+
 // Export estimation types
 export interface ExportEstimate {
 	person_count: number;

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1059,6 +1059,83 @@ class ApiClient {
 		return response.json();
 	}
 
+	/**
+	 * Import a GEDCOM file while receiving real-time parse progress via Server-Sent
+	 * Events. onProgress is invoked with each progress update; the resolved value is
+	 * the final import result. Falls back cleanly if the browser/stream provides no
+	 * progress events (onProgress simply won't be called).
+	 */
+	async importGedcomStream(
+		file: File,
+		onProgress?: (progress: ImportProgress) => void
+	): Promise<ImportResult> {
+		const formData = new FormData();
+		formData.append('file', file);
+
+		const response = await fetch(`${API_BASE}/gedcom/import/stream`, {
+			method: 'POST',
+			body: formData
+		});
+
+		if (!response.ok || !response.body) {
+			const error: ApiError = await response.json().catch(() => ({
+				code: 'UNKNOWN_ERROR',
+				message: response.statusText
+			}));
+			error.status = response.status;
+			throw error;
+		}
+
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = '';
+		let result: ImportResult | null = null;
+		let streamError: string | null = null;
+
+		// Parse the SSE stream: events are separated by a blank line and consist of
+		// `event: <name>` and `data: <json>` lines.
+		const handleEvent = (raw: string) => {
+			let eventName = 'message';
+			const dataLines: string[] = [];
+			for (const line of raw.split('\n')) {
+				if (line.startsWith('event:')) eventName = line.slice(6).trim();
+				else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+			}
+			if (dataLines.length === 0) return;
+			const data = JSON.parse(dataLines.join('\n'));
+			if (eventName === 'progress') {
+				onProgress?.(data as ImportProgress);
+			} else if (eventName === 'result') {
+				result = data as ImportResult;
+			} else if (eventName === 'error') {
+				streamError = (data as { message?: string }).message || 'Import failed';
+			}
+		};
+
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			let sep: number;
+			// Process complete events (delimited by a blank line).
+			while ((sep = buffer.indexOf('\n\n')) !== -1) {
+				const rawEvent = buffer.slice(0, sep);
+				buffer = buffer.slice(sep + 2);
+				if (rawEvent.trim()) handleEvent(rawEvent);
+			}
+		}
+		// Flush any trailing event without a terminating blank line.
+		if (buffer.trim()) handleEvent(buffer);
+
+		if (streamError !== null) {
+			throw { code: 'IMPORT_ERROR', message: streamError } as ApiError;
+		}
+		if (result === null) {
+			throw { code: 'IMPORT_ERROR', message: 'Import stream ended without a result' } as ApiError;
+		}
+		return result;
+	}
+
 	async exportGedcom(): Promise<string> {
 		const response = await fetch(`${API_BASE}/gedcom/export`);
 

--- a/web/src/lib/components/import/ImportProgress.svelte
+++ b/web/src/lib/components/import/ImportProgress.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import type { ImportProgress } from '$lib/api/client';
+
+	interface Props {
+		progress: ImportProgress;
+	}
+
+	let { progress }: Props = $props();
+
+	// Whether a meaningful percentage is available (total size known).
+	let determinate = $derived(progress.percent >= 0 && progress.total_bytes > 0);
+
+	// Format a byte count as a human-readable size.
+	function formatBytes(bytes: number): string {
+		if (bytes < 0) return 'unknown';
+		if (bytes < 1024) return `${bytes} B`;
+		const units = ['KB', 'MB', 'GB'];
+		let value = bytes / 1024;
+		let unit = 0;
+		while (value >= 1024 && unit < units.length - 1) {
+			value /= 1024;
+			unit++;
+		}
+		return `${value.toFixed(1)} ${units[unit]}`;
+	}
+</script>
+
+<div
+	class="import-progress"
+	role="progressbar"
+	aria-valuenow={determinate ? progress.percent : undefined}
+	aria-valuemin={0}
+	aria-valuemax={100}
+	aria-label={determinate
+		? `Import progress: ${progress.percent}% complete`
+		: 'Importing GEDCOM file'}
+>
+	<div class="progress-header">
+		<span class="phase-text">Importing GEDCOM file</span>
+		{#if determinate}
+			<span class="percentage-text">{progress.percent}%</span>
+		{/if}
+	</div>
+	<div class="progress-bar-container" class:indeterminate={!determinate}>
+		{#if determinate}
+			<div class="progress-bar-fill" style="width: {progress.percent}%"></div>
+		{:else}
+			<div class="progress-bar-fill indeterminate-fill"></div>
+		{/if}
+	</div>
+	<div class="progress-detail">
+		<span class="sr-only">Progress: </span>
+		{formatBytes(progress.bytes_read)}{#if progress.total_bytes > 0}
+			of {formatBytes(progress.total_bytes)}{/if} read
+	</div>
+</div>
+
+<style>
+	.import-progress {
+		width: 100%;
+	}
+
+	.progress-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.375rem;
+	}
+
+	.phase-text {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: #475569;
+	}
+
+	.percentage-text {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: #1e293b;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.progress-bar-container {
+		width: 100%;
+		height: 0.5rem;
+		background: #e2e8f0;
+		border-radius: 9999px;
+		overflow: hidden;
+	}
+
+	.progress-bar-fill {
+		height: 100%;
+		background: #3b82f6;
+		border-radius: 9999px;
+		transition: width 0.3s ease-out;
+	}
+
+	/* Indeterminate animation when the total size is unknown. */
+	.indeterminate-fill {
+		width: 40%;
+		animation: indeterminate 1.2s ease-in-out infinite;
+	}
+
+	@keyframes indeterminate {
+		0% {
+			transform: translateX(-100%);
+		}
+		100% {
+			transform: translateX(250%);
+		}
+	}
+
+	.progress-detail {
+		margin-top: 0.25rem;
+		font-size: 0.75rem;
+		color: #64748b;
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	@media (max-width: 480px) {
+		.progress-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.125rem;
+		}
+
+		.percentage-text {
+			font-size: 0.8125rem;
+		}
+	}
+</style>

--- a/web/src/lib/components/import/ImportProgress.test.ts
+++ b/web/src/lib/components/import/ImportProgress.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ImportProgress from './ImportProgress.svelte';
+import type { ImportProgress as ImportProgressType } from '$lib/api/client';
+
+describe('ImportProgress', () => {
+	it('renders a determinate progress bar with percent and byte counts', () => {
+		const progress: ImportProgressType = {
+			bytes_read: 512 * 1024,
+			total_bytes: 1024 * 1024,
+			percent: 50
+		};
+		render(ImportProgress, { progress });
+
+		const bar = screen.getByRole('progressbar');
+		expect(bar.getAttribute('aria-valuenow')).toBe('50');
+		expect(screen.getByText('50%')).toBeTruthy();
+		// Human-readable byte sizes for read / total.
+		expect(screen.getByText(/512\.0 KB/)).toBeTruthy();
+		expect(screen.getByText(/1\.0 MB/)).toBeTruthy();
+	});
+
+	it('renders an indeterminate bar when the total size is unknown', () => {
+		const progress: ImportProgressType = {
+			bytes_read: 4096,
+			total_bytes: -1,
+			percent: -1
+		};
+		render(ImportProgress, { progress });
+
+		const bar = screen.getByRole('progressbar');
+		// No meaningful percentage is exposed when total is unknown.
+		expect(bar.getAttribute('aria-valuenow')).toBeNull();
+		expect(bar.getAttribute('aria-label')).toBe('Importing GEDCOM file');
+		expect(screen.getByText(/4\.0 KB/)).toBeTruthy();
+	});
+
+	it('formats raw byte counts under 1KB', () => {
+		const progress: ImportProgressType = {
+			bytes_read: 512,
+			total_bytes: 800,
+			percent: 64
+		};
+		render(ImportProgress, { progress });
+		expect(screen.getByText(/512 B/)).toBeTruthy();
+	});
+});

--- a/web/src/routes/import/+page.svelte
+++ b/web/src/routes/import/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { api, type ImportResult } from '$lib/api/client';
+	import { api, type ImportResult, type ImportProgress } from '$lib/api/client';
 	import { ExportButton } from '$lib/components/export';
+	import ImportProgressBar from '$lib/components/import/ImportProgress.svelte';
 	import { Button } from '$lib/components/ui/button';
 
 	let file: File | null = $state(null);
@@ -9,6 +9,7 @@
 	let result: ImportResult | null = $state(null);
 	let error: string | null = $state(null);
 	let dragOver = $state(false);
+	let progress: ImportProgress | null = $state(null);
 
 	// Export state
 	type EntityType = 'tree' | 'persons' | 'families' | 'sources' | 'citations' | 'events' | 'attributes';
@@ -246,13 +247,17 @@
 		importing = true;
 		error = null;
 		result = null;
+		progress = null;
 
 		try {
-			result = await api.importGedcom(file);
+			result = await api.importGedcomStream(file, (p) => {
+				progress = p;
+			});
 		} catch (e) {
 			error = (e as { message?: string }).message || 'Import failed';
 		} finally {
 			importing = false;
+			progress = null;
 		}
 	}
 
@@ -260,6 +265,7 @@
 		file = null;
 		result = null;
 		error = null;
+		progress = null;
 	}
 
 	async function exportData() {
@@ -436,6 +442,12 @@
 
 				{#if error}
 					<p class="error-message" role="alert">{error}</p>
+				{/if}
+
+				{#if importing && progress}
+					<div class="import-progress-wrap">
+						<ImportProgressBar {progress} />
+					</div>
 				{/if}
 
 				{#if file}
@@ -753,6 +765,10 @@
 	.remove-btn:hover {
 		background: #e2e8f0;
 		color: #1e293b;
+	}
+
+	.import-progress-wrap {
+		margin-top: 1rem;
 	}
 
 	.error-message {


### PR DESCRIPTION
Adds real-time progress reporting during GEDCOM file imports, using gedcom-go's decoder progress callbacks.

## What changed

**Backend**
- `Importer.ImportWithOptions(ctx, reader, ImportOptions{TotalSize, OnProgress})` plumbs gedcom-go decoder progress callbacks through the importer. `Import()` is unchanged (delegates with empty options) — zero overhead when no callback is supplied.
- `command.ImportGedcomInput` gains an optional `OnProgress` callback.
- New `POST /gedcom/import/stream` endpoint streams parse progress via **Server-Sent Events**: zero or more `progress` events followed by a terminal `result` or `error` event. It's registered outside the OpenAPI-generated strict server because SSE does not map cleanly onto that layer.

**Frontend**
- `ImportProgress.svelte` — a progress component (determinate when the file size is known, indeterminate otherwise), mirroring the existing `ExportProgress` pattern.
- `api.importGedcomStream(file, onProgress)` parses the SSE stream and resolves to the final `ImportResult`.
- The Import page now streams progress and renders the bar during import.

## Tests
- `importer_progress_test.go` — verifies the progress callback fires with sane byte counts and that a nil callback is safe.
- `import_progress_test.go` — SSE endpoint: success (asserts `result` event + counts, validates any `progress` events), no-file (400), and in-stream `error` event on a failed import.
- `ImportProgress.test.ts` — determinate/indeterminate rendering and byte formatting.

## Verification
- `make build`, `make check-coverage` (api 64.5% / gedcom 78.9% / command 82.5% — all above their thresholds), `make lint` (0 issues)
- `svelte-check --threshold error` clean; full vitest suite (243 tests) green

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time progress tracking for GEDCOM imports with a visual progress indicator displaying bytes processed and completion percentage
  * Gracefully handles imports of unknown file size with indeterminate progress display

* **Tests**
  * Added comprehensive test coverage for import streaming and progress reporting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->