### PR TITLE
Add Repository management UI

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -43,6 +43,13 @@ export type BatchDismissRequest = components['schemas']['BatchDismissRequest'];
 export type BatchDismissResponse = components['schemas']['BatchDismissResponse'];
 export type BatchDismissResult = components['schemas']['BatchDismissResult'];
 
+// Re-export Repository types from generated file (single source of truth)
+export type Repository = components['schemas']['Repository'];
+export type RepositoryCreate = components['schemas']['RepositoryCreate'];
+export type RepositoryUpdate = components['schemas']['RepositoryUpdate'];
+export type RepositoryList = components['schemas']['RepositoryList'];
+export type Address = components['schemas']['Address'];
+
 const API_BASE = '/api/v1';
 
 // Types based on OpenAPI schemas
@@ -1311,6 +1318,39 @@ class ApiClient {
 
 	async deleteSource(id: string, version: number): Promise<void> {
 		return this.request<void>('DELETE', `/sources/${id}?version=${version}`);
+	}
+
+	// Repository endpoints
+	async listRepositories(params?: {
+		limit?: number;
+		offset?: number;
+		sort?: 'name' | 'updated_at';
+		order?: 'asc' | 'desc';
+	}): Promise<RepositoryList> {
+		const searchParams = new URLSearchParams();
+		if (params?.limit) searchParams.set('limit', params.limit.toString());
+		if (params?.offset) searchParams.set('offset', params.offset.toString());
+		if (params?.sort) searchParams.set('sort', params.sort);
+		if (params?.order) searchParams.set('order', params.order);
+
+		const query = searchParams.toString();
+		return this.request<RepositoryList>('GET', `/repositories${query ? `?${query}` : ''}`);
+	}
+
+	async getRepository(id: string): Promise<Repository> {
+		return this.request<Repository>('GET', `/repositories/${id}`);
+	}
+
+	async createRepository(data: RepositoryCreate): Promise<Repository> {
+		return this.request<Repository>('POST', '/repositories', data);
+	}
+
+	async updateRepository(id: string, data: RepositoryUpdate): Promise<Repository> {
+		return this.request<Repository>('PUT', `/repositories/${id}`, data);
+	}
+
+	async deleteRepository(id: string, version: number): Promise<void> {
+		return this.request<void>('DELETE', `/repositories/${id}?version=${version}`);
 	}
 
 	async searchSources(q: string, limit?: number): Promise<SourceSearchResponse> {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -98,6 +98,7 @@
 					<DropdownMenu.Item><a href="/browse/cemeteries">By Cemetery</a></DropdownMenu.Item>
 					<DropdownMenu.Item><a href="/browse/brick-walls">Brick Walls</a></DropdownMenu.Item>
 					<DropdownMenu.Item><a href="/browse/citation-templates">Citation Templates</a></DropdownMenu.Item>
+					<DropdownMenu.Item><a href="/repositories">Repositories</a></DropdownMenu.Item>
 				</DropdownMenu.Content>
 			</DropdownMenu.Root>
 			<a href="/sources" class:active={$page.url.pathname.startsWith('/sources')}>Sources</a>

--- a/web/src/routes/repositories/+page.svelte
+++ b/web/src/routes/repositories/+page.svelte
@@ -1,0 +1,539 @@
+<script lang="ts">
+	import { api, type Repository, type Address } from '$lib/api/client';
+	import { Button } from '$lib/components/ui/button';
+
+	let repositories: Repository[] = $state([]);
+	let total = $state(0);
+	let loading = $state(true);
+	let currentPage = $state(1);
+	let sort = $state<'name' | 'updated_at'>('name');
+	let order = $state<'asc' | 'desc'>('asc');
+	let showAddForm = $state(false);
+	let saving = $state(false);
+	let error: string | null = $state(null);
+	const pageSize = 20;
+
+	const emptyForm = () => ({
+		name: '',
+		line1: '',
+		line2: '',
+		city: '',
+		state: '',
+		postal_code: '',
+		country: '',
+		phone: '',
+		email: '',
+		fax: '',
+		notes: '',
+		gedcom_xref: ''
+	});
+
+	let newRepo = $state(emptyForm());
+
+	async function loadRepositories() {
+		loading = true;
+		try {
+			const result = await api.listRepositories({
+				limit: pageSize,
+				offset: (currentPage - 1) * pageSize,
+				sort,
+				order
+			});
+			repositories = result.repositories;
+			total = result.total;
+		} catch (e) {
+			console.error('Failed to load repositories:', e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleSortChange(e: Event) {
+		const select = e.target as HTMLSelectElement;
+		sort = select.value as typeof sort;
+		currentPage = 1;
+		loadRepositories();
+	}
+
+	function handleOrderChange() {
+		order = order === 'asc' ? 'desc' : 'asc';
+		loadRepositories();
+	}
+
+	function prevPage() {
+		if (currentPage > 1) {
+			currentPage--;
+			loadRepositories();
+		}
+	}
+
+	function nextPage() {
+		if (currentPage * pageSize < total) {
+			currentPage++;
+			loadRepositories();
+		}
+	}
+
+	function openAddForm() {
+		newRepo = emptyForm();
+		showAddForm = true;
+		error = null;
+	}
+
+	function cancelAdd() {
+		showAddForm = false;
+		error = null;
+	}
+
+	// Build an Address from form fields, returning undefined when no field is set.
+	function buildAddress(f: ReturnType<typeof emptyForm>): Address | undefined {
+		const address: Address = {};
+		if (f.line1.trim()) address.line1 = f.line1.trim();
+		if (f.line2.trim()) address.line2 = f.line2.trim();
+		if (f.city.trim()) address.city = f.city.trim();
+		if (f.state.trim()) address.state = f.state.trim();
+		if (f.postal_code.trim()) address.postal_code = f.postal_code.trim();
+		if (f.country.trim()) address.country = f.country.trim();
+		if (f.phone.trim()) address.phone = f.phone.trim();
+		if (f.email.trim()) address.email = f.email.trim();
+		if (f.fax.trim()) address.fax = f.fax.trim();
+		return Object.keys(address).length > 0 ? address : undefined;
+	}
+
+	async function saveNewRepository() {
+		if (!newRepo.name.trim()) {
+			error = 'Name is required';
+			return;
+		}
+
+		saving = true;
+		error = null;
+		try {
+			await api.createRepository({
+				name: newRepo.name.trim(),
+				address: buildAddress(newRepo),
+				notes: newRepo.notes.trim() || undefined,
+				gedcom_xref: newRepo.gedcom_xref.trim() || undefined
+			});
+			showAddForm = false;
+			loadRepositories();
+		} catch (e) {
+			error = (e as { message?: string }).message || 'Failed to create repository';
+		} finally {
+			saving = false;
+		}
+	}
+
+	// Compose a one-line address summary for the table.
+	function addressSummary(address?: Address): string {
+		if (!address) return '';
+		return [address.city, address.state, address.country].filter(Boolean).join(', ');
+	}
+
+	$effect(() => {
+		loadRepositories();
+	});
+
+	const totalPages = $derived(Math.ceil(total / pageSize));
+</script>
+
+<svelte:head>
+	<title>Repositories | My Family</title>
+</svelte:head>
+
+<div class="repositories-page">
+	<header class="page-header">
+		<h1>Repositories</h1>
+		<div class="controls">
+			<label>
+				Sort by:
+				<select value={sort} onchange={handleSortChange}>
+					<option value="name">Name</option>
+					<option value="updated_at">Last Updated</option>
+				</select>
+			</label>
+			<button class="order-btn" onclick={handleOrderChange} title="Toggle sort order">
+				{#if order === 'asc'}
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+						<path d="M12 5v14M5 12l7-7 7 7" />
+					</svg>
+				{:else}
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+						<path d="M12 19V5M5 12l7 7 7-7" />
+					</svg>
+				{/if}
+			</button>
+			<Button onclick={openAddForm}>Add Repository</Button>
+		</div>
+	</header>
+
+	{#if showAddForm}
+		<div class="add-form-container">
+			<form class="entity-form" onsubmit={(e) => { e.preventDefault(); saveNewRepository(); }}>
+				<h2>Add New Repository</h2>
+
+				{#if error}
+					<div class="form-error">{error}</div>
+				{/if}
+
+				<label>
+					Name <span class="required">*</span>
+					<input type="text" bind:value={newRepo.name} required />
+				</label>
+
+				<fieldset>
+					<legend>Address</legend>
+					<div class="form-row">
+						<label>
+							Address Line 1
+							<input type="text" bind:value={newRepo.line1} />
+						</label>
+						<label>
+							Address Line 2
+							<input type="text" bind:value={newRepo.line2} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							City
+							<input type="text" bind:value={newRepo.city} />
+						</label>
+						<label>
+							State/Province
+							<input type="text" bind:value={newRepo.state} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Postal Code
+							<input type="text" bind:value={newRepo.postal_code} />
+						</label>
+						<label>
+							Country
+							<input type="text" bind:value={newRepo.country} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Phone
+							<input type="tel" bind:value={newRepo.phone} />
+						</label>
+						<label>
+							Email
+							<input type="email" bind:value={newRepo.email} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Fax
+							<input type="tel" bind:value={newRepo.fax} />
+						</label>
+					</div>
+				</fieldset>
+
+				<label>
+					Notes
+					<textarea bind:value={newRepo.notes} rows="3"></textarea>
+				</label>
+
+				<label>
+					GEDCOM Xref
+					<input type="text" bind:value={newRepo.gedcom_xref} placeholder="e.g., @R1@" />
+				</label>
+
+				<div class="form-actions">
+					<Button variant="outline" onclick={cancelAdd} disabled={saving}>Cancel</Button>
+					<Button type="submit" disabled={saving}>
+						{saving ? 'Saving...' : 'Create Repository'}
+					</Button>
+				</div>
+			</form>
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="loading">Loading...</div>
+	{:else if repositories.length === 0}
+		<div class="empty">
+			<p>No repositories found.</p>
+			<Button onclick={openAddForm}>Add Repository</Button>
+		</div>
+	{:else}
+		<table class="repositories-table">
+			<thead>
+				<tr>
+					<th scope="col">Name</th>
+					<th scope="col">Location</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each repositories as repo}
+					<tr>
+						<td><a href="/repositories/{repo.id}" class="repo-link">{repo.name}</a></td>
+						<td class="location">{addressSummary(repo.address) || '—'}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+
+		{#if totalPages > 1}
+			<div class="pagination">
+				<button onclick={prevPage} disabled={currentPage === 1}>Previous</button>
+				<span>Page {currentPage} of {totalPages}</span>
+				<button onclick={nextPage} disabled={currentPage >= totalPages}>Next</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.repositories-page {
+		max-width: 1000px;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+
+	.page-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1.5rem;
+		flex-wrap: wrap;
+		gap: 1rem;
+	}
+
+	.page-header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+		color: #1e293b;
+	}
+
+	.controls {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.controls label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	.controls select {
+		padding: 0.375rem 0.75rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 6px;
+		background: white;
+		font-size: 0.875rem;
+	}
+
+	.order-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 6px;
+		background: white;
+		cursor: pointer;
+	}
+
+	.order-btn:hover {
+		background: #f1f5f9;
+	}
+
+	.order-btn svg {
+		width: 1rem;
+		height: 1rem;
+		color: #64748b;
+	}
+
+	.add-form-container {
+		margin-bottom: 1.5rem;
+	}
+
+	.entity-form {
+		background: white;
+		border-radius: 12px;
+		border: 1px solid #e2e8f0;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.entity-form h2 {
+		margin: 0;
+		font-size: 1.125rem;
+		color: #1e293b;
+	}
+
+	.form-error {
+		padding: 0.75rem;
+		background: #fef2f2;
+		border: 1px solid #fecaca;
+		border-radius: 6px;
+		color: #dc2626;
+		font-size: 0.875rem;
+	}
+
+	fieldset {
+		border: 1px solid #e2e8f0;
+		border-radius: 8px;
+		padding: 1rem;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	legend {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: #64748b;
+		padding: 0 0.375rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	.entity-form label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	.required {
+		color: #dc2626;
+	}
+
+	.entity-form input,
+	.entity-form textarea {
+		padding: 0.625rem 0.75rem;
+		border: 1px solid #e2e8f0;
+		border-radius: 6px;
+		font-size: 0.875rem;
+	}
+
+	.entity-form input:focus,
+	.entity-form textarea:focus {
+		outline: none;
+		border-color: #3b82f6;
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+	}
+
+	.entity-form textarea {
+		resize: vertical;
+	}
+
+	.form-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+		padding-top: 1rem;
+		border-top: 1px solid #e2e8f0;
+	}
+
+	.loading,
+	.empty {
+		text-align: center;
+		padding: 3rem;
+		color: #64748b;
+	}
+
+	.empty p {
+		margin: 0 0 1rem;
+	}
+
+	.repositories-table {
+		width: 100%;
+		border-collapse: collapse;
+		background: white;
+		border: 1px solid #e2e8f0;
+		border-radius: 12px;
+		overflow: hidden;
+	}
+
+	.repositories-table th {
+		text-align: left;
+		padding: 0.75rem 1rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: #f8fafc;
+		border-bottom: 1px solid #e2e8f0;
+	}
+
+	.repositories-table td {
+		padding: 0.75rem 1rem;
+		font-size: 0.875rem;
+		color: #1e293b;
+		border-bottom: 1px solid #f1f5f9;
+	}
+
+	.repositories-table tr:last-child td {
+		border-bottom: none;
+	}
+
+	.repo-link {
+		color: #3b82f6;
+		text-decoration: none;
+		font-weight: 500;
+	}
+
+	.repo-link:hover {
+		text-decoration: underline;
+	}
+
+	.location {
+		color: #64748b;
+	}
+
+	.pagination {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		gap: 1rem;
+		margin-top: 2rem;
+		padding-top: 1rem;
+		border-top: 1px solid #e2e8f0;
+	}
+
+	.pagination button {
+		padding: 0.5rem 1rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 6px;
+		background: white;
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+
+	.pagination button:hover:not(:disabled) {
+		background: #f1f5f9;
+	}
+
+	.pagination button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.pagination span {
+		font-size: 0.875rem;
+		color: #64748b;
+	}
+</style>

--- a/web/src/routes/repositories/[id]/+page.svelte
+++ b/web/src/routes/repositories/[id]/+page.svelte
@@ -1,0 +1,490 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { api, type Repository, type Address } from '$lib/api/client';
+	import { Button } from '$lib/components/ui/button';
+
+	let repository: Repository | null = $state(null);
+	let loading = $state(true);
+	let error: string | null = $state(null);
+	let editing = $state(false);
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	const emptyForm = () => ({
+		name: '',
+		line1: '',
+		line2: '',
+		city: '',
+		state: '',
+		postal_code: '',
+		country: '',
+		phone: '',
+		email: '',
+		fax: '',
+		notes: '',
+		gedcom_xref: ''
+	});
+
+	let formData = $state(emptyForm());
+
+	async function loadRepository(id: string) {
+		loading = true;
+		error = null;
+		try {
+			repository = await api.getRepository(id);
+			resetForm();
+		} catch (e) {
+			error = (e as { message?: string }).message || 'Failed to load repository';
+			repository = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		if (repository) {
+			const a = repository.address ?? {};
+			formData = {
+				name: repository.name,
+				line1: a.line1 ?? '',
+				line2: a.line2 ?? '',
+				city: a.city ?? '',
+				state: a.state ?? '',
+				postal_code: a.postal_code ?? '',
+				country: a.country ?? '',
+				phone: a.phone ?? '',
+				email: a.email ?? '',
+				fax: a.fax ?? '',
+				notes: repository.notes ?? '',
+				gedcom_xref: repository.gedcom_xref ?? ''
+			};
+		}
+	}
+
+	function startEdit() {
+		resetForm();
+		editing = true;
+		error = null;
+	}
+
+	function cancelEdit() {
+		resetForm();
+		editing = false;
+		error = null;
+	}
+
+	function buildAddress(f: ReturnType<typeof emptyForm>): Address | undefined {
+		const address: Address = {};
+		if (f.line1.trim()) address.line1 = f.line1.trim();
+		if (f.line2.trim()) address.line2 = f.line2.trim();
+		if (f.city.trim()) address.city = f.city.trim();
+		if (f.state.trim()) address.state = f.state.trim();
+		if (f.postal_code.trim()) address.postal_code = f.postal_code.trim();
+		if (f.country.trim()) address.country = f.country.trim();
+		if (f.phone.trim()) address.phone = f.phone.trim();
+		if (f.email.trim()) address.email = f.email.trim();
+		if (f.fax.trim()) address.fax = f.fax.trim();
+		return Object.keys(address).length > 0 ? address : undefined;
+	}
+
+	async function saveRepository() {
+		if (!repository) return;
+		if (!formData.name.trim()) {
+			error = 'Name is required';
+			return;
+		}
+
+		saving = true;
+		error = null;
+		try {
+			await api.updateRepository(repository.id, {
+				name: formData.name.trim(),
+				address: buildAddress(formData),
+				notes: formData.notes.trim() || undefined,
+				gedcom_xref: formData.gedcom_xref.trim() || undefined,
+				version: repository.version
+			});
+			await loadRepository(repository.id);
+			editing = false;
+		} catch (e) {
+			const err = e as { message?: string; status?: number };
+			if (err.status === 409) {
+				error = 'This repository was modified by someone else. Reload and try again.';
+			} else {
+				error = err.message || 'Failed to save';
+			}
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteRepository() {
+		if (!repository) return;
+		if (!confirm(`Delete "${repository.name}"? This cannot be undone.`)) return;
+
+		deleting = true;
+		error = null;
+		try {
+			await api.deleteRepository(repository.id, repository.version);
+			goto('/repositories');
+		} catch (e) {
+			const err = e as { message?: string; status?: number };
+			if (err.status === 409) {
+				error = 'This repository was modified by someone else. Reload and try again.';
+			} else if (err.status === 404) {
+				error = 'This repository no longer exists.';
+			} else {
+				error = err.message || 'Failed to delete';
+			}
+			deleting = false;
+		}
+	}
+
+	// Whether the repository has any address field populated.
+	function hasAddress(a?: Address): boolean {
+		return !!a && Object.values(a).some((v) => v != null && v !== '');
+	}
+
+	$effect(() => {
+		const id = $page.params.id;
+		if (id) {
+			loadRepository(id);
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{repository ? repository.name : 'Repository'} | My Family</title>
+</svelte:head>
+
+<div class="repository-page">
+	<header class="page-header">
+		<a href="/repositories" class="back-link">&larr; Repositories</a>
+		{#if repository && !editing}
+			<div class="actions">
+				<Button variant="outline" onclick={startEdit}>Edit</Button>
+				<Button variant="destructive" onclick={deleteRepository} disabled={deleting}>
+					{deleting ? 'Deleting...' : 'Delete'}
+				</Button>
+			</div>
+		{/if}
+	</header>
+
+	{#if loading}
+		<div class="loading">Loading...</div>
+	{:else if error && !repository}
+		<div class="error">{error}</div>
+	{:else if repository}
+		{#if editing}
+			<form class="entity-form" onsubmit={(e) => { e.preventDefault(); saveRepository(); }}>
+				{#if error}
+					<div class="form-error">{error}</div>
+				{/if}
+
+				<label>
+					Name <span class="required">*</span>
+					<input type="text" bind:value={formData.name} required />
+				</label>
+
+				<fieldset>
+					<legend>Address</legend>
+					<div class="form-row">
+						<label>
+							Address Line 1
+							<input type="text" bind:value={formData.line1} />
+						</label>
+						<label>
+							Address Line 2
+							<input type="text" bind:value={formData.line2} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							City
+							<input type="text" bind:value={formData.city} />
+						</label>
+						<label>
+							State/Province
+							<input type="text" bind:value={formData.state} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Postal Code
+							<input type="text" bind:value={formData.postal_code} />
+						</label>
+						<label>
+							Country
+							<input type="text" bind:value={formData.country} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Phone
+							<input type="tel" bind:value={formData.phone} />
+						</label>
+						<label>
+							Email
+							<input type="email" bind:value={formData.email} />
+						</label>
+					</div>
+					<div class="form-row">
+						<label>
+							Fax
+							<input type="tel" bind:value={formData.fax} />
+						</label>
+					</div>
+				</fieldset>
+
+				<label>
+					Notes
+					<textarea bind:value={formData.notes} rows="4"></textarea>
+				</label>
+
+				<label>
+					GEDCOM Xref
+					<input type="text" bind:value={formData.gedcom_xref} placeholder="e.g., @R1@" />
+				</label>
+
+				<div class="form-actions">
+					<Button variant="outline" onclick={cancelEdit} disabled={saving}>Cancel</Button>
+					<Button type="submit" disabled={saving}>
+						{saving ? 'Saving...' : 'Save Changes'}
+					</Button>
+				</div>
+			</form>
+		{:else}
+			<div class="repository-detail">
+				<div class="repository-header">
+					<h1>{repository.name}</h1>
+				</div>
+
+				{#if hasAddress(repository.address)}
+					{@const a = repository.address}
+					<div class="info-section">
+						<h2>Address</h2>
+						<dl>
+							{#if a?.line1}<dt>Line 1</dt><dd>{a.line1}</dd>{/if}
+							{#if a?.line2}<dt>Line 2</dt><dd>{a.line2}</dd>{/if}
+							{#if a?.city}<dt>City</dt><dd>{a.city}</dd>{/if}
+							{#if a?.state}<dt>State/Province</dt><dd>{a.state}</dd>{/if}
+							{#if a?.postal_code}<dt>Postal Code</dt><dd>{a.postal_code}</dd>{/if}
+							{#if a?.country}<dt>Country</dt><dd>{a.country}</dd>{/if}
+							{#if a?.phone}<dt>Phone</dt><dd>{a.phone}</dd>{/if}
+							{#if a?.email}<dt>Email</dt><dd>{a.email}</dd>{/if}
+							{#if a?.fax}<dt>Fax</dt><dd>{a.fax}</dd>{/if}
+						</dl>
+					</div>
+				{/if}
+
+				{#if repository.notes}
+					<div class="info-section">
+						<h2>Notes</h2>
+						<p class="notes">{repository.notes}</p>
+					</div>
+				{/if}
+
+				{#if repository.gedcom_xref}
+					<div class="info-section">
+						<h2>GEDCOM Xref</h2>
+						<p class="mono">{repository.gedcom_xref}</p>
+					</div>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.repository-page {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+
+	.page-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1.5rem;
+	}
+
+	.back-link {
+		color: #64748b;
+		text-decoration: none;
+		font-size: 0.875rem;
+	}
+
+	.back-link:hover {
+		color: #3b82f6;
+	}
+
+	.actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.loading,
+	.error {
+		text-align: center;
+		padding: 3rem;
+		color: #64748b;
+	}
+
+	.error {
+		color: #dc2626;
+	}
+
+	.repository-detail {
+		background: white;
+		border-radius: 12px;
+		border: 1px solid #e2e8f0;
+		padding: 1.5rem;
+	}
+
+	.repository-header {
+		margin-bottom: 1.5rem;
+		padding-bottom: 1.5rem;
+		border-bottom: 1px solid #e2e8f0;
+	}
+
+	.repository-header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+		color: #1e293b;
+	}
+
+	.info-section {
+		margin-bottom: 1.5rem;
+	}
+
+	.info-section:last-child {
+		margin-bottom: 0;
+	}
+
+	.info-section h2 {
+		margin: 0 0 0.75rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.info-section dl {
+		margin: 0;
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.25rem 1rem;
+	}
+
+	.info-section dt {
+		color: #94a3b8;
+		font-size: 0.8125rem;
+	}
+
+	.info-section dd {
+		margin: 0;
+		color: #1e293b;
+		font-size: 0.875rem;
+	}
+
+	.notes {
+		margin: 0;
+		color: #475569;
+		font-size: 0.875rem;
+		white-space: pre-wrap;
+	}
+
+	.mono {
+		margin: 0;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	.entity-form {
+		background: white;
+		border-radius: 12px;
+		border: 1px solid #e2e8f0;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.form-error {
+		padding: 0.75rem;
+		background: #fef2f2;
+		border: 1px solid #fecaca;
+		border-radius: 6px;
+		color: #dc2626;
+		font-size: 0.875rem;
+	}
+
+	fieldset {
+		border: 1px solid #e2e8f0;
+		border-radius: 8px;
+		padding: 1rem;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	legend {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: #64748b;
+		padding: 0 0.375rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	.entity-form label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		font-size: 0.875rem;
+		color: #475569;
+	}
+
+	.required {
+		color: #dc2626;
+	}
+
+	.entity-form input,
+	.entity-form textarea {
+		padding: 0.625rem 0.75rem;
+		border: 1px solid #e2e8f0;
+		border-radius: 6px;
+		font-size: 0.875rem;
+	}
+
+	.entity-form input:focus,
+	.entity-form textarea:focus {
+		outline: none;
+		border-color: #3b82f6;
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+	}
+
+	.entity-form textarea {
+		resize: vertical;
+	}
+
+	.form-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+		padding-top: 1rem;
+		border-top: 1px solid #e2e8f0;
+	}
+</style>

--- a/web/src/routes/repositories/page.test.ts
+++ b/web/src/routes/repositories/page.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import RepositoriesPage from './+page.svelte';
+import * as apiModule from '$lib/api/client';
+
+// Mock the API module
+vi.mock('$lib/api/client', async (importOriginal) => {
+	const actual = await importOriginal<typeof apiModule>();
+	return {
+		...actual,
+		api: {
+			listRepositories: vi.fn(),
+			createRepository: vi.fn()
+		}
+	};
+});
+
+const mockList: apiModule.RepositoryList = {
+	repositories: [
+		{
+			id: 'repo-1',
+			name: 'National Archives',
+			address: { city: 'Washington', state: 'DC', country: 'USA' },
+			version: 1
+		},
+		{
+			id: 'repo-2',
+			name: 'Local Library',
+			version: 1
+		}
+	],
+	total: 2
+};
+
+describe('Repositories list page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(apiModule.api.listRepositories).mockResolvedValue(mockList);
+		vi.mocked(apiModule.api.createRepository).mockResolvedValue({
+			id: 'repo-3',
+			name: 'New Repo',
+			version: 1
+		});
+	});
+
+	it('loads and renders repositories in a table with an address summary', async () => {
+		render(RepositoriesPage);
+
+		await waitFor(() => {
+			expect(screen.getByText('National Archives')).toBeTruthy();
+		});
+		expect(screen.getByText('Local Library')).toBeTruthy();
+		// Address summary composed from city/state/country
+		expect(screen.getByText('Washington, DC, USA')).toBeTruthy();
+		// Detail link uses the repository id
+		const link = screen.getByText('National Archives').closest('a');
+		expect(link?.getAttribute('href')).toBe('/repositories/repo-1');
+	});
+
+	it('rejects a blank (whitespace-only) name before creating', async () => {
+		render(RepositoriesPage);
+		await waitFor(() => expect(screen.getByText('Local Library')).toBeTruthy());
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Add Repository' }));
+		// A whitespace-only name satisfies the native `required` attribute but must
+		// still be rejected by the trim()-based guard.
+		await fireEvent.input(screen.getByLabelText(/Name/), { target: { value: '   ' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Create Repository' }));
+
+		await waitFor(() => expect(screen.getByText('Name is required')).toBeTruthy());
+		expect(apiModule.api.createRepository).not.toHaveBeenCalled();
+	});
+
+	it('creates a repository with a nested address and reloads', async () => {
+		render(RepositoriesPage);
+		await waitFor(() => expect(screen.getByText('Local Library')).toBeTruthy());
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Add Repository' }));
+
+		await fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'New Repo' } });
+		await fireEvent.input(screen.getByLabelText('City'), { target: { value: 'Boston' } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Create Repository' }));
+
+		await waitFor(() => {
+			expect(apiModule.api.createRepository).toHaveBeenCalledWith({
+				name: 'New Repo',
+				address: { city: 'Boston' },
+				notes: undefined,
+				gedcom_xref: undefined
+			});
+		});
+		// Reloaded the list after create (initial load + post-create reload)
+		expect(apiModule.api.listRepositories).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
Builds the Svelte frontend for managing Repository entities, consuming the `/repositories` REST API and generated types delivered by #239 (backend complete across all 7 layers; only the UI remained).

## What changed

**List page** (`/repositories`)
- Paginated table of repositories (name + location summary), sort by name/updated_at with order toggle.
- Inline create form: name (required), nested address fields (line1/2, city, state, postal, country, phone, email, fax), notes, gedcom_xref.

**Detail page** (`/repositories/[id]`)
- View name, address, notes, GEDCOM xref.
- Inline edit (PUT) and delete (with confirm). Handles 409 version conflicts and 404 with clear messages.

**Plumbing**
- `Repository`, `RepositoryCreate`, `RepositoryUpdate`, `RepositoryList`, and `Address` re-exported from the generated OpenAPI types — no hand-rolled request/response shapes.
- Typed client methods: `listRepositories`, `getRepository`, `createRepository`, `updateRepository`, `deleteRepository`.
- Repositories link added under the Browse nav dropdown.
- The API exposes a single nested `address` object (not the flat phone/email arrays used by Submitter); the UI matches that shape.

## Tests
- `repositories/page.test.ts`: list render + address summary + detail link, blank-name rejection, and create-with-nested-address + reload.
- `svelte-check --threshold error` clean; full vitest suite (246 tests) green.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Repositories management interface with full create, read, update, and delete functionality
  * Repositories list page with pagination and sorting by name or last updated
  * Added "Repositories" link to the Browse menu
  * Repository creation form with address and metadata support
  * Repository detail view with in-place editing and deletion

* **Tests**
  * Added test suite for Repositories page covering listing, creation, and address validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->