### PR TITLE
Wrap bare error returns in command handlers with operation context

### DIFF
--- a/internal/command/association_commands.go
+++ b/internal/command/association_commands.go
@@ -79,7 +79,7 @@ func (h *Handler) CreateAssociation(ctx context.Context, input CreateAssociation
 	// Execute command (append + project)
 	version, err := h.execute(ctx, association.ID.String(), "Association", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create association command: %w", err)
 	}
 
 	return &CreateAssociationResult{
@@ -108,7 +108,7 @@ func (h *Handler) UpdateAssociation(ctx context.Context, input UpdateAssociation
 	// Get current association from read model
 	current, err := h.readStore.GetAssociation(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting association: %w", err)
 	}
 	if current == nil {
 		return nil, ErrAssociationNotFound
@@ -163,7 +163,7 @@ func (h *Handler) UpdateAssociation(ctx context.Context, input UpdateAssociation
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Association", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update association command: %w", err)
 	}
 
 	return &UpdateAssociationResult{Version: version}, nil
@@ -174,7 +174,7 @@ func (h *Handler) DeleteAssociation(ctx context.Context, id uuid.UUID, version i
 	// Get current association from read model
 	current, err := h.readStore.GetAssociation(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting association: %w", err)
 	}
 	if current == nil {
 		return ErrAssociationNotFound
@@ -190,7 +190,10 @@ func (h *Handler) DeleteAssociation(ctx context.Context, id uuid.UUID, version i
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Association", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete association command: %w", err)
+	}
+	return nil
 }
 
 // equalStringSlices compares two string slices for equality.

--- a/internal/command/evidence_commands.go
+++ b/internal/command/evidence_commands.go
@@ -70,7 +70,7 @@ func (h *Handler) CreateEvidenceAnalysis(ctx context.Context, input CreateEviden
 	// Execute command (append + project)
 	version, err := h.execute(ctx, analysis.ID.String(), "EvidenceAnalysis", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create evidence analysis command: %w", err)
 	}
 
 	result := &CreateEvidenceAnalysisResult{
@@ -113,7 +113,7 @@ func (h *Handler) UpdateEvidenceAnalysis(ctx context.Context, input UpdateEviden
 	// Get current from read model
 	current, err := h.readStore.GetEvidenceAnalysis(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting evidence analysis: %w", err)
 	}
 	if current == nil {
 		return nil, ErrEvidenceAnalysisNotFound
@@ -186,7 +186,7 @@ func (h *Handler) UpdateEvidenceAnalysis(ctx context.Context, input UpdateEviden
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "EvidenceAnalysis", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update evidence analysis command: %w", err)
 	}
 
 	result := &UpdateEvidenceAnalysisResult{Version: version}
@@ -206,7 +206,7 @@ func (h *Handler) UpdateEvidenceAnalysis(ctx context.Context, input UpdateEviden
 func (h *Handler) DeleteEvidenceAnalysis(ctx context.Context, id uuid.UUID, version int64, reason string) error {
 	current, err := h.readStore.GetEvidenceAnalysis(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting evidence analysis: %w", err)
 	}
 	if current == nil {
 		return ErrEvidenceAnalysisNotFound
@@ -217,7 +217,10 @@ func (h *Handler) DeleteEvidenceAnalysis(ctx context.Context, id uuid.UUID, vers
 
 	event := domain.NewEvidenceAnalysisDeleted(id, reason)
 	_, err = h.execute(ctx, id.String(), "EvidenceAnalysis", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete evidence analysis command: %w", err)
+	}
+	return nil
 }
 
 // --- EvidenceConflict management ---
@@ -231,7 +234,7 @@ type ResolveEvidenceConflictResult struct {
 func (h *Handler) ResolveEvidenceConflict(ctx context.Context, id uuid.UUID, resolution string, version int64) (*ResolveEvidenceConflictResult, error) {
 	current, err := h.readStore.GetEvidenceConflict(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting evidence conflict: %w", err)
 	}
 	if current == nil {
 		return nil, ErrEvidenceConflictNotFound
@@ -248,7 +251,7 @@ func (h *Handler) ResolveEvidenceConflict(ctx context.Context, id uuid.UUID, res
 
 	newVersion, err := h.execute(ctx, id.String(), "EvidenceConflict", []domain.Event{event}, version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing resolve evidence conflict command: %w", err)
 	}
 
 	return &ResolveEvidenceConflictResult{Version: newVersion}, nil
@@ -295,7 +298,7 @@ func (h *Handler) CreateResearchLog(ctx context.Context, input CreateResearchLog
 	event := domain.NewResearchLogCreated(log)
 	version, err := h.execute(ctx, log.ID.String(), "ResearchLog", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create research log command: %w", err)
 	}
 
 	return &CreateResearchLogResult{ID: log.ID, Version: version}, nil
@@ -323,7 +326,7 @@ type UpdateResearchLogResult struct {
 func (h *Handler) UpdateResearchLog(ctx context.Context, input UpdateResearchLogInput) (*UpdateResearchLogResult, error) {
 	current, err := h.readStore.GetResearchLog(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting research log: %w", err)
 	}
 	if current == nil {
 		return nil, ErrResearchLogNotFound
@@ -385,7 +388,7 @@ func (h *Handler) UpdateResearchLog(ctx context.Context, input UpdateResearchLog
 	event := domain.NewResearchLogUpdated(input.ID, changes)
 	version, err := h.execute(ctx, input.ID.String(), "ResearchLog", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update research log command: %w", err)
 	}
 
 	return &UpdateResearchLogResult{Version: version}, nil
@@ -395,7 +398,7 @@ func (h *Handler) UpdateResearchLog(ctx context.Context, input UpdateResearchLog
 func (h *Handler) DeleteResearchLog(ctx context.Context, id uuid.UUID, version int64, reason string) error {
 	current, err := h.readStore.GetResearchLog(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting research log: %w", err)
 	}
 	if current == nil {
 		return ErrResearchLogNotFound
@@ -406,7 +409,10 @@ func (h *Handler) DeleteResearchLog(ctx context.Context, id uuid.UUID, version i
 
 	event := domain.NewResearchLogDeleted(id, reason)
 	_, err = h.execute(ctx, id.String(), "ResearchLog", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete research log command: %w", err)
+	}
+	return nil
 }
 
 // --- ProofSummary CRUD ---
@@ -450,7 +456,7 @@ func (h *Handler) CreateProofSummary(ctx context.Context, input CreateProofSumma
 	event := domain.NewProofSummaryCreated(summary)
 	version, err := h.execute(ctx, summary.ID.String(), "ProofSummary", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create proof summary command: %w", err)
 	}
 
 	return &CreateProofSummaryResult{ID: summary.ID, Version: version}, nil
@@ -477,7 +483,7 @@ type UpdateProofSummaryResult struct {
 func (h *Handler) UpdateProofSummary(ctx context.Context, input UpdateProofSummaryInput) (*UpdateProofSummaryResult, error) {
 	current, err := h.readStore.GetProofSummary(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting proof summary: %w", err)
 	}
 	if current == nil {
 		return nil, ErrProofSummaryNotFound
@@ -541,7 +547,7 @@ func (h *Handler) UpdateProofSummary(ctx context.Context, input UpdateProofSumma
 	event := domain.NewProofSummaryUpdated(input.ID, changes)
 	version, err := h.execute(ctx, input.ID.String(), "ProofSummary", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update proof summary command: %w", err)
 	}
 
 	return &UpdateProofSummaryResult{Version: version}, nil
@@ -551,7 +557,7 @@ func (h *Handler) UpdateProofSummary(ctx context.Context, input UpdateProofSumma
 func (h *Handler) DeleteProofSummary(ctx context.Context, id uuid.UUID, version int64, reason string) error {
 	current, err := h.readStore.GetProofSummary(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting proof summary: %w", err)
 	}
 	if current == nil {
 		return ErrProofSummaryNotFound
@@ -562,7 +568,10 @@ func (h *Handler) DeleteProofSummary(ctx context.Context, id uuid.UUID, version 
 
 	event := domain.NewProofSummaryDeleted(id, reason)
 	_, err = h.execute(ctx, id.String(), "ProofSummary", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete proof summary command: %w", err)
+	}
+	return nil
 }
 
 // --- Conflict auto-detection helper ---
@@ -573,7 +582,7 @@ func (h *Handler) detectEvidenceConflicts(ctx context.Context, analysisID uuid.U
 	// Get analyses for the same fact type and subject
 	analyses, err := h.readStore.GetAnalysesForFact(ctx, factType, subjectID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting analyses for fact: %w", err)
 	}
 
 	var conflicting []uuid.UUID
@@ -590,7 +599,7 @@ func (h *Handler) detectEvidenceConflicts(ctx context.Context, analysisID uuid.U
 	// Check for existing open conflict to avoid duplicates
 	existingConflicts, err := h.readStore.GetConflictsForSubject(ctx, subjectID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting conflicts for subject: %w", err)
 	}
 	for _, c := range existingConflicts {
 		if c.FactType == factType && c.Status == domain.ConflictStatusOpen {
@@ -610,7 +619,7 @@ func (h *Handler) detectEvidenceConflicts(ctx context.Context, analysisID uuid.U
 	event := domain.NewEvidenceConflictDetected(conflict)
 	_, err = h.execute(ctx, conflict.ID.String(), "EvidenceConflict", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create evidence conflict command: %w", err)
 	}
 
 	return &conflict.ID, nil

--- a/internal/command/family_commands.go
+++ b/internal/command/family_commands.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -46,7 +47,7 @@ func (h *Handler) CreateFamily(ctx context.Context, input CreateFamilyInput) (*C
 	if input.Partner1ID != nil {
 		p, err := h.readStore.GetPerson(ctx, *input.Partner1ID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting partner1: %w", err)
 		}
 		if p == nil {
 			return nil, errors.New("invalid family input: partner1 not found")
@@ -55,7 +56,7 @@ func (h *Handler) CreateFamily(ctx context.Context, input CreateFamilyInput) (*C
 	if input.Partner2ID != nil {
 		p, err := h.readStore.GetPerson(ctx, *input.Partner2ID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting partner2: %w", err)
 		}
 		if p == nil {
 			return nil, errors.New("invalid family input: partner2 not found")
@@ -93,12 +94,12 @@ func (h *Handler) CreateFamily(ctx context.Context, input CreateFamilyInput) (*C
 	// Append to event store
 	err := h.eventStore.Append(ctx, family.ID, "family", []domain.Event{event}, 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("appending family created event: %w", err)
 	}
 
 	// Update read model
 	if err := h.projector.Apply(ctx, event); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("applying family created event: %w", err)
 	}
 
 	return &CreateFamilyResult{
@@ -128,7 +129,7 @@ func (h *Handler) UpdateFamily(ctx context.Context, input UpdateFamilyInput) (*U
 	// Check family exists
 	family, err := h.readStore.GetFamily(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting family: %w", err)
 	}
 	if family == nil {
 		return nil, ErrFamilyNotFound
@@ -170,12 +171,12 @@ func (h *Handler) UpdateFamily(ctx context.Context, input UpdateFamilyInput) (*U
 		if errors.Is(err, repository.ErrConcurrencyConflict) {
 			return nil, repository.ErrConcurrencyConflict
 		}
-		return nil, err
+		return nil, fmt.Errorf("appending family updated event: %w", err)
 	}
 
 	// Update read model
 	if err := h.projector.Apply(ctx, event); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("applying family updated event: %w", err)
 	}
 
 	return &UpdateFamilyResult{
@@ -194,7 +195,7 @@ func (h *Handler) DeleteFamily(ctx context.Context, input DeleteFamilyInput) err
 	// Check family exists
 	family, err := h.readStore.GetFamily(ctx, input.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting family: %w", err)
 	}
 	if family == nil {
 		return ErrFamilyNotFound
@@ -203,7 +204,7 @@ func (h *Handler) DeleteFamily(ctx context.Context, input DeleteFamilyInput) err
 	// Check for children
 	children, err := h.readStore.GetChildrenOfFamily(ctx, input.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting children of family: %w", err)
 	}
 	if len(children) > 0 {
 		return ErrFamilyHasChildren
@@ -218,7 +219,7 @@ func (h *Handler) DeleteFamily(ctx context.Context, input DeleteFamilyInput) err
 		if errors.Is(err, repository.ErrConcurrencyConflict) {
 			return repository.ErrConcurrencyConflict
 		}
-		return err
+		return fmt.Errorf("appending family deleted event: %w", err)
 	}
 
 	// Update read model
@@ -242,7 +243,7 @@ func (h *Handler) LinkChild(ctx context.Context, input LinkChildInput) (*LinkChi
 	// Verify family exists
 	family, err := h.readStore.GetFamily(ctx, input.FamilyID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting family: %w", err)
 	}
 	if family == nil {
 		return nil, ErrFamilyNotFound
@@ -251,7 +252,7 @@ func (h *Handler) LinkChild(ctx context.Context, input LinkChildInput) (*LinkChi
 	// Verify child exists
 	child, err := h.readStore.GetPerson(ctx, input.ChildID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting child: %w", err)
 	}
 	if child == nil {
 		return nil, ErrPersonNotFound
@@ -260,7 +261,7 @@ func (h *Handler) LinkChild(ctx context.Context, input LinkChildInput) (*LinkChi
 	// Check if child is already linked to a family
 	existingFamily, err := h.readStore.GetChildFamily(ctx, input.ChildID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting child family: %w", err)
 	}
 	if existingFamily != nil {
 		return nil, ErrChildAlreadyLinked
@@ -269,14 +270,14 @@ func (h *Handler) LinkChild(ctx context.Context, input LinkChildInput) (*LinkChi
 	// Circular ancestry check: child cannot be an ancestor of either partner
 	if family.Partner1ID != nil {
 		if isAncestor, err := h.isAncestor(ctx, input.ChildID, *family.Partner1ID); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("checking circular ancestry: %w", err)
 		} else if isAncestor {
 			return nil, ErrCircularAncestry
 		}
 	}
 	if family.Partner2ID != nil {
 		if isAncestor, err := h.isAncestor(ctx, input.ChildID, *family.Partner2ID); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("checking circular ancestry: %w", err)
 		} else if isAncestor {
 			return nil, ErrCircularAncestry
 		}
@@ -298,12 +299,12 @@ func (h *Handler) LinkChild(ctx context.Context, input LinkChildInput) (*LinkChi
 		if errors.Is(err, repository.ErrConcurrencyConflict) {
 			return nil, repository.ErrConcurrencyConflict
 		}
-		return nil, err
+		return nil, fmt.Errorf("appending child linked event: %w", err)
 	}
 
 	// Update read model
 	if err := h.projector.Apply(ctx, event); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("applying child linked event: %w", err)
 	}
 
 	return &LinkChildResult{
@@ -322,7 +323,7 @@ func (h *Handler) UnlinkChild(ctx context.Context, input UnlinkChildInput) error
 	// Verify family exists
 	family, err := h.readStore.GetFamily(ctx, input.FamilyID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting family: %w", err)
 	}
 	if family == nil {
 		return ErrFamilyNotFound
@@ -331,7 +332,7 @@ func (h *Handler) UnlinkChild(ctx context.Context, input UnlinkChildInput) error
 	// Verify child is in this family
 	childFamily, err := h.readStore.GetChildFamily(ctx, input.ChildID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting child family: %w", err)
 	}
 	if childFamily == nil || childFamily.ID != input.FamilyID {
 		return ErrChildNotInFamily
@@ -346,7 +347,7 @@ func (h *Handler) UnlinkChild(ctx context.Context, input UnlinkChildInput) error
 		if errors.Is(err, repository.ErrConcurrencyConflict) {
 			return repository.ErrConcurrencyConflict
 		}
-		return err
+		return fmt.Errorf("appending child unlinked event: %w", err)
 	}
 
 	// Update read model

--- a/internal/command/gedcom_commands.go
+++ b/internal/command/gedcom_commands.go
@@ -266,12 +266,12 @@ func (h *Handler) importPerson(ctx context.Context, p gedcom.PersonData) error {
 	// Append to event store
 	err := h.eventStore.Append(ctx, person.ID, "person", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending person created event: %w", err)
 	}
 
 	// Project to read model
 	if err := h.projector.Project(ctx, event, 1); err != nil {
-		return err
+		return fmt.Errorf("projecting person created event: %w", err)
 	}
 
 	// Update read model with GEDCOM coordinates (not in event schema)
@@ -308,13 +308,13 @@ func (h *Handler) importPerson(ctx context.Context, p gedcom.PersonData) error {
 		// Append name event to person stream with version tracking
 		err := h.eventStore.Append(ctx, person.ID, "person", []domain.Event{nameEvent}, currentVersion)
 		if err != nil {
-			return err
+			return fmt.Errorf("appending name added event: %w", err)
 		}
 		currentVersion++
 
 		// Project to read model with correct version
 		if err := h.projector.Project(ctx, nameEvent, currentVersion); err != nil {
-			return err
+			return fmt.Errorf("projecting name added event: %w", err)
 		}
 	}
 
@@ -351,7 +351,7 @@ func (h *Handler) importFamily(ctx context.Context, f gedcom.FamilyData) error {
 	// Append to event store
 	err := h.eventStore.Append(ctx, family.ID, "family", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending family created event: %w", err)
 	}
 
 	// Project to read model
@@ -393,7 +393,7 @@ func (h *Handler) importSource(ctx context.Context, s gedcom.SourceData) error {
 	// Append to event store
 	err := h.eventStore.Append(ctx, source.ID, "source", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending source created event: %w", err)
 	}
 
 	// Project to read model
@@ -425,7 +425,7 @@ func (h *Handler) importRepository(ctx context.Context, r gedcom.RepositoryData)
 	// Append to event store
 	err := h.eventStore.Append(ctx, repo.ID, "repository", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending repository created event: %w", err)
 	}
 
 	// Project to read model
@@ -477,7 +477,7 @@ func (h *Handler) importCitation(ctx context.Context, c gedcom.CitationData, sou
 	// Append to event store
 	err := h.eventStore.Append(ctx, citation.ID, "citation", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending citation created event: %w", err)
 	}
 
 	// Project to read model
@@ -489,7 +489,7 @@ func (h *Handler) linkChildToFamily(ctx context.Context, familyID, childID uuid.
 	// Check if child is already linked
 	existingFamily, err := h.readStore.GetChildFamily(ctx, childID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting child family: %w", err)
 	}
 	if existingFamily != nil {
 		// Child already in a family, skip
@@ -503,7 +503,7 @@ func (h *Handler) linkChildToFamily(ctx context.Context, familyID, childID uuid.
 	// Get current family version
 	family, err := h.readStore.GetFamily(ctx, familyID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting family: %w", err)
 	}
 	if family == nil {
 		return nil // Family doesn't exist, skip
@@ -512,7 +512,7 @@ func (h *Handler) linkChildToFamily(ctx context.Context, familyID, childID uuid.
 	// Append to event store
 	err = h.eventStore.Append(ctx, familyID, "family", []domain.Event{event}, family.Version)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending child linked event: %w", err)
 	}
 
 	// Project to read model
@@ -549,12 +549,12 @@ func (h *Handler) importEvent(ctx context.Context, e gedcom.EventData) error {
 	// Append to event store using owner's stream
 	err := h.eventStore.Append(ctx, e.ID, "event", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending life event created event: %w", err)
 	}
 
 	// Project to read model
 	if err := h.projector.Project(ctx, event, 1); err != nil {
-		return err
+		return fmt.Errorf("projecting life event created event: %w", err)
 	}
 
 	// Update read model with GEDCOM coordinates (not in event schema)
@@ -595,7 +595,7 @@ func (h *Handler) importAttribute(ctx context.Context, a gedcom.AttributeData) e
 	// Append to event store
 	err := h.eventStore.Append(ctx, a.ID, "attribute", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending attribute created event: %w", err)
 	}
 
 	// Project to read model
@@ -614,7 +614,7 @@ func (h *Handler) importNote(ctx context.Context, n gedcom.NoteData) error {
 	// Append to event store
 	err := h.eventStore.Append(ctx, note.ID, "note", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending note created event: %w", err)
 	}
 
 	// Project to read model
@@ -646,7 +646,7 @@ func (h *Handler) importSubmitter(ctx context.Context, s gedcom.SubmitterData) e
 	// Append to event store
 	err := h.eventStore.Append(ctx, submitter.ID, "submitter", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending submitter created event: %w", err)
 	}
 
 	// Project to read model
@@ -671,7 +671,7 @@ func (h *Handler) importAssociation(ctx context.Context, a gedcom.AssociationDat
 	// Append to event store
 	err := h.eventStore.Append(ctx, association.ID, "association", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending association created event: %w", err)
 	}
 
 	// Project to read model
@@ -708,7 +708,7 @@ func (h *Handler) importLDSOrdinance(ctx context.Context, o gedcom.LDSOrdinanceD
 	// Append to event store
 	err := h.eventStore.Append(ctx, ordinance.ID, "LDSOrdinance", []domain.Event{event}, -1)
 	if err != nil {
-		return err
+		return fmt.Errorf("appending LDS ordinance created event: %w", err)
 	}
 
 	// Project to read model

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -4,6 +4,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -147,7 +148,7 @@ func (h *Handler) rollbackEntity(ctx context.Context, entityType string, entityI
 		if errors.Is(err, repository.ErrStreamNotFound) {
 			return nil, query.ErrNoEvents
 		}
-		return nil, err
+		return nil, fmt.Errorf("getting stream version: %w", err)
 	}
 
 	// Validate target version is less than current version
@@ -161,7 +162,7 @@ func (h *Handler) rollbackEntity(ctx context.Context, entityType string, entityI
 	// Check if entity is currently deleted (follow-up feature to handle recreation)
 	deleted, err := isDeleted(entityID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("checking if entity is deleted: %w", err)
 	}
 	if deleted {
 		return nil, ErrRollbackDeletedEntity
@@ -170,7 +171,7 @@ func (h *Handler) rollbackEntity(ctx context.Context, entityType string, entityI
 	// Compute rollback changes using RollbackService
 	changes, err := h.rollbackService.ComputeRollbackChanges(ctx, entityType, entityID, targetVersion)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("computing rollback changes: %w", err)
 	}
 
 	// If no changes needed, this is a no-op
@@ -203,7 +204,7 @@ func (h *Handler) rollbackEntity(ctx context.Context, entityType string, entityI
 	// Append event with optimistic locking
 	newVersion, err := h.execute(ctx, entityID.String(), entityType, []domain.Event{event}, currentVersion)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing rollback event: %w", err)
 	}
 
 	return &RollbackResult{

--- a/internal/command/handler_test.go
+++ b/internal/command/handler_test.go
@@ -2,6 +2,7 @@ package command_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -387,7 +388,7 @@ func TestRollbackPerson_ConcurrencyConflict(t *testing.T) {
 
 	// Try to rollback - should fail with concurrency error
 	_, err = handler.RollbackPerson(ctx, createResult.ID, 1)
-	if err != repository.ErrConcurrencyConflict {
+	if !errors.Is(err, repository.ErrConcurrencyConflict) {
 		t.Errorf("Expected ErrConcurrencyConflict, got %v", err)
 	}
 }

--- a/internal/command/lds_ordinance_commands.go
+++ b/internal/command/lds_ordinance_commands.go
@@ -68,7 +68,7 @@ func (h *Handler) CreateLDSOrdinance(ctx context.Context, input CreateLDSOrdinan
 	// Execute command (append + project)
 	version, err := h.execute(ctx, ordinance.ID.String(), "LDSOrdinance", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create LDS ordinance command: %w", err)
 	}
 
 	return &CreateLDSOrdinanceResult{
@@ -97,7 +97,7 @@ func (h *Handler) UpdateLDSOrdinance(ctx context.Context, input UpdateLDSOrdinan
 	// Get current ordinance from read model
 	current, err := h.readStore.GetLDSOrdinance(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting LDS ordinance: %w", err)
 	}
 	if current == nil {
 		return nil, ErrLDSOrdinanceNotFound
@@ -135,7 +135,7 @@ func (h *Handler) UpdateLDSOrdinance(ctx context.Context, input UpdateLDSOrdinan
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "LDSOrdinance", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update LDS ordinance command: %w", err)
 	}
 
 	return &UpdateLDSOrdinanceResult{Version: version}, nil
@@ -146,7 +146,7 @@ func (h *Handler) DeleteLDSOrdinance(ctx context.Context, id uuid.UUID, version 
 	// Get current ordinance from read model
 	current, err := h.readStore.GetLDSOrdinance(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting LDS ordinance: %w", err)
 	}
 	if current == nil {
 		return ErrLDSOrdinanceNotFound
@@ -162,5 +162,8 @@ func (h *Handler) DeleteLDSOrdinance(ctx context.Context, id uuid.UUID, version 
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "LDSOrdinance", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete LDS ordinance command: %w", err)
+	}
+	return nil
 }

--- a/internal/command/media_commands.go
+++ b/internal/command/media_commands.go
@@ -95,7 +95,7 @@ func (h *Handler) UploadMedia(ctx context.Context, input UploadMediaInput) (*Upl
 	// Execute command (append + project)
 	version, err := h.execute(ctx, m.ID.String(), "Media", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing upload media command: %w", err)
 	}
 
 	return &UploadMediaResult{
@@ -127,7 +127,7 @@ func (h *Handler) UpdateMedia(ctx context.Context, input UpdateMediaInput) (*Upd
 	// Get current media from read model
 	current, err := h.readStore.GetMedia(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting media: %w", err)
 	}
 	if current == nil {
 		return nil, ErrMediaNotFound
@@ -174,7 +174,7 @@ func (h *Handler) UpdateMedia(ctx context.Context, input UpdateMediaInput) (*Upd
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Media", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update media command: %w", err)
 	}
 
 	return &UpdateMediaResult{Version: version}, nil
@@ -185,7 +185,7 @@ func (h *Handler) DeleteMedia(ctx context.Context, id uuid.UUID, version int64, 
 	// Get current media from read model
 	current, err := h.readStore.GetMedia(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting media: %w", err)
 	}
 	if current == nil {
 		return ErrMediaNotFound
@@ -201,7 +201,10 @@ func (h *Handler) DeleteMedia(ctx context.Context, id uuid.UUID, version int64, 
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Media", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete media command: %w", err)
+	}
+	return nil
 }
 
 // RollbackMedia rolls back media to a specific version.

--- a/internal/command/merge_commands.go
+++ b/internal/command/merge_commands.go
@@ -56,24 +56,24 @@ func (h *Handler) MergePersons(ctx context.Context, input MergePersonsInput) (*M
 	// 2. Fetch and validate both persons exist with version check
 	survivor, merged, err := h.validateMergePersons(ctx, input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validating merge persons: %w", err)
 	}
 
 	// 3. Check for circular ancestry and child-family conflicts
 	if err := h.validateMergeRelationships(ctx, input.SurvivorID, input.MergedID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validating merge relationships: %w", err)
 	}
 
 	// 4. Build merge event and execute
 	event, fieldsUpdated, err := h.buildMergeEvent(ctx, input, survivor, merged)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building merge event: %w", err)
 	}
 
 	// 5. Execute command (append + project)
 	version, err := h.execute(ctx, input.SurvivorID.String(), "Person", []domain.Event{event}, input.SurvivorVersion)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing merge persons command: %w", err)
 	}
 
 	// 6. Build summary
@@ -127,12 +127,12 @@ func (h *Handler) validateMergePersons(ctx context.Context, input MergePersonsIn
 func (h *Handler) validateMergeRelationships(ctx context.Context, survivorID, mergedID uuid.UUID) error {
 	// Circular ancestry check: neither person can be an ancestor of the other
 	if isAnc, err := h.isAncestor(ctx, mergedID, survivorID); err != nil {
-		return err
+		return fmt.Errorf("checking circular ancestry: %w", err)
 	} else if isAnc {
 		return ErrCircularMerge
 	}
 	if isAnc, err := h.isAncestor(ctx, survivorID, mergedID); err != nil {
-		return err
+		return fmt.Errorf("checking circular ancestry: %w", err)
 	} else if isAnc {
 		return ErrCircularMerge
 	}
@@ -140,11 +140,11 @@ func (h *Handler) validateMergeRelationships(ctx context.Context, survivorID, me
 	// Child-family conflict check: if both are children in different families, block
 	survivorChildFamily, err := h.readStore.GetChildFamily(ctx, survivorID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting survivor child family: %w", err)
 	}
 	mergedChildFamily, err := h.readStore.GetChildFamily(ctx, mergedID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting merged child family: %w", err)
 	}
 	if survivorChildFamily != nil && mergedChildFamily != nil &&
 		survivorChildFamily.ID != mergedChildFamily.ID {
@@ -287,7 +287,7 @@ func resolveFields(survivor, merged *repository.PersonReadModel, resolution map[
 func (h *Handler) collectAffectedFamilies(ctx context.Context, mergedID uuid.UUID) ([]uuid.UUID, error) {
 	families, err := h.readStore.GetFamiliesForPerson(ctx, mergedID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting families for person: %w", err)
 	}
 
 	ids := make([]uuid.UUID, len(families))
@@ -301,7 +301,7 @@ func (h *Handler) collectAffectedFamilies(ctx context.Context, mergedID uuid.UUI
 func (h *Handler) collectAffectedCitations(ctx context.Context, mergedID uuid.UUID) ([]uuid.UUID, error) {
 	citations, err := h.readStore.GetCitationsForPerson(ctx, mergedID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting citations for person: %w", err)
 	}
 
 	ids := make([]uuid.UUID, len(citations))
@@ -315,7 +315,7 @@ func (h *Handler) collectAffectedCitations(ctx context.Context, mergedID uuid.UU
 func (h *Handler) collectTransferredNames(ctx context.Context, mergedID uuid.UUID) ([]uuid.UUID, error) {
 	names, err := h.readStore.GetPersonNames(ctx, mergedID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting person names: %w", err)
 	}
 
 	ids := make([]uuid.UUID, len(names))
@@ -329,7 +329,7 @@ func (h *Handler) collectTransferredNames(ctx context.Context, mergedID uuid.UUI
 func (h *Handler) collectTransferredEvents(ctx context.Context, mergedID uuid.UUID) ([]uuid.UUID, error) {
 	events, err := h.readStore.ListEventsForPerson(ctx, mergedID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing events for person: %w", err)
 	}
 
 	ids := make([]uuid.UUID, len(events))
@@ -343,7 +343,7 @@ func (h *Handler) collectTransferredEvents(ctx context.Context, mergedID uuid.UU
 func (h *Handler) collectTransferredMedia(ctx context.Context, mergedID uuid.UUID) ([]uuid.UUID, error) {
 	media, _, err := h.readStore.ListMediaForEntity(ctx, "person", mergedID, repository.ListOptions{Limit: 10000})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing media for person: %w", err)
 	}
 
 	ids := make([]uuid.UUID, len(media))

--- a/internal/command/merge_commands_test.go
+++ b/internal/command/merge_commands_test.go
@@ -2,6 +2,7 @@ package command_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -178,7 +179,7 @@ func TestMergePersons_SurvivorVersionConflict(t *testing.T) {
 		SurvivorVersion: 999, // Wrong version
 		MergedVersion:   merged.Version,
 	})
-	if err != repository.ErrConcurrencyConflict {
+	if !errors.Is(err, repository.ErrConcurrencyConflict) {
 		t.Errorf("Expected ErrConcurrencyConflict, got %v", err)
 	}
 }
@@ -204,7 +205,7 @@ func TestMergePersons_MergedVersionConflict(t *testing.T) {
 		SurvivorVersion: survivor.Version,
 		MergedVersion:   999, // Wrong version
 	})
-	if err != repository.ErrConcurrencyConflict {
+	if !errors.Is(err, repository.ErrConcurrencyConflict) {
 		t.Errorf("Expected ErrConcurrencyConflict, got %v", err)
 	}
 }
@@ -244,7 +245,7 @@ func TestMergePersons_CircularMerge_SurvivorIsAncestor(t *testing.T) {
 		SurvivorVersion: child.Version,
 		MergedVersion:   parent.Version,
 	})
-	if err != command.ErrCircularMerge {
+	if !errors.Is(err, command.ErrCircularMerge) {
 		t.Errorf("Expected ErrCircularMerge, got %v", err)
 	}
 }
@@ -284,7 +285,7 @@ func TestMergePersons_CircularMerge_MergedIsAncestor(t *testing.T) {
 		SurvivorVersion: parent.Version,
 		MergedVersion:   child.Version,
 	})
-	if err != command.ErrCircularMerge {
+	if !errors.Is(err, command.ErrCircularMerge) {
 		t.Errorf("Expected ErrCircularMerge, got %v", err)
 	}
 }
@@ -342,7 +343,7 @@ func TestMergePersons_ChildFamilyConflict(t *testing.T) {
 		SurvivorVersion: child1.Version,
 		MergedVersion:   child2.Version,
 	})
-	if err != command.ErrChildFamilyConflict {
+	if !errors.Is(err, command.ErrChildFamilyConflict) {
 		t.Errorf("Expected ErrChildFamilyConflict, got %v", err)
 	}
 }

--- a/internal/command/name_commands.go
+++ b/internal/command/name_commands.go
@@ -48,7 +48,7 @@ func (h *Handler) AddName(ctx context.Context, input AddNameInput) (*AddNameResu
 	// Verify person exists
 	person, err := h.readStore.GetPerson(ctx, input.PersonID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting person: %w", err)
 	}
 	if person == nil {
 		return nil, ErrPersonNotFound
@@ -57,7 +57,7 @@ func (h *Handler) AddName(ctx context.Context, input AddNameInput) (*AddNameResu
 	// Get existing names to check primary status
 	existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting person names: %w", err)
 	}
 
 	// Create the person name entity
@@ -111,7 +111,7 @@ func (h *Handler) AddName(ctx context.Context, input AddNameInput) (*AddNameResu
 	// Execute command
 	_, err = h.execute(ctx, input.PersonID.String(), "Person", events, person.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing add name command: %w", err)
 	}
 
 	return &AddNameResult{
@@ -174,7 +174,7 @@ func applyNameUpdates(pn *domain.PersonName, input UpdateNameInput) {
 func (h *Handler) UpdateName(ctx context.Context, input UpdateNameInput) (*UpdateNameResult, error) {
 	person, existingName, err := h.validateNameUpdate(ctx, input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validating name update: %w", err)
 	}
 
 	// Build updated name from existing
@@ -187,11 +187,11 @@ func (h *Handler) UpdateName(ctx context.Context, input UpdateNameInput) (*Updat
 
 	events, err := h.buildNameUpdateEvents(ctx, pn, existingName, input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building name update events: %w", err)
 	}
 
 	if _, err = h.execute(ctx, input.PersonID.String(), "Person", events, person.Version); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update name command: %w", err)
 	}
 
 	return &UpdateNameResult{
@@ -246,7 +246,7 @@ func (h *Handler) buildNameUpdateEvents(ctx context.Context, pn *domain.PersonNa
 	if pn.IsPrimary && !existingName.IsPrimary {
 		existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting person names: %w", err)
 		}
 		for _, existing := range existingNames {
 			if existing.IsPrimary && existing.ID != input.NameID {
@@ -273,7 +273,7 @@ func (h *Handler) DeleteName(ctx context.Context, input DeleteNameInput) error {
 	// Verify person exists
 	person, err := h.readStore.GetPerson(ctx, input.PersonID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting person: %w", err)
 	}
 	if person == nil {
 		return ErrPersonNotFound
@@ -282,7 +282,7 @@ func (h *Handler) DeleteName(ctx context.Context, input DeleteNameInput) error {
 	// Get all names for the person
 	existingNames, err := h.readStore.GetPersonNames(ctx, input.PersonID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting person names: %w", err)
 	}
 
 	// Find the name to delete
@@ -317,5 +317,8 @@ func (h *Handler) DeleteName(ctx context.Context, input DeleteNameInput) error {
 
 	// Execute command
 	_, err = h.execute(ctx, input.PersonID.String(), "Person", []domain.Event{event}, person.Version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete name command: %w", err)
+	}
+	return nil
 }

--- a/internal/command/note_commands.go
+++ b/internal/command/note_commands.go
@@ -48,7 +48,7 @@ func (h *Handler) CreateNote(ctx context.Context, input CreateNoteInput) (*Creat
 	// Execute command (append + project)
 	version, err := h.execute(ctx, note.ID.String(), "Note", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create note command: %w", err)
 	}
 
 	return &CreateNoteResult{
@@ -74,7 +74,7 @@ func (h *Handler) UpdateNote(ctx context.Context, input UpdateNoteInput) (*Updat
 	// Get current note from read model
 	current, err := h.readStore.GetNote(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting note: %w", err)
 	}
 	if current == nil {
 		return nil, ErrNoteNotFound
@@ -103,7 +103,7 @@ func (h *Handler) UpdateNote(ctx context.Context, input UpdateNoteInput) (*Updat
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Note", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update note command: %w", err)
 	}
 
 	return &UpdateNoteResult{Version: version}, nil
@@ -114,7 +114,7 @@ func (h *Handler) DeleteNote(ctx context.Context, id uuid.UUID, version int64, r
 	// Get current note from read model
 	current, err := h.readStore.GetNote(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting note: %w", err)
 	}
 	if current == nil {
 		return ErrNoteNotFound
@@ -130,5 +130,8 @@ func (h *Handler) DeleteNote(ctx context.Context, id uuid.UUID, version int64, r
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Note", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete note command: %w", err)
+	}
+	return nil
 }

--- a/internal/command/person_commands.go
+++ b/internal/command/person_commands.go
@@ -81,7 +81,7 @@ func (h *Handler) CreatePerson(ctx context.Context, input CreatePersonInput) (*C
 	// Execute command (append + project)
 	version, err := h.execute(ctx, person.ID.String(), "Person", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create person command: %w", err)
 	}
 
 	return &CreatePersonResult{
@@ -115,7 +115,7 @@ func (h *Handler) UpdatePerson(ctx context.Context, input UpdatePersonInput) (*U
 	// Get current person from read model
 	current, err := h.readStore.GetPerson(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting person: %w", err)
 	}
 	if current == nil {
 		return nil, ErrPersonNotFound
@@ -203,7 +203,7 @@ func (h *Handler) UpdatePerson(ctx context.Context, input UpdatePersonInput) (*U
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Person", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update person command: %w", err)
 	}
 
 	return &UpdatePersonResult{Version: version}, nil
@@ -221,7 +221,7 @@ func (h *Handler) DeletePerson(ctx context.Context, input DeletePersonInput) err
 	// Get current person from read model
 	current, err := h.readStore.GetPerson(ctx, input.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting person: %w", err)
 	}
 	if current == nil {
 		return ErrPersonNotFound
@@ -235,7 +235,7 @@ func (h *Handler) DeletePerson(ctx context.Context, input DeletePersonInput) err
 	// Check if person is linked to any families as partner
 	families, err := h.readStore.GetFamiliesForPerson(ctx, input.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("checking families for person: %w", err)
 	}
 	if len(families) > 0 {
 		return ErrPersonHasFamilies
@@ -244,7 +244,7 @@ func (h *Handler) DeletePerson(ctx context.Context, input DeletePersonInput) err
 	// Check if person is a child in any family
 	childFamily, err := h.readStore.GetChildFamily(ctx, input.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting child family: %w", err)
 	}
 	if childFamily != nil {
 		return ErrPersonHasFamilies
@@ -255,7 +255,10 @@ func (h *Handler) DeletePerson(ctx context.Context, input DeletePersonInput) err
 
 	// Execute command
 	_, err = h.execute(ctx, input.ID.String(), "Person", []domain.Event{event}, input.Version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete person command: %w", err)
+	}
+	return nil
 }
 
 // parseUUID parses a string to UUID.

--- a/internal/command/repository_commands.go
+++ b/internal/command/repository_commands.go
@@ -56,7 +56,7 @@ func (h *Handler) CreateRepository(ctx context.Context, input CreateRepositoryIn
 	// Execute command (append + project)
 	version, err := h.execute(ctx, repo.ID.String(), "Repository", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create repository command: %w", err)
 	}
 
 	return &CreateRepositoryResult{
@@ -85,7 +85,7 @@ func (h *Handler) UpdateRepository(ctx context.Context, input UpdateRepositoryIn
 	// Get current repository from read model
 	current, err := h.readStore.GetRepository(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting repository: %w", err)
 	}
 	if current == nil {
 		return nil, ErrRepositoryNotFound
@@ -124,7 +124,7 @@ func (h *Handler) UpdateRepository(ctx context.Context, input UpdateRepositoryIn
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Repository", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update repository command: %w", err)
 	}
 
 	return &UpdateRepositoryResult{Version: version}, nil
@@ -135,7 +135,7 @@ func (h *Handler) DeleteRepository(ctx context.Context, id uuid.UUID, version in
 	// Get current repository from read model
 	current, err := h.readStore.GetRepository(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting repository: %w", err)
 	}
 	if current == nil {
 		return ErrRepositoryNotFound
@@ -151,5 +151,8 @@ func (h *Handler) DeleteRepository(ctx context.Context, id uuid.UUID, version in
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Repository", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete repository command: %w", err)
+	}
+	return nil
 }

--- a/internal/command/source_commands.go
+++ b/internal/command/source_commands.go
@@ -85,7 +85,7 @@ func (h *Handler) CreateSource(ctx context.Context, input CreateSourceInput) (*C
 	// Execute command (append + project)
 	version, err := h.execute(ctx, source.ID.String(), "Source", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create source command: %w", err)
 	}
 
 	return &CreateSourceResult{
@@ -120,7 +120,7 @@ func (h *Handler) UpdateSource(ctx context.Context, input UpdateSourceInput) (*U
 	// Get current source from read model
 	current, err := h.readStore.GetSource(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting source: %w", err)
 	}
 	if current == nil {
 		return nil, ErrSourceNotFound
@@ -211,7 +211,7 @@ func (h *Handler) UpdateSource(ctx context.Context, input UpdateSourceInput) (*U
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Source", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update source command: %w", err)
 	}
 
 	return &UpdateSourceResult{Version: version}, nil
@@ -222,7 +222,7 @@ func (h *Handler) DeleteSource(ctx context.Context, id uuid.UUID, version int64,
 	// Get current source from read model
 	current, err := h.readStore.GetSource(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting source: %w", err)
 	}
 	if current == nil {
 		return ErrSourceNotFound
@@ -236,7 +236,7 @@ func (h *Handler) DeleteSource(ctx context.Context, id uuid.UUID, version int64,
 	// Check if source has citations (referential integrity)
 	citations, err := h.readStore.GetCitationsForSource(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting citations for source: %w", err)
 	}
 	if len(citations) > 0 {
 		return ErrSourceHasCitations
@@ -247,7 +247,10 @@ func (h *Handler) DeleteSource(ctx context.Context, id uuid.UUID, version int64,
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Source", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete source command: %w", err)
+	}
+	return nil
 }
 
 // CreateCitationInput contains the data for creating a new citation.
@@ -286,7 +289,7 @@ func (h *Handler) CreateCitation(ctx context.Context, input CreateCitationInput)
 	// Verify source exists
 	source, err := h.readStore.GetSource(ctx, input.SourceID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting source: %w", err)
 	}
 	if source == nil {
 		return nil, fmt.Errorf("%w: source does not exist", ErrInvalidInput)
@@ -341,7 +344,7 @@ func (h *Handler) CreateCitation(ctx context.Context, input CreateCitationInput)
 	// Execute command (append + project)
 	version, err := h.execute(ctx, citation.ID.String(), "Citation", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create citation command: %w", err)
 	}
 
 	return &CreateCitationResult{
@@ -378,7 +381,7 @@ func (h *Handler) UpdateCitation(ctx context.Context, input UpdateCitationInput)
 	// Get current citation from read model
 	current, err := h.readStore.GetCitation(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting citation: %w", err)
 	}
 	if current == nil {
 		return nil, ErrCitationNotFound
@@ -412,7 +415,7 @@ func (h *Handler) UpdateCitation(ctx context.Context, input UpdateCitationInput)
 		// Verify source exists
 		source, err := h.readStore.GetSource(ctx, *input.SourceID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("getting source: %w", err)
 		}
 		if source == nil {
 			return nil, fmt.Errorf("%w: source does not exist", ErrInvalidInput)
@@ -481,7 +484,7 @@ func (h *Handler) UpdateCitation(ctx context.Context, input UpdateCitationInput)
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Citation", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update citation command: %w", err)
 	}
 
 	return &UpdateCitationResult{Version: version}, nil
@@ -492,7 +495,7 @@ func (h *Handler) DeleteCitation(ctx context.Context, id uuid.UUID, version int6
 	// Get current citation from read model
 	current, err := h.readStore.GetCitation(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting citation: %w", err)
 	}
 	if current == nil {
 		return ErrCitationNotFound
@@ -508,5 +511,8 @@ func (h *Handler) DeleteCitation(ctx context.Context, id uuid.UUID, version int6
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Citation", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete citation command: %w", err)
+	}
+	return nil
 }

--- a/internal/command/submitter_commands.go
+++ b/internal/command/submitter_commands.go
@@ -68,7 +68,7 @@ func (h *Handler) CreateSubmitter(ctx context.Context, input CreateSubmitterInpu
 	// Execute command (append + project)
 	version, err := h.execute(ctx, submitter.ID.String(), "Submitter", []domain.Event{event}, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing create submitter command: %w", err)
 	}
 
 	return &CreateSubmitterResult{
@@ -99,7 +99,7 @@ func (h *Handler) UpdateSubmitter(ctx context.Context, input UpdateSubmitterInpu
 	// Get current submitter from read model
 	current, err := h.readStore.GetSubmitter(ctx, input.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting submitter: %w", err)
 	}
 	if current == nil {
 		return nil, ErrSubmitterNotFound
@@ -143,7 +143,7 @@ func (h *Handler) UpdateSubmitter(ctx context.Context, input UpdateSubmitterInpu
 	// Execute command
 	version, err := h.execute(ctx, input.ID.String(), "Submitter", []domain.Event{event}, input.Version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executing update submitter command: %w", err)
 	}
 
 	return &UpdateSubmitterResult{Version: version}, nil
@@ -154,7 +154,7 @@ func (h *Handler) DeleteSubmitter(ctx context.Context, id uuid.UUID, version int
 	// Get current submitter from read model
 	current, err := h.readStore.GetSubmitter(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting submitter: %w", err)
 	}
 	if current == nil {
 		return ErrSubmitterNotFound
@@ -170,5 +170,8 @@ func (h *Handler) DeleteSubmitter(ctx context.Context, id uuid.UUID, version int
 
 	// Execute command
 	_, err = h.execute(ctx, id.String(), "Submitter", []domain.Event{event}, version)
-	return err
+	if err != nil {
+		return fmt.Errorf("executing delete submitter command: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Adds contextual wrapping to bare error returns in `internal/command/`, per the error-handling convention in `docs/CONVENTIONS.md`. Surfaced by the 2026-02-07 project health check.

## Problem
~135 sites in `internal/command/` returned errors bare (`return err` / `return nil, err`), producing stack traces with no indication of which command/operation triggered them.

## Change
Each bare return is now wrapped with `fmt.Errorf("<operation>: %w", err)`, where the message names the operation that produced the error (e.g. `getting person`, `appending person created event`, `executing delete citation command`, `checking circular ancestry`).

- Covers both `return err` (58) and the same-anti-pattern `return nil, err` (77) across 14 files, so no function is left half-wrapped.
- `%w` preserves the error chain. The API layer maps sentinels (`ErrConcurrencyConflict`, `ErrPersonNotFound`, `ErrCircularMerge`, ...) via `errors.Is`, so HTTP status mapping (404/409/...) is **unchanged** — verified.
- Sentinel returns (`return ErrPersonNotFound`, `return repository.ErrConcurrencyConflict`) and already-wrapped returns were left untouched.
- Updated 6 command tests that compared a now-wrapped sentinel with `==` to use `errors.Is`.

## Out of scope (follow-up)
The issue also suggested grepping other packages. `internal/repository*` has ~87 more bare returns; wrapping those is a separate, larger cleanup left out to keep this PR atomic and reviewable. (`internal/api`'s bare returns are almost entirely in generated code.)

## Verification
- `make build`, `make lint` (0 issues), `make check-coverage` (command 82.0% above its 80% threshold; all packages PASS)
- `go vet ./internal/command/`, `gofmt` clean

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages across command operations to provide clearer context about which step failed, making it easier to diagnose issues.

* **Tests**
  * Updated error assertions to work with contextually-wrapped error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->