### PR TITLE
Fix npm audit moderate+ vulnerabilities to unblock CI security gate

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -502,9 +502,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@redocly/openapi-core": {
-			"version": "1.34.11",
-			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
-			"integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
+			"version": "1.34.16",
+			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.16.tgz",
+			"integrity": "sha512-zIgmQTT2TV/U/SJ3N4jlIw36erH6X8ga1UNIoyrlbr0yLEbsiII/16LZ0kMxWu2A8pw0xd56rwTz5sMudy2OAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -513,7 +513,7 @@
 				"colorette": "1.4.0",
 				"https-proxy-agent": "7.0.6",
 				"js-levenshtein": "1.1.6",
-				"js-yaml": "4.1.1",
+				"js-yaml": "4.2.0",
 				"minimatch": "5.1.9",
 				"pluralize": "8.0.0",
 				"yaml-ast-parser": "0.0.43"
@@ -825,9 +825,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.62.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.62.0.tgz",
-			"integrity": "sha512-4JlkXGRJ3kW15dL4LCHV3Mu5aSTTtmH8EBNE4QjJl+KLY77dClgAsZg8aebpwFcDXemNP1z9az8EatD2UNWAcQ==",
+			"version": "2.68.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.68.0.tgz",
+			"integrity": "sha512-PdKiWsqinAoubVsSiRgVFkg3MHzGhQPnwQ8VxnGQKpZYijpapZ3UHHBje0GeByt2TvfjHPw+kxV+dNK2RIZg9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2743,10 +2743,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -3855,9 +3865,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
## Summary

The `security` CI gate (`npm audit --audit-level=moderate`) has been red on `main`, blocking all open Dependabot PRs from merging. Three ≥moderate vulnerabilities were present, each fixable but split across different Dependabot PRs (none of which could pass the gate alone):

| Severity | Package | Advisory |
|---|---|---|
| HIGH | undici | GHSA-vmh5-mc38-953g (+ related) |
| MODERATE | js-yaml | GHSA-h67p-54hq-rp68 |
| MODERATE | @redocly/openapi-core | transitive js-yaml |

This PR runs `npm audit fix` (lockfile-only) to resolve all three at once, turning the gate green so the Dependabot backlog can drain.

## Notes
- Supersedes Dependabot PRs #566 (undici) and #571 (js-yaml/@redocly).
- Only `web/package-lock.json` changes; no `package.json` / direct-dependency changes.
- Remaining 7 `low` advisories are below the moderate gate threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)