### PR TITLE
Link GEDCOM source to repository by ID, not name

### DIFF
--- a/internal/gedcom/exporter.go
+++ b/internal/gedcom/exporter.go
@@ -157,8 +157,10 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 		return repositories[i].ID.String() < repositories[j].ID.String()
 	})
 	// repoNameToXref lets sources that reference a repository by name be linked
-	// to the standalone REPO record via a SOUR.REPO cross-reference.
+	// to the standalone REPO record via a SOUR.REPO cross-reference. repoIDToXref
+	// is the authoritative ID-based map, preferred over name matching (issue #525).
 	repoNameToXref := make(map[string]string)
+	repoIDToXref := make(map[uuid.UUID]string)
 	for i, r := range repositories {
 		// Use GedcomXref if available (for round-trip), otherwise generate.
 		if r.GedcomXref != "" {
@@ -166,6 +168,7 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 		} else {
 			repositoryXrefs[r.ID] = fmt.Sprintf("@R%d@", i+1)
 		}
+		repoIDToXref[r.ID] = repositoryXrefs[r.ID]
 		if r.Name != "" {
 			repoNameToXref[r.Name] = repositoryXrefs[r.ID]
 		}
@@ -184,7 +187,7 @@ func (exp *Exporter) ExportWithProgress(ctx context.Context, w io.Writer, onProg
 	// Add source records
 	for i, s := range sources {
 		xref := sourceXrefs[s.ID]
-		src := toGedcomSource(s, repoNameToXref)
+		src := toGedcomSource(s, repoIDToXref, repoNameToXref)
 		doc.Records = append(doc.Records, &gedcom.Record{
 			XRef:   xref,
 			Type:   gedcom.RecordTypeSource,
@@ -413,11 +416,12 @@ func (cw *countingWriter) Write(p []byte) (n int, err error) {
 // toGedcomSource converts a repository SourceReadModel to a gedcom.Source entity.
 // The encoder will automatically convert this to GEDCOM tags, handling CONT/CONC.
 //
-// repoNameToXref maps a Repository's name (and any @XREF@ used as a name) to the
-// xref of its standalone REPO record. When a source references a repository that
-// exists as a Repository entity, emit a SOUR.REPO cross-reference to that record;
-// otherwise fall back to an inline repository definition (name-only sources).
-func toGedcomSource(s repository.SourceReadModel, repoNameToXref map[string]string) *gedcom.Source {
+// repoIDToXref maps a Repository's ID to the xref of its standalone REPO record;
+// it is the authoritative link and is preferred when the source carries a
+// RepositoryID. repoNameToXref maps a Repository's name (and any @XREF@ used as a
+// name) to the same xref, used as a fallback for legacy sources linked only by
+// name. When neither resolves, fall back to an inline repository definition.
+func toGedcomSource(s repository.SourceReadModel, repoIDToXref map[uuid.UUID]string, repoNameToXref map[string]string) *gedcom.Source {
 	src := &gedcom.Source{}
 
 	// Title
@@ -435,20 +439,25 @@ func toGedcomSource(s repository.SourceReadModel, repoNameToXref map[string]stri
 		src.Publication = s.Publisher
 	}
 
-	// Repository
-	if s.RepositoryName != "" {
-		switch {
-		case repoNameToXref[s.RepositoryName] != "":
-			// Source references a Repository entity by name: emit a SOUR.REPO
-			// cross-reference to the standalone REPO record.
-			src.RepositoryRef = repoNameToXref[s.RepositoryName]
-		case strings.HasPrefix(s.RepositoryName, "@") && strings.HasSuffix(s.RepositoryName, "@"):
-			// Already an XREF (e.g. an unresolved import reference): preserve it.
-			src.RepositoryRef = s.RepositoryName
-		default:
-			// Inline repository with NAME subordinate (name-only / unlinked source).
-			src.Repository = &gedcom.InlineRepository{Name: s.RepositoryName}
-		}
+	// Repository. Prefer the authoritative RepositoryID link (issue #525): it is
+	// robust against duplicate or renamed repository names. Fall back to name
+	// matching only when no ID is present (e.g. legacy data).
+	switch {
+	case s.RepositoryID != nil && repoIDToXref[*s.RepositoryID] != "":
+		// Source links to a Repository entity by ID: emit a SOUR.REPO
+		// cross-reference to the standalone REPO record.
+		src.RepositoryRef = repoIDToXref[*s.RepositoryID]
+	case s.RepositoryName == "":
+		// No repository link at all.
+	case repoNameToXref[s.RepositoryName] != "":
+		// Legacy: source references a Repository entity by name.
+		src.RepositoryRef = repoNameToXref[s.RepositoryName]
+	case strings.HasPrefix(s.RepositoryName, "@") && strings.HasSuffix(s.RepositoryName, "@"):
+		// Already an XREF (e.g. an unresolved import reference): preserve it.
+		src.RepositoryRef = s.RepositoryName
+	default:
+		// Inline repository with NAME subordinate (name-only / unlinked source).
+		src.Repository = &gedcom.InlineRepository{Name: s.RepositoryName}
 	}
 
 	// Notes - encoder handles CONT/CONC automatically for multiline text

--- a/internal/gedcom/exporter_test.go
+++ b/internal/gedcom/exporter_test.go
@@ -2619,6 +2619,62 @@ func TestExport_Repositories(t *testing.T) {
 	}
 }
 
+// TestExport_SourceLinkedByRepositoryID verifies that a source linked to a
+// repository by RepositoryID exports the correct SOUR.REPO cross-reference even
+// when another repository shares the same name — the ID link must win over the
+// fragile name match (issue #525).
+func TestExport_SourceLinkedByRepositoryID(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	ctx := context.Background()
+
+	// Two repositories with the SAME name but different IDs and xrefs.
+	repoA := &repository.RepositoryReadModel{
+		ID:         uuid.New(),
+		Name:       "National Archives",
+		GedcomXref: "@RA@",
+	}
+	repoB := &repository.RepositoryReadModel{
+		ID:         uuid.New(),
+		Name:       "National Archives",
+		GedcomXref: "@RB@",
+	}
+	if err := readStore.SaveRepository(ctx, repoA); err != nil {
+		t.Fatal(err)
+	}
+	if err := readStore.SaveRepository(ctx, repoB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Source authoritatively linked to repoB by ID (its name would match either).
+	repoBID := repoB.ID
+	source := &repository.SourceReadModel{
+		ID:             uuid.New(),
+		SourceType:     "book",
+		Title:          "Census Records",
+		RepositoryID:   &repoBID,
+		RepositoryName: "National Archives",
+		GedcomXref:     "@S1@",
+	}
+	if err := readStore.SaveSource(ctx, source); err != nil {
+		t.Fatal(err)
+	}
+
+	exporter := gedcom.NewExporter(readStore)
+	buf := &bytes.Buffer{}
+	if _, err := exporter.Export(ctx, buf); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	// The source must reference repoB's xref (by ID), not repoA's.
+	if !strings.Contains(output, "1 REPO @RB@\n") {
+		t.Errorf("Source should reference repoB (@RB@) via its RepositoryID; got:\n%s", output)
+	}
+	if strings.Contains(output, "1 REPO @RA@\n") {
+		t.Errorf("Source must not be mislinked to repoA (@RA@) by name; got:\n%s", output)
+	}
+}
+
 // TestExport_RepositoryRoundTrip imports a GEDCOM containing REPO records and
 // SOUR.REPO cross-references, exports it, and asserts the repositories and the
 // source->repository links survive with no dropped data.

--- a/internal/repository/postgres/readmodel.go
+++ b/internal/repository/postgres/readmodel.go
@@ -134,6 +134,7 @@ func (s *ReadModelStore) createTables() error {
 			publish_date_raw VARCHAR(100),
 			publish_date_sort DATE,
 			url VARCHAR(500),
+			repository_id UUID,
 			repository_name VARCHAR(200),
 			collection_name VARCHAR(200),
 			call_number VARCHAR(100),
@@ -501,6 +502,9 @@ func (s *ReadModelStore) runMigrations() {
 		_, _ = tx.Exec(`ALTER TABLE family_children DROP COLUMN IF EXISTS person_name`)
 		_ = tx.Commit()
 	}
+
+	// Add repository_id to sources for ID-based source→repository linkage (issue #525).
+	_, _ = s.db.Exec(`ALTER TABLE sources ADD COLUMN IF NOT EXISTS repository_id UUID`)
 }
 
 // GetPerson retrieves a person by ID.
@@ -1457,7 +1461,7 @@ func nullableBytes(b []byte) any {
 func (s *ReadModelStore) GetSource(ctx context.Context, id uuid.UUID) (*repository.SourceReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources WHERE id = $1
 	`, id)
@@ -1475,7 +1479,7 @@ func (s *ReadModelStore) ListSources(ctx context.Context, opts repository.ListOp
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources
 		ORDER BY title ASC
@@ -1502,7 +1506,7 @@ func (s *ReadModelStore) ListSources(ctx context.Context, opts repository.ListOp
 func (s *ReadModelStore) SearchSources(ctx context.Context, query string, limit int) ([]repository.SourceReadModel, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources
 		WHERE title ILIKE '%' || $1 || '%' OR author ILIKE '%' || $1 || '%'
@@ -1530,9 +1534,9 @@ func (s *ReadModelStore) SearchSources(ctx context.Context, query string, limit 
 func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.SourceReadModel) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO sources (id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-							 url, repository_name, collection_name, call_number, notes, gedcom_xref,
+							 url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 							 citation_count, version, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 		ON CONFLICT(id) DO UPDATE SET
 			source_type = EXCLUDED.source_type,
 			title = EXCLUDED.title,
@@ -1541,6 +1545,7 @@ func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.Sour
 			publish_date_raw = EXCLUDED.publish_date_raw,
 			publish_date_sort = EXCLUDED.publish_date_sort,
 			url = EXCLUDED.url,
+			repository_id = EXCLUDED.repository_id,
 			repository_name = EXCLUDED.repository_name,
 			collection_name = EXCLUDED.collection_name,
 			call_number = EXCLUDED.call_number,
@@ -1552,7 +1557,7 @@ func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.Sour
 	`, source.ID, nullableString(string(source.SourceType)), source.Title,
 		nullableString(source.Author), nullableString(source.Publisher),
 		nullableString(source.PublishDateRaw), nullableTime(source.PublishDateSort),
-		nullableString(source.URL), nullableString(source.RepositoryName),
+		nullableString(source.URL), nullableUUID(source.RepositoryID), nullableString(source.RepositoryName),
 		nullableString(source.CollectionName), nullableString(source.CallNumber),
 		nullableString(source.Notes), nullableString(source.GedcomXref),
 		source.CitationCount, source.Version, source.UpdatedAt)
@@ -1996,8 +2001,8 @@ func scanSourceRow(row rowScanner) (*repository.SourceReadModel, error) {
 		id                                uuid.UUID
 		sourceType, title                 string
 		author, publisher, publishDateRaw sql.NullString
-		url, repoName, collName, callNum  sql.NullString
-		notes, gedcomXref                 sql.NullString
+		url, repoID, repoName, collName   sql.NullString
+		callNum, notes, gedcomXref        sql.NullString
 		publishDateSort                   sql.NullTime
 		citationCount                     int
 		version                           int64
@@ -2005,7 +2010,7 @@ func scanSourceRow(row rowScanner) (*repository.SourceReadModel, error) {
 	)
 
 	err := row.Scan(&id, &sourceType, &title, &author, &publisher, &publishDateRaw, &publishDateSort,
-		&url, &repoName, &collName, &callNum, &notes, &gedcomXref,
+		&url, &repoID, &repoName, &collName, &callNum, &notes, &gedcomXref,
 		&citationCount, &version, &updatedAt)
 
 	if err == sql.ErrNoRows {
@@ -2033,6 +2038,11 @@ func scanSourceRow(row rowScanner) (*repository.SourceReadModel, error) {
 		UpdatedAt:      updatedAt,
 	}
 
+	if repoID.Valid {
+		if rid, err := uuid.Parse(repoID.String); err == nil {
+			src.RepositoryID = &rid
+		}
+	}
 	if publishDateSort.Valid {
 		src.PublishDateSort = &publishDateSort.Time
 	}

--- a/internal/repository/projection.go
+++ b/internal/repository/projection.go
@@ -360,6 +360,33 @@ func (p *Projector) projectFamilyUpdated(ctx context.Context, e domain.FamilyUpd
 // JSON: a string UUID for a swap, nil/empty to clear. Unknown person IDs leave
 // the names empty rather than failing — the name will be backfilled the next
 // time the projection sees the person.
+// parseOptionalUUID coerces a change-map value into an optional UUID. Values may
+// arrive as a string (the JSON-decoded form after event replay), a uuid.UUID, or a
+// *uuid.UUID (freshly built in-memory). A nil, empty, or unparseable value yields
+// nil, which clears the link.
+func parseOptionalUUID(value any) *uuid.UUID {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *uuid.UUID:
+		return v
+	case uuid.UUID:
+		id := v
+		return &id
+	case string:
+		if v == "" {
+			return nil
+		}
+		id, err := uuid.Parse(v)
+		if err != nil {
+			return nil
+		}
+		return &id
+	default:
+		return nil
+	}
+}
+
 func (p *Projector) resolvePartnerChange(ctx context.Context, value any) (*uuid.UUID, string, string) {
 	s, ok := value.(string)
 	if !ok || s == "" {
@@ -513,6 +540,7 @@ func (p *Projector) projectSourceCreated(ctx context.Context, e domain.SourceCre
 		PublishDateRaw:  publishDateRaw,
 		PublishDateSort: publishDateSort,
 		URL:             e.URL,
+		RepositoryID:    e.RepositoryID,
 		RepositoryName:  e.RepositoryName,
 		CollectionName:  e.CollectionName,
 		CallNumber:      e.CallNumber,
@@ -569,6 +597,8 @@ func (p *Projector) projectSourceUpdated(ctx context.Context, e domain.SourceUpd
 			if v, ok := value.(string); ok {
 				source.URL = v
 			}
+		case "repository_id":
+			source.RepositoryID = parseOptionalUUID(value)
 		case "repository_name":
 			if v, ok := value.(string); ok {
 				source.RepositoryName = v

--- a/internal/repository/projection_test.go
+++ b/internal/repository/projection_test.go
@@ -816,6 +816,49 @@ func TestProjector_SourceCreated(t *testing.T) {
 	}
 }
 
+// TestProjector_SourceRepositoryID verifies the RepositoryID link carried by the
+// SourceCreated/SourceUpdated events is projected onto the read model rather than
+// dropped (issue #525).
+func TestProjector_SourceRepositoryID(t *testing.T) {
+	readStore := memory.NewReadModelStore()
+	projector := repository.NewProjector(readStore)
+	ctx := context.Background()
+
+	repoID := uuid.New()
+	source := domain.NewSource("Linked Source", domain.SourceBook)
+	source.RepositoryID = &repoID
+
+	if err := projector.Project(ctx, domain.NewSourceCreated(source), 1); err != nil {
+		t.Fatalf("Project create failed: %v", err)
+	}
+
+	rm, err := readStore.GetSource(ctx, source.ID)
+	if err != nil {
+		t.Fatalf("GetSource failed: %v", err)
+	}
+	if rm.RepositoryID == nil {
+		t.Fatal("RepositoryID was dropped by the projection")
+	}
+	if *rm.RepositoryID != repoID {
+		t.Errorf("RepositoryID = %s, want %s", rm.RepositoryID, repoID)
+	}
+
+	// Update the link to a different repository via a change-map (string form, as
+	// it arrives after event replay).
+	newRepoID := uuid.New()
+	changes := map[string]any{"repository_id": newRepoID.String()}
+	if err := projector.Project(ctx, domain.NewSourceUpdated(source.ID, changes), 2); err != nil {
+		t.Fatalf("Project update failed: %v", err)
+	}
+	rm, err = readStore.GetSource(ctx, source.ID)
+	if err != nil {
+		t.Fatalf("GetSource failed: %v", err)
+	}
+	if rm.RepositoryID == nil || *rm.RepositoryID != newRepoID {
+		t.Errorf("RepositoryID after update = %v, want %s", rm.RepositoryID, newRepoID)
+	}
+}
+
 func TestProjector_SourceUpdated(t *testing.T) {
 	readStore := memory.NewReadModelStore()
 	projector := repository.NewProjector(readStore)

--- a/internal/repository/readmodel.go
+++ b/internal/repository/readmodel.go
@@ -84,6 +84,7 @@ type SourceReadModel struct {
 	PublishDateRaw  string            `json:"publish_date_raw,omitempty"`
 	PublishDateSort *time.Time        `json:"publish_date_sort,omitempty"`
 	URL             string            `json:"url,omitempty"`
+	RepositoryID    *uuid.UUID        `json:"repository_id,omitempty"`
 	RepositoryName  string            `json:"repository_name,omitempty"`
 	CollectionName  string            `json:"collection_name,omitempty"`
 	CallNumber      string            `json:"call_number,omitempty"`

--- a/internal/repository/sqlite/readmodel.go
+++ b/internal/repository/sqlite/readmodel.go
@@ -121,6 +121,7 @@ func (s *ReadModelStore) createTables() error {
 			publish_date_raw TEXT,
 			publish_date_sort TEXT,
 			url TEXT,
+			repository_id TEXT,
 			repository_name TEXT,
 			collection_name TEXT,
 			call_number TEXT,
@@ -472,6 +473,9 @@ func (s *ReadModelStore) runMigrations() {
 			person_surname    = COALESCE((SELECT surname    FROM persons WHERE id = person_id), '')
 		WHERE person_id IS NOT NULL AND person_given_name IS NULL
 	`)
+
+	// Add repository_id to sources for ID-based source→repository linkage (issue #525).
+	_, _ = s.db.Exec(`ALTER TABLE sources ADD COLUMN repository_id TEXT`)
 }
 
 // tryCreateFTS5 attempts to create FTS5 virtual table for full-text search.
@@ -1815,7 +1819,7 @@ func escapeFTS5Query(query string) string {
 func (s *ReadModelStore) GetSource(ctx context.Context, id uuid.UUID) (*repository.SourceReadModel, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources WHERE id = ?
 	`, id.String())
@@ -1833,7 +1837,7 @@ func (s *ReadModelStore) ListSources(ctx context.Context, opts repository.ListOp
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources
 		ORDER BY title ASC
@@ -1862,7 +1866,7 @@ func (s *ReadModelStore) SearchSources(ctx context.Context, query string, limit 
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-			   url, repository_name, collection_name, call_number, notes, gedcom_xref,
+			   url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 			   citation_count, version, updated_at
 		FROM sources
 		WHERE LOWER(title) LIKE ? OR LOWER(author) LIKE ?
@@ -1892,11 +1896,16 @@ func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.Sour
 		publishDateSort = sql.NullString{String: source.PublishDateSort.Format("2006-01-02"), Valid: true}
 	}
 
+	var repositoryID sql.NullString
+	if source.RepositoryID != nil {
+		repositoryID = sql.NullString{String: source.RepositoryID.String(), Valid: true}
+	}
+
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO sources (id, source_type, title, author, publisher, publish_date_raw, publish_date_sort,
-							 url, repository_name, collection_name, call_number, notes, gedcom_xref,
+							 url, repository_id, repository_name, collection_name, call_number, notes, gedcom_xref,
 							 citation_count, version, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			source_type = excluded.source_type,
 			title = excluded.title,
@@ -1905,6 +1914,7 @@ func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.Sour
 			publish_date_raw = excluded.publish_date_raw,
 			publish_date_sort = excluded.publish_date_sort,
 			url = excluded.url,
+			repository_id = excluded.repository_id,
 			repository_name = excluded.repository_name,
 			collection_name = excluded.collection_name,
 			call_number = excluded.call_number,
@@ -1914,7 +1924,7 @@ func (s *ReadModelStore) SaveSource(ctx context.Context, source *repository.Sour
 			version = excluded.version,
 			updated_at = excluded.updated_at
 	`, source.ID.String(), string(source.SourceType), source.Title, source.Author, source.Publisher,
-		source.PublishDateRaw, publishDateSort, source.URL, source.RepositoryName, source.CollectionName,
+		source.PublishDateRaw, publishDateSort, source.URL, repositoryID, source.RepositoryName, source.CollectionName,
 		source.CallNumber, source.Notes, source.GedcomXref, source.CitationCount, source.Version,
 		formatTimestamp(source.UpdatedAt))
 
@@ -2377,16 +2387,16 @@ func (s *ReadModelStore) DeleteAttribute(ctx context.Context, id uuid.UUID) erro
 
 func scanSource(row rowScanner) (*repository.SourceReadModel, error) {
 	var (
-		idStr, sourceType, title                            string
-		author, publisher, publishDateRaw, publishDateSort  sql.NullString
-		url, repoName, collName, callNum, notes, gedcomXref sql.NullString
-		citationCount                                       int
-		version                                             int64
-		updatedAt                                           string
+		idStr, sourceType, title                                    string
+		author, publisher, publishDateRaw, publishDateSort          sql.NullString
+		url, repoID, repoName, collName, callNum, notes, gedcomXref sql.NullString
+		citationCount                                               int
+		version                                                     int64
+		updatedAt                                                   string
 	)
 
 	err := row.Scan(&idStr, &sourceType, &title, &author, &publisher, &publishDateRaw, &publishDateSort,
-		&url, &repoName, &collName, &callNum, &notes, &gedcomXref,
+		&url, &repoID, &repoName, &collName, &callNum, &notes, &gedcomXref,
 		&citationCount, &version, &updatedAt)
 
 	if err == sql.ErrNoRows {
@@ -2414,6 +2424,11 @@ func scanSource(row rowScanner) (*repository.SourceReadModel, error) {
 		Version:        version,
 	}
 
+	if repoID.Valid {
+		if rid, err := uuid.Parse(repoID.String); err == nil {
+			src.RepositoryID = &rid
+		}
+	}
 	if publishDateSort.Valid {
 		if t, err := time.Parse("2006-01-02", publishDateSort.String); err == nil {
 			src.PublishDateSort = &t

--- a/internal/repository/sqlite/readmodel_test.go
+++ b/internal/repository/sqlite/readmodel_test.go
@@ -41,6 +41,57 @@ func setupTestReadModelDB(t *testing.T) (*sqlite.ReadModelStore, func()) {
 	}
 }
 
+// TestReadModelStore_SourceRepositoryID verifies the repository_id column round-trips
+// through SaveSource/GetSource, including the nil case (issue #525).
+func TestReadModelStore_SourceRepositoryID(t *testing.T) {
+	store, cleanup := setupTestReadModelDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	repoID := uuid.New()
+	linked := &repository.SourceReadModel{
+		ID:             uuid.New(),
+		SourceType:     domain.SourceBook,
+		Title:          "Linked Source",
+		RepositoryID:   &repoID,
+		RepositoryName: "National Archives",
+		Version:        1,
+	}
+	if err := store.SaveSource(ctx, linked); err != nil {
+		t.Fatalf("SaveSource (linked): %v", err)
+	}
+
+	got, err := store.GetSource(ctx, linked.ID)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if got.RepositoryID == nil {
+		t.Fatal("RepositoryID was not persisted")
+	}
+	if *got.RepositoryID != repoID {
+		t.Errorf("RepositoryID = %s, want %s", got.RepositoryID, repoID)
+	}
+
+	// A source without a RepositoryID must round-trip as nil, not a zero UUID.
+	unlinked := &repository.SourceReadModel{
+		ID:         uuid.New(),
+		SourceType: domain.SourceBook,
+		Title:      "Unlinked Source",
+		Version:    1,
+	}
+	if err := store.SaveSource(ctx, unlinked); err != nil {
+		t.Fatalf("SaveSource (unlinked): %v", err)
+	}
+	got, err = store.GetSource(ctx, unlinked.ID)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if got.RepositoryID != nil {
+		t.Errorf("RepositoryID = %s, want nil", got.RepositoryID)
+	}
+}
+
 func TestReadModelStore_PersonCRUD(t *testing.T) {
 	store, cleanup := setupTestReadModelDB(t)
 	defer cleanup()


### PR DESCRIPTION
Links GEDCOM sources to repositories by **ID** instead of by name match.

## Problem
`SourceReadModel` had no `RepositoryID` field, and `projectSourceCreated` dropped the `RepositoryID` carried by the `SourceCreated` event. As a result the GEDCOM exporter matched `SourceReadModel.RepositoryName` against `RepositoryReadModel.Name` to emit `SOUR.REPO @xref@` — fragile against duplicate or renamed repository names, and able to mislink a source when names collide.

## Change
- **Read model**: add `RepositoryID *uuid.UUID` to `SourceReadModel`.
- **Projection**: project `RepositoryID` in `projectSourceCreated` and handle a `repository_id` change in `projectSourceUpdated` (a small `parseOptionalUUID` helper accepts the string form seen after event replay as well as `uuid.UUID`/`*uuid.UUID`).
- **Stores** (kept in sync per DB-001):
  - memory — automatic (struct copy).
  - sqlite & postgres — new `repository_id` column in the schema, an idempotent `ALTER TABLE ... ADD COLUMN` migration for existing DBs, plus the upsert and scan paths.
- **Exporter**: prefer the authoritative `RepositoryID` link (look up xref by ID); fall back to name matching only when no ID is present (legacy data).

## Tests
- Projection carries `RepositoryID` through create **and** update.
- sqlite `repository_id` column round-trips, including the nil case (no zero-UUID leakage).
- Exporter emits the correct `SOUR.REPO` xref by ID **even when another repository shares the same name** (the core acceptance criterion).
- `make build`, `make check-coverage` (all packages PASS), `make lint` (0 issues); existing postgres/sqlite/gedcom suites green.

## Follow-up (out of scope)
`parseSource` still ignores inline `SOUR.REPO` `NAME` subordinates on import (noted in the issue) — left as a separate change to keep this atomic.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
